### PR TITLE
Basic Travis CI setup for MAST build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # CMake build files.
 build/dbg/
 build/opt/
+build
 src/base/mast_config.h
 
 # CLion IDE files.

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ install:
 
 
 before_script:
+- export MAST_INSTALL_DIR=${HOME}/mast
 - cd ${TRAVIS_BUILD_DIR}
 - echo ${PWD}
 - ls
@@ -46,5 +47,17 @@ before_script:
 - mkdir build
 - cd build
 - cmake ..
+    -DCMAKE_INSTALL_PREFIX=${MAST_INSTALL_DIR}
+    -DCMAKE_C_COMPILER=${CC}
+    -DCMAKE_CXX_COMPILER=${CXX}
+    -DCMAKE_Fortran_COMPILER=${FC}
+    -DlibMesh_DIR=${libMesh_DIR}
+    -DPETSc_DIR=${PETSC_DIR}
+    -DSLEPc_DIR=${SLEPC_DIR}
+    -DBOOST_ROOT=/usr
+    -DBUILD_DOC=OFF
+    -DENABLE_DOT=OFF
+    -DENABLE_GCMMA=OFF
+    -DENABLE_NPSOL=OFF
 
 script: make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,50 @@
+language: cpp
+dist: xenial
+
+cache:
+  directories:
+  - ${HOME}/.cache
+
+before_install:
+- sudo apt-get install -y gfortran wget m4
+- sudo apt-get install -y openmpi-bin libopenmpi-dev
+- sudo apt-get install -y libpetsc3.6 libpetsc3.6.2-dev
+- sudo apt-get install -y libslepc3.6 libslepc3.6.1-dev libparpack2-dev
+- sudo apt-get install -y libboost-all-dev
+- sudo apt-get install -y libeigen3-dev
+
+install:
+- export CC=mpicc
+- export CXX=mpic++
+- export FC=mpifort
+- export F77=mpif77
+- export PETSC_DIR=/usr/lib/petscdir/3.6.2/x86_64-linux-gnu-real
+- export SLEPC_DIR=/usr/lib/slepcdir/3.6.1/x86_64-linux-gnu-real
+- export HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
+- export libMesh_DIR=${HOME}/.cache/libmesh
+- if [ ! -f ${libMesh_DIR}/include/libmesh/libmesh.h ]; then
+    mkdir ${libMesh_DIR};
+    cd ${libMesh_DIR};
+    wget https://github.com/libMesh/libmesh/releases/download/v1.3.1/libmesh-1.3.1.tar.gz;
+    tar -xf libmesh-1.3.1.tar.gz;
+    cd libmesh-1.3.1;
+    mkdir build;
+    cd build;
+    ../configure --prefix=${libMesh_DIR} --with-methods="opt dbg" --disable-examples --disable-metaphysicl;
+    make -j 2;
+    make install;
+  fi
+
+
+before_script:
+- cd ${TRAVIS_BUILD_DIR}
+- echo ${PWD}
+- ls
+- echo ${libMesh_DIR}
+- echo ${PETSC_DIR}
+- echo ${SLEPC_DIR}
+- mkdir build
+- cd build
+- cmake ..
+
+script: make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 language: cpp
 dist: xenial
 
-cache:
-  directories:
-  - ${HOME}/.cache
-
 before_install:
 - sudo apt-get install -y gfortran wget m4
 - sudo apt-get install -y openmpi-bin libopenmpi-dev
@@ -14,46 +10,23 @@ before_install:
 - sudo apt-get install -y libeigen3-dev
 
 install:
-- export CC=mpicc
-- export CXX=mpic++
-- export FC=mpifort
-- export F77=mpif77
-- export PETSC_DIR=/usr/lib/petscdir/3.6.2/x86_64-linux-gnu-real
-- export SLEPC_DIR=/usr/lib/slepcdir/3.6.1/x86_64-linux-gnu-real
-- export HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
-- export libMesh_DIR=${HOME}/.cache/libmesh
-- if [ ! -f ${libMesh_DIR}/include/libmesh/libmesh.h ]; then
-    mkdir ${libMesh_DIR};
-    cd ${libMesh_DIR};
-    wget https://github.com/libMesh/libmesh/releases/download/v1.3.1/libmesh-1.3.1.tar.gz;
-    tar -xf libmesh-1.3.1.tar.gz;
-    cd libmesh-1.3.1;
-    mkdir build;
-    cd build;
-    ../configure --prefix=${libMesh_DIR} --with-methods="opt dbg" --disable-examples --disable-metaphysicl;
-    make -j 2;
-    make install;
-  fi
-
+- cd ${HOME}
+- wget https://github.com/MASTmultiphysics/mast-ci-packages/releases/download/libmesh-1.3.1-1.deb/libmesh-1.3.1-1.deb
+- sudo apt install ./libmesh-1.3.1-1.deb
 
 before_script:
 - export MAST_INSTALL_DIR=${HOME}/mast
 - cd ${TRAVIS_BUILD_DIR}
-- echo ${PWD}
-- ls
-- echo ${libMesh_DIR}
-- echo ${PETSC_DIR}
-- echo ${SLEPC_DIR}
 - mkdir build
 - cd build
 - cmake ..
     -DCMAKE_INSTALL_PREFIX=${MAST_INSTALL_DIR}
-    -DCMAKE_C_COMPILER=${CC}
-    -DCMAKE_CXX_COMPILER=${CXX}
-    -DCMAKE_Fortran_COMPILER=${FC}
-    -DlibMesh_DIR=${libMesh_DIR}
-    -DPETSc_DIR=${PETSC_DIR}
-    -DSLEPc_DIR=${SLEPC_DIR}
+    -DCMAKE_C_COMPILER=mpicc
+    -DCMAKE_CXX_COMPILER=mpic++
+    -DCMAKE_Fortran_COMPILER=mpifort
+    -DlibMesh_DIR=/usr/local
+    -DPETSc_DIR=/usr/lib/petscdir/3.6.2/x86_64-linux-gnu-real
+    -DSLEPc_DIR=/usr/lib/slepcdir/3.6.1/x86_64-linux-gnu-real
     -DEigen_DIR=/usr/include/eigen3
     -DBOOST_ROOT=/usr
     -DBUILD_DOC=OFF
@@ -61,4 +34,4 @@ before_script:
     -DENABLE_GCMMA=OFF
     -DENABLE_NPSOL=OFF
 
-script: make
+script: make -j 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ before_script:
     -DlibMesh_DIR=${libMesh_DIR}
     -DPETSc_DIR=${PETSC_DIR}
     -DSLEPc_DIR=${SLEPC_DIR}
+    -DEigen_DIR=/usr/include/eigen3
     -DBOOST_ROOT=/usr
     -DBUILD_DOC=OFF
     -DENABLE_DOT=OFF

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,9 @@ set(libMesh_DIR "libMesh_DIR" CACHE PATH "Directory containing libMesh include/ 
 set(PETSc_DIR   "PETSc_DIR"   CACHE PATH "Directory containing PETSc include/ and lib/")
 set(SLEPc_DIR   "SLEPc_DIR"   CACHE PATH "Directory containing SLEPc include/ and lib/")
 
+# Optional dependency paths.
+set(Eigen_DIR "${libMesh_DIR}/include" CACHE PATH "Directory containing Eigen/ if not using libMesh provided Eigen.")
+
 # EXTERNALLY PROVIDED CONTENT
 # None. Use this if we pull something in during the build in the future.
 
@@ -33,6 +36,7 @@ find_package(MPI REQUIRED)
 find_package(PETSc REQUIRED)
 find_package(SLEPc REQUIRED)
 find_package(libMesh REQUIRED)
+find_package(Eigen REQUIRED)
 find_package(Boost REQUIRED) # Boost is currently only utilized in src/optimization/function_evaluation (not counting tests).
                              # We possibly could refactor to move finding Boost libraries closer to source where Boost is used.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(MAST
 # PROJECT WIDE SETUP
 # Get CMake modules and set language standards.
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Configure installation sub-directories.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
 Copyright (C) 2013-2016  Manav Bhatia
 
+[![Build Status](https://travis-ci.com/MASTmultiphysics/mast-multiphysics.svg?branch=master)](https://travis-ci.com/MASTmultiphysics/mast-multiphysics)
+
 This code was developed under funding from the Air Force Research Laboratory. 
 MAST was cleared for public release on 08 Nov 2016 with case number 88ABW-2016-5689. 
 

--- a/cmake/FindEigen.cmake
+++ b/cmake/FindEigen.cmake
@@ -1,0 +1,23 @@
+# This module relies on Eigen_DIR being set.
+#
+# Note that Eigen is a header only library.
+#
+# Eigen_FOUND - system has Eigen
+# Eigen_INCLUDE_DIRS - Eigen include directories.
+
+
+# Find the headers.
+find_path(Eigen_INCLUDE_DIR Eigen/Core
+        HINTS ${Eigen_DIR})
+
+# Find Eigen version.
+# Sometime would be good to add in a check to make sure we are finding Eigen 3.
+
+# Set variables.
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Eigen
+        REQUIRED_VARS Eigen_INCLUDE_DIR)
+
+mark_as_advanced(Eigen_INCLUDE_DIR)
+
+set(Eigen_INCLUDE_DIRS ${Eigen_INCLUDE_DIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,7 @@ target_include_directories(mast
             ${PETSc_INCLUDE_DIRS}
             ${SLEPc_INCLUDE_DIRS}
             ${libMesh_INCLUDE_DIRS}
+            ${Eigen_INCLUDE_DIRS}
             ${Boost_INCLUDE_DIRS}) # Could possibly move this into src/optimization since it is closer to where Boost is actually used.
 
 # Add libraries.


### PR DESCRIPTION
Basic implementation of `.travis.yml` to enable Travis CI checks on a successful build. It will build whatever is specified by the CMake build. As of right now this is the `mast` target (`libmast.a`) and two basic examples. The `make install` feature enabled by CMake is not utilized at the moment.

There's also a bug fix for the incorrect C++ version in the top level `CMakeLists.txt`. I also ran into an issue where the current CMake build wouldn't work if you didn't use the libMesh provided Eigen. To get around this I added some CMake functionality where you can optionally specify `Eigen_DIR` as a CMake option. If you don't give this, CMake will look for Eigen packaged with libMesh.

## Travis CI Runner
The test runner is Travis CI's default Linux virtual machine runner on Ubuntu 16.04. This runner has approximately 18GB of disk space, 7.5 GB of RAM, and 2 cores (https://docs.travis-ci.com/user/reference/overview/).

## Compiler & Package Manager Dependencies
The default compiler provided is GCC 5.4.0 so we currently just use it. ALL of the dependencies for libMesh are obtained as binaries (or dev headers) from Ubuntu's default package repositories for 16.04. Packages with sub-dependencies also fetch them as binaries from the package manager. Doing this part appears to take around 1 minute. The major dependencies/sub-dependencies of relevance to libMesh/MAST are:
- OpenMPI 1.10.2
- PETSc 3.6.2
- SLEPc 3.6.1
- Boost 1.58.0
- Eigen 3.3
- hypre 2.8.0
- mumps 4.10.0
- Blas/Lapack 3.6.0-2ubuntu2

## libMesh
libMesh is built from source from the version 1.3.1 release. The libMesh installation is cached the first time it is run for a repository (including forks). Subsequent Travis CI builds in that repository load this and don't need to recompile. When we want to use a different version of libMesh, we will need to clear the cache.

libMesh is currently configured/installed with:
```bash
export CC=mpicc
export CXX=mpic++
export FC=mpifort
export F77=mpif77
export PETSC_DIR=/usr/lib/petscdir/3.6.2/x86_64-linux-gnu-real
export SLEPC_DIR=/usr/lib/slepcdir/3.6.1/x86_64-linux-gnu-real
export HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
export libMesh_DIR=${HOME}/.cache/libmesh
../configure --prefix=${libMesh_DIR} --with-methods="opt dbg" --disable-examples --disable-metaphysicl
make -j 2
make install
```
Building libMesh currently appears to take about 35-40 minutes to build both the `dbg` and `opt` libraries on the runner. It's a good thing it can be cached. In the future this could easily be sped up if we could figure out how to host the binaries/headers like a standard Ubuntu repository. We wouldn't need to worry about cache at all then.

## MAST
MAST is configured in the Travis `before_script` stage with CMake with commands effectively equivalent to:
```bash
export MAST_INSTALL_DIR=${HOME}/mast
cd ${TRAVIS_BUILD_DIR}
- mkdir build
- cd build
- cmake .. \
    -DCMAKE_INSTALL_PREFIX=${MAST_INSTALL_DIR} \
    -DCMAKE_C_COMPILER=${CC} \
    -DCMAKE_CXX_COMPILER=${CXX} \
    -DCMAKE_Fortran_COMPILER=${FC} \
    -DlibMesh_DIR=${libMesh_DIR} \
    -DPETSc_DIR=${PETSC_DIR} \
    -DSLEPc_DIR=${SLEPC_DIR} \
    -DEigen_DIR=/usr/include/eigen3 \
    -DBOOST_ROOT=/usr \
    -DBUILD_DOC=OFF \
    -DENABLE_DOT=OFF \
    -DENABLE_GCMMA=OFF \
    -DENABLE_NPSOL=OFF \
```
The main Travis `script` that performs the MAST build is done with simply `make` for now. This can eventually be extended to run tests and whatnot.