### PR TITLE
Updates to documentation 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_install:
 - sudo apt-get -qq install -y libboost-all-dev
 - sudo apt-get -qq install -y libeigen3-dev
 - sudo apt-get -qq install -y doxygen graphviz rsync
+- sudo apt-get -qq install -y texlive-latex-base dvi2ps
 
 install:
 - cd ${HOME}

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 - sudo apt-get -qq install -y libboost-all-dev
 - sudo apt-get -qq install -y libeigen3-dev
 - sudo apt-get -qq install -y doxygen graphviz rsync
-- sudo apt-get -qq install -y texlive-latex-base dvi2ps
+- sudo apt-get -qq install -y texlive-latex-base dvi2ps ghostscript
 
 install:
 - cd ${HOME}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-Copyright (C) 2013-2018  Manav Bhatia
+Copyright (C) 2013-2019  Manav Bhatia
 
 [![Build Status](https://travis-ci.com/MASTmultiphysics/mast-multiphysics.svg?branch=master)](https://travis-ci.com/MASTmultiphysics/mast-multiphysics)
 

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1458,7 +1458,7 @@ DISABLE_INDEX          = NO
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-GENERATE_TREEVIEW      = NO
+GENERATE_TREEVIEW      = YES
 
 # The ENUM_VALUES_PER_LINE tag can be used to set the number of enum values that
 # doxygen will group on one line in the generated HTML documentation.

--- a/doc/installation.dox
+++ b/doc/installation.dox
@@ -2,7 +2,35 @@
 /*!
 
 \page InstallationPage Installation instructions
-- \subpage SourceInstall
+
+MAST runs on various flavors of Unix and can leverage MPI for
+distributed memory parallelism. The required list of dependencies includes
+    - hdf5
+    - boost
+    - eigen3
+    - cmake
+    - MPI
+    - PETSc
+    - SLEPc
+    - libMesh
+
+These dependencies can be installed from an automated
+package manager before proceeding with installation of MAST. It is
+recommended that PETSc be installed with support for direct sparse
+solvers, such as MUMPS, SuperLU_dist or Pardiso.
+
+Given that a large number of dependencies are required for MAST, it is strongly
+recommended that an automated package manager be used to install the dependencies
+listed above.
+    - On Mac OS [Macports](https://www.macports.org) and
+    [HomeBrew](https://brew.sh) have been used with good success to install all
+    dependencies except libMesh since no recipe/port has been created for libMesh
+    in these package managers (as of Feb 2019).
+    - [Spack](https://spack.io) is a python-based package manager that can install
+    MAST and all dependencies.
+
+Specific instructions for installation are provided in these pages
+- \subpage SourceInstall 
 - \subpage SpackInstall
 
 

--- a/doc/main.dox
+++ b/doc/main.dox
@@ -2,25 +2,52 @@
  * \mainpage
  *
  * Multidisciplinary-design Adaptation and Sensitivity Toolkit (MAST) is being
- * developed at the Computational Dynamics and Design Laboratory through
- * research efforts with a focus on design of nonlinear multiphysics systems
- * that exhibit dynamic responses. Due to the need for computational efficiency
- * and reliability in design, specialized mechanisms have been implemented to
- * efficiently quantify the static and dynamic stability characteristics of
- * such systems. Significant effort has been made towards the design of
- * object-oriented data-structures that allow easy extensibility of the
- * solvers. The framework implements sensitivity analysis for all solver
- * components with interfaces to multiple optimization softwares. MAST
- * leverages open-source libraries to enable efficient high-performance
- * computations.
+ * developed at the [Computational Dynamics and Design Laboratory](http://bhatia.ae.msstate.edu)
+ * through research efforts with a focus on design of nonlinear multiphysics systems
+ * that exhibit dynamic responses.
+ *
+ *  Following is a brief list of capabilities for the software
+ *  - Nonlinear heat conduction
+ *    - Temperature dependent material properties
+ *    - Radiation boundary conditions
+ *    - Convection boundary conditions
+ *    - 1D, 2D and 3D elements
+ *    - Nonlinear steady-state analysis
+ *    - Nonlinear transient analysis
+ *  - Structural analysis
+ *    - Thermoelastic loading
+ *    - Surface pressure loading
+ *    - 1D beam (Bernounlli and Timoshenko) and bar elements
+ *    - 2D plate (DKT and Mindlin) membrane elements
+ *    - Nonlinear von Karman strain
+ *    - Nonlinear static analysis
+ *    - Modal analysis (about nonlinear steady-state)
+ *    - Nonlinear transient analysis
+ *    - Preliminary ability to analyze NASTRAN input-deck parsed using [pyNastran](http://pynastran-git.readthedocs.io/en/latest/).
+ *  - Fluid analysis
+ *    - SU/PG discretization of compressible Euler equations
+ *    - Small-disturbance linearized time-domain and frequency-domain solvers for Euler equations
+ *    - SU/PG discretization of compressible Navier-Stokes equations (experimental).
+ *  - Fluid-structure interaction
+ *    - Small-disturbance flutter solution through coupling of structural and fluid discretizations.
+ *    - Time-accurate fluid-structure interaction (experimental).
+ *  - Aeroelasticity
+ *    - U-g flutter solver with mode tracking
+ *    - Time-domain flutter solver for piston-theory aerodynamics
+ *  - Level-sets
+ *    - Hamilton-Jacobi solver 
+ *  - Optimization
+ *    - Level-set based topology optimization
+ *    - Sensitivity analysis for almost all analysis capabilities mentioned above
+ *    - Interfaces to optimizers (GCMMA, DOT, NPSOL)
  *
  *
- *   MAST leverages the following libraries:
- *
- *   - libMesh for finite element analysis capabilities,
- *   - PETSc for linear and nonlinear solvers.
- *   - SLEPc for eigensolvers,
- *   - Eigen for dense matrix and vector operations.
+ *  MAST leverages following open-source libraries to enable efficient
+ *  high-performance computations:
+ *   - [libMesh](http://libmesh.github.io) for finite element analysis capabilities,
+ *   - [PETSc](https://www.mcs.anl.gov/petsc/) for linear and nonlinear solvers.
+ *   - [SLEPc](http://slepc.upv.es) for eigensolvers,
+ *   - [Eigen](http://eigen.tuxfamily.org) for dense matrix and vector operations.
  *
  *  # Contact
  *

--- a/doc/source_install.dox
+++ b/doc/source_install.dox
@@ -1,9 +1,333 @@
 
 /*!
 
-\page SourceInstall Installation from source
+\page SourceInstall Installation on Mac OS with MacPorts
 
-How to install MAST from source
+This installs some dependencies using MacPorts followed by installation of
+PETSc, SLEPc, libMesh and MAST using source.
+
+1.  Install Xcode from Mac App Store.
+
+2.  Install the command line tools to support the rest of the install process. Use Terminal app and type:
+```
+$ xcode-select --install
+```
+
+3.  Download and install [XQuartz](https://www.xquartz.org)
+
+4.  Download and install [MacPorts](https://www.macports.org/install.php)
+
+5.  Once installed, open a fresh terminal window and use the following commands to install the dependencies:
+```
+$ sudo port install hdf5
+$ sudo port install boost
+$ sudo port install eigen3
+$ sudo port install cmake
+$ sudo port install openmpi-clang
+```
+
+6.  The following assumes that PETSc, SLEPc, libMesh and MAST will be installed in the directory: `{CODES}`
+If this directory is `~/Documents/codes/` (Note that in Unix `~/` is the users home directory), then
+create it using the following commands:
+```
+$ cd ~/Documents
+$ mkdir codes
+$ cd codes
+```
+In the following steps, replace `{CODES}` with the directory path.
+
+7.  Download [PETSc](https://www.mcs.anl.gov/petsc/download/index.html). This will download the
+code to `~/Downloads` directory. Find the file name using command line
+```
+$ ls -lt ~/Downloads
+```
+This will list all files in `~/Downloads` starting with the latest file.
+The PETSc file will likely have the following format: `petsc-*.tar.gz`, where `*` is replaced with the version number.
+The next step assumes that the file name is `{PETSC_FILE}.tar.gz`, where `{PETSC_FILE}` is the initial part of the file
+name preceding `.tar.gz`.
+
+8.  Create a directory where PETSc will be built; move `{PETSC_FILE}.tar.gz` to this directory and extract it.
+```
+$ cd {CODES}
+$ mkdir petsc
+$ cd petsc
+$ mv ~/Downloads/{PETSC_FILE}.tar.gz ./
+```
+Replace `{PETSC_FILE}` with the name found in step 7.
+```
+$ tar -zxf {PETSC_FILE}.tar.gz
+```
+This will create a directory by the name of `{PETSC_FILE}`.
+
+9.  Configure PETSc:
+```
+$ cd {PETSC_FILE}
+```
+Create a text file containing the configuration options for PETSc. The following commands use `emacs` as the
+text editor to accomplish this task:
+```
+$ emacs petsc_config_options
+```
+this will open emacs to edit file `petsc_config_options`
+
+Copy and paste the PETSc configuration [options](#petsc-options). Then save these changes
+by typing `<ctrl>x<ctrl>s`, where `<ctrl>` is the `Control` key. This is `Control` followed by `x`, then
+`Control` followed by `s`.
+Exit the editor by typing `<ctrl>x<ctrl>c`. This is `Control` followed by `x`, then `Control` followed by `c`.
+Change the permission of this file to allow execution:
+```
+$ chmod +x petsc_config_options
+```
+Configure petsc by executing this file:
+```
+$ ./petsc_config_options
+```
+This will take some time, during which it will verify all configuration options, download, configure, build
+and install the external libraries specified in the configuration options.
+Note that once PETSc finishes configuration, it will list the options in the Terminal window. At the bottom should
+be the command to build PETSc.
+
+10. Build PETSc by using the instructions provided by PETSc at the end of previous step. Following is the likely format
+suggested by PETSc, where `{PETSC_FILE}` is the name identified in 8. In case of any differences, follow PETSc's
+instructions.
+```
+$  make PETSC_DIR={CODES}/petsc/{PETSC_FILE} PETSC_ARCH=arch-darwin-c-opt all
+```
+This will take some time to go through building the library. At the end, PETSc will print the command to install the
+library built in this step.
+
+11. Install PETSc by using the instructions from PETSc in previous step. Again, replace `{PETSC_FILE}` with the name
+identified in step 8 and in case of any differences, follow the instructions from PETSc.
+```
+$ make PETSC_DIR={CODES}/petsc/{PETSC_FILE} PETSC_ARCH=arch-darwin-c-opt install
+```
+This should install all the hearder files in `{CODES}/petsc/include` and the libraries in `{CODES}/petsc/lib`.
+
+12. Download [SLEPc](http://slepc.upv.es/download/). This will download the file in `~/Downloads` and use the same
+procedure from step 7 to identify the file name:
+```
+$ ls -lt ~/Downloads
+```
+The SLEPc file name should be of the following format: `{SLEPC_FILE}.tar.gz`
+
+13. Create a directory for building and installation of SLEPc. Move the file there and unpack it. In the following commands,
+replace `{SLEPC_FILE}` with the file name identified in the previous step.
+```
+$ cd {CODES}
+$ mkdir slepc
+$ cd slepc
+$ mv ~/Downloads/{SLEPC_FILE}.tar.gz ./
+$ tar -zxf {SLEPC_FILE}.tar.gz
+```
+This should extract the code in the directory `{SLEPC_FILE}`.
+
+14. Configure SLEPc. In the following commands, relace `{CODES}` with the full path identified in step 6.
+```
+$ PETSC_DIR={CODES}/petsc ./configure --prefix=${PWD}/../
+```
+This will verify the PETSc installation and configure SLEPc for installation in `{CODES}/slepc`. It will
+also print the commands to be used for building SLEPc. Use these in the next step.
+
+15. Build SLEPc:
+```
+$ make SLEPC_DIR=$PWD PETSC_DIR={CODES}/petsc
+```
+This will build SLEPc and at the end will print the command to be used for installation of SLEPc.
+
+16. Install using the instructions from SLEPc at the end of previous step:
+```
+$ make SLEPC_DIR={CODES}/slepc/{SLEPC_FILE} PETSC_DIR={CODES}/petsc install
+```
+
+17. Download [libMesh](http://libmesh.github.io/installation.html):
+```
+$ cd {CODES}
+$ mkdir libmesh
+$ cd libmesh
+$ git clone git://github.com/libMesh/libmesh.git      [this will use git to clone the remote repository from GitHub to {CODES}/libmesh/libmesh ]
+$ cd libmesh
+```
+
+18. Configure libMesh.
+```
+$ emacs libmesh_config_options
+```
+Copy and paste the contents of the configuration [options](#libmesh-options). Replace
+`{CODES}` with its full path identified above.
+Save:  `<ctrl>x<ctrl>s`
+Exit:  `<ctrl>x<ctrl>c`
+Make this file executable, and then run it.
+```
+$ chmod +x libmesh_config_options
+$ ./libmesh_config_options
+```
+This will verify the installation of PETSc, SLEPc, and other dependencies, and configure the build
+options for libMesh. It will print all configured options on the Terminal. Verify that it is able to
+identify the correct versions for all dependencies (exodus, hdf5, metis, nemesis, parmetis, petsc,
+slepc, mpi, etc.)
+
+19. Build libMesh:
+```
+$ make -j N
+```
+Replace `N` with the number of cores on your machine to enable parallel build.
+This will build all components of libMesh.
+
+20. Install libMesh:
+```
+$ make install -j N
+```
+Replace `N` with the number of cores on your machine to enable parallel build.
+
+21. Download MAST
+```
+$ cd {CODES}
+$ mkdir mast
+$ cd mast
+$ git clone https://github.com/MASTmultiphysics/mast-multiphysics.git
+```
+
+22. Configure MAST
+```
+$ cd ../
+$ mkdir dbg
+$ cd dbg
+```
+Create a file with configuration options for MAST
+```
+$ emacs mast_config_options
+```
+Copy and paste the MAST configuration [options](#mast-options). Replace
+`{CODES}` with the full path
+Save: `<ctrl>x<ctrl>s`
+Exit: `<ctrl>x<ctrl>c`
+Make this file executable and run it:
+```
+$ chmod +x mast_config_options
+$ ./mast_config_options
+```
+
+23. Build MAST:
+```
+$ make example_2 -j N
+```
+Replace N with the number of cores on your machine to enable parallel build.
+
+24. Test MAST by running example_2:
+```
+$ ./examples/example_2/example_2 -ksp_type preonly -pc_type lu
+```
+
+
+
+*   PETSC configuration options: (copy and past the content and replace
+`{CODES}` with its path defined above)
+{: #petsc-options}
+```
+python2.7 ./configure                                  \
+--prefix=${PWD}/../                                    \
+--CC=mpicc-openmpi-clang                               \
+--CXX=mpicxx-openmpi-clang                             \
+--FC=mpif90-openmpi-clang                              \
+--with-fortran=0                                       \
+--with-mpiexec=/opt/local/bin/mpiexec-openmpi-clang    \
+--with-shared-libraries=1                              \
+--with-x=1 --with-x-dir=/opt/X11                       \
+--with-debugging=0                                     \
+--with-lapack-lib=/usr/lib/liblapack.dylib             \
+--with-blas-lib=/usr/lib/libblas.dylib                 \
+--download-superlu=yes                                 \
+--download-superlu_dist=yes                            \
+--download-suitesparse=yes                             \
+--download-mumps=yes                                   \
+--download-scalapack=yes                               \
+--download-parmetis=yes                                \
+--download-metis=yes                                   \
+--download-hypre=yes                                   \
+--download-ml=yes
+```
+
+
+
+*  libMesh configuration options: (copy and past the content and replace
+`{CODES}` with its path defined above)
+{: #libmesh-options}
+```
+PETSC_DIR={CODES}/petsc                              \
+SLEPC_DIR={CODES}/slepc                              \
+FC=mpif90-openmpi-clang                              \
+F77=mpif90-openmpi-clang                             \
+CC=mpicc-openmpi-clang                               \
+CXX=mpicxx-openmpi-clang                             \
+./configure --prefix=${PWD}/../                      \
+--enable-mpi                                         \
+--disable-unique-id                                  \
+--enable-dependency-tracking                         \
+--enable-fortran                                     \
+--enable-shared                                      \
+--enable-exceptions                                  \
+--disable-openmp                                     \
+--disable-default-comm-world                         \
+--enable-tracefiles                                  \
+--enable-amr                                         \
+--enable-vsmoother                                   \
+--enable-periodic                                    \
+--enable-dirichlet                                   \
+--enable-parmesh                                     \
+--enable-nodeconstraint                              \
+--enable-ghosted                                     \
+--enable-pfem                                        \
+--enable-ifem                                        \
+--enable-second                                      \
+--enable-xdr                                         \
+--enable-reference-counting                          \
+--enable-perflog                                     \
+--enable-examples                                    \
+--enable-boost                                       \
+--disable-trilinos                                   \
+--disable-tbb                                        \
+--enable-sfc                                         \
+--disable-tecplot                                    \
+--disable-tecio                                      \
+--enable-metis                                       \
+--enable-parmetis                                    \
+--enable-tetgen                                      \
+--enable-triangle                                    \
+--disable-vtk                                        \
+--enable-hdf5                                        \
+--enable-libHilbert                                  \
+--enable-nanoflann                                   \
+--enable-exodus                                      \
+--enable-netcdf                                      \
+--enable-petsc                                       \
+--enable-slepc                                       \
+--with-mpi=/opt/local                                \
+--with-tbb=/opt/local/include/tbb                    \
+--with-tbb-lib=/opt/local/lib                        \
+--with-metis=internal                                \
+--with-hdf5=/opt/local/                              \
+--with-methods="opt dbg"
+```
+
+
+
+*  MAST configuration options: (copy and past the content and replace
+`{CODES}` with its path defined above)
+{: #mast-options}
+```
+export CODES_PATH={CODES}                                \
+cmake  ../mast-multiphysics                              \
+-DMPI_C_COMPILER=mpicc-openmpi-clang                     \
+-DMPI_CXX_COMPILER=mpicxx-openmpi-clang                  \
+-DCMAKE_C_COMPILER=mpicc-openmpi-clang                   \
+-DCMAKE_CXX_COMPILER=mpicxx-openmpi-clang                \
+-DCMAKE_Fortran_COMPILER=mpif90-openmpi-clang            \
+-DlibMesh_DIR=${CODES_PATH}/libmesh                      \
+-DPETSc_DIR=${CODES_PATH}/petsc                          \
+-DSLEPc_DIR=${CODES_PATH}/slepc                          \
+-DBOOST_ROOT=/opt/local                                  \
+-DCMAKE_BUILD_TYPE=Debug
+```
 
 */
 

--- a/doc/spack_install.dox
+++ b/doc/spack_install.dox
@@ -1,18 +1,73 @@
 
 /*!
 
-\page SpackInstall Installation using spack
+\page SpackInstall Installation using Spack
 
-How to install MAST using spack
+[Spack](https://spack.io) is a python-based package manager that can install
+all dependencies. MAST is installed from source.
 
-\code{.cpp}
-int c;
-float d;
-class myc {
-  public:
-    myc();
-};
+1. Install Spack using instructions
+\code{bash}
+$ git clone https://github.com/spack/spack.git
+$ . spack/share/spack/setup-env.sh
+\endcode
+
+2. Install MAST and all dependencies
+\code{bash}
+$ spack install                                                  \
+ ^libmesh +exodusii+hdf5+metis+boost+eigen+slepc                \
+ ^eigen ~fftw~metis~mpfr                                        \
+ ^petsc ~complex~debug+double+hdf5+hypre~int64+metis+mpi+mumps+shared+suite-sparse+superlu-dist+trilinos \
+ ^intel-mkl %gcc@8.2.0
+\endcode
+
+3. Create symbolic link to all packages on in a directory for MAST installation.
+Replace `{SPACK_CODES}` with the directory where you want these links created.
+\code{bash}
+$ spack view -v -d true symlink {SPACK_CODES}                    \
+ ^libmesh +exodusii+hdf5+metis+boost+eigen+slepc                \
+ ^eigen ~fftw~metis~mpfr                                        \
+ ^petsc ~complex~debug+double+hdf5+hypre~int64+metis+mpi+mumps+shared+suite-sparse+superlu-dist+trilinos \
+ ^intel-mkl %gcc@8.2.0
+\endcode
+
+4. Download MAST in directory where it will be built. The directory is called
+`{CODES}` in the following and should be replaced.
+\code{bash}
+$ cd {CODES}
+$ mkdir mast
+$ cd mast
+$ git clone https://github.com/MASTmultiphysics/mast-multiphysics.git
+\endcode
+
+5. Configure MAST
+\code{bash}
+$ cd ../
+$ mkdir dbg
+$ cd dbg
+$ export SPACK_VIEW_DIR={SPACK_CODES}                            \
+  cmake  ../mast-multiphysics                                    \
+  -DMPI_C_COMPILER=${SPACK_VIEW_DIR}/mpiccc                      \
+  -DMPI_CXX_COMPILER=${SPACK_VIEW_DIR}/mpicxx                    \
+  -DCMAKE_C_COMPILER=${SPACK_VIEW_DIR}/mpiccc                    \
+  -DCMAKE_CXX_COMPILER=${SPACK_VIEW_DIR}/mpicxx                  \
+  -DCMAKE_Fortran_COMPILER=${SPACK_VIEW_DIR}/mpif90              \
+  -DlibMesh_DIR=${SPACK_VIEW_DIR}                                \
+  -DPETSc_DIR=${SPACK_VIEW_DIR}                                  \
+  -DSLEPc_DIR=${SPACK_VIEW_DIR}                                  \
+  -DBOOST_ROOT=${SPACK_VIEW_DIR}/include                         \
+  -DCMAKE_BUILD_TYPE=Debug
+\endcode
+
+6. Build MAST:
+\code{bash}
+$ make example_driver -j N
+\endcode
+Replace N with the number of cores on your machine to enable parallel build.
+
+7. Test MAST by running example_2:
+\code{bash}
+$ ./examples/example_2/example_2 -ksp_type preonly -pc_type lu
 \endcode
 
 */
-

--- a/doc/tutorials.dox
+++ b/doc/tutorials.dox
@@ -3,6 +3,9 @@
 
 \page TutorialsPage Tutorials for MAST
 
+  Several examples have been implemented in MAST, some of which have been
+  ported as tutorials listed below. 
+
   - \subpage example_1
   - \subpage example_2
   - \subpage example_3 

--- a/examples/base/augment_ghost_elem_send_list.cpp
+++ b/examples/base/augment_ghost_elem_send_list.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/base/augment_ghost_elem_send_list.h
+++ b/examples/base/augment_ghost_elem_send_list.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/base/example_base.cpp
+++ b/examples/base/example_base.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/base/example_base.h
+++ b/examples/base/example_base.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/base/examples_driver.cpp
+++ b/examples/base/examples_driver.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/base/input_wrapper.h
+++ b/examples/base/input_wrapper.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/base/multilinear_interpolation.cpp
+++ b/examples/base/multilinear_interpolation.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/base/multilinear_interpolation.h
+++ b/examples/base/multilinear_interpolation.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/base/plot_results.cpp
+++ b/examples/base/plot_results.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/base/plot_results.h
+++ b/examples/base/plot_results.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/base/rigid_surface_motion.cpp
+++ b/examples/base/rigid_surface_motion.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/base/rigid_surface_motion.h
+++ b/examples/base/rigid_surface_motion.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -47,7 +47,7 @@ namespace MAST {
         
         /*!
          *   initiate the motion object with oscillation data. 
-         *   \par pitch_phase is the phase angle by which pitch leads
+         *   \p pitch_phase is the phase angle by which pitch leads
          *   plunge.
          */
         void init(MAST::FrequencyFunction& freq,
@@ -72,7 +72,7 @@ namespace MAST {
 
         /*!
          *   provides a function for the definition of surface displacement,
-         *   \par w, and rotation of the surface normal in \par dn_rot
+         *   \p w, and rotation of the surface normal in \p dn_rot
          */
         virtual void
         freq_domain_motion(const libMesh::Point& p,

--- a/examples/example_1/example_1.cpp
+++ b/examples/example_1/example_1.cpp
@@ -1,3 +1,21 @@
+/*
+ * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
+ * Copyright (C) 2013-2019  Manav Bhatia
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
 
 // C/C++ includes.
 #include <iostream>

--- a/examples/example_2/example_2.cpp
+++ b/examples/example_2/example_2.cpp
@@ -1,3 +1,21 @@
+/*
+ * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
+ * Copyright (C) 2013-2019  Manav Bhatia
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
 
 // C/C++ includes.
 #include <iostream>

--- a/examples/example_3/constrain_beam_dofs.cpp
+++ b/examples/example_3/constrain_beam_dofs.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/example_3/constrain_beam_dofs.h
+++ b/examples/example_3/constrain_beam_dofs.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/example_3/example_3.cpp
+++ b/examples/example_3/example_3.cpp
@@ -1,3 +1,22 @@
+/*
+ * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
+ * Copyright (C) 2013-2019  Manav Bhatia
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 // C++ includes
 #include <vector>
 
@@ -62,7 +81,7 @@ int main(int argc, char* argv[]) {
 
     // initialize the wrapper to read input parameters. This will check
     // if the executable parameters included a parameter of type
-    // input=<filename>. If included, then the input parameters will be read
+    // `input=${filename}`. If included, then the input parameters will be read
     // from this filename. Otherwise, the parameters will be read from the
     // executable arguments. The wrapper uses default values for parameters
     // if none are provided.

--- a/examples/fluid/base/fluid_example_base.cpp
+++ b/examples/fluid/base/fluid_example_base.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fluid/base/fluid_example_base.h
+++ b/examples/fluid/base/fluid_example_base.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fluid/cylinder_analysis_2D/cylinder_analysis_2d.cpp
+++ b/examples/fluid/cylinder_analysis_2D/cylinder_analysis_2d.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fluid/cylinder_analysis_2D/cylinder_analysis_2d.h
+++ b/examples/fluid/cylinder_analysis_2D/cylinder_analysis_2d.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fluid/meshing/cylinder.cpp
+++ b/examples/fluid/meshing/cylinder.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fluid/meshing/cylinder.h
+++ b/examples/fluid/meshing/cylinder.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fluid/meshing/flag_mesh_2D.cpp
+++ b/examples/fluid/meshing/flag_mesh_2D.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fluid/meshing/flag_mesh_2D.h
+++ b/examples/fluid/meshing/flag_mesh_2D.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fluid/meshing/flag_mesh_3D.cpp
+++ b/examples/fluid/meshing/flag_mesh_3D.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fluid/meshing/flag_mesh_3D.h
+++ b/examples/fluid/meshing/flag_mesh_3D.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fluid/meshing/mesh_initializer.cpp
+++ b/examples/fluid/meshing/mesh_initializer.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fluid/meshing/mesh_initializer.h
+++ b/examples/fluid/meshing/mesh_initializer.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -122,7 +122,7 @@ namespace MAST {
             }
             
             /*!
-             *   @returns location of division point \par i
+             *   @returns location of division point \p i
              */
             Real div_location(unsigned int i) const {
                 libmesh_assert(_n_divs > 0);
@@ -132,7 +132,7 @@ namespace MAST {
 
             
             /*!
-             *   @returns relative mesh size at point \par i
+             *   @returns relative mesh size at point \p i
              */
             Real relative_mesh_size(unsigned int i) const {
                 libmesh_assert(_n_divs > 0);
@@ -142,7 +142,7 @@ namespace MAST {
 
             
             /*!
-             *   @returns number of elements in division \par i
+             *   @returns number of elements in division \p i
              */
             Real n_elements_in_div(unsigned int i) const {
                 libmesh_assert(_n_divs > 0);

--- a/examples/fluid/meshing/naca0012.cpp
+++ b/examples/fluid/meshing/naca0012.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fluid/meshing/naca0012.h
+++ b/examples/fluid/meshing/naca0012.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fluid/meshing/panel_mesh_2D.cpp
+++ b/examples/fluid/meshing/panel_mesh_2D.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fluid/meshing/panel_mesh_2D.h
+++ b/examples/fluid/meshing/panel_mesh_2D.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fluid/meshing/panel_mesh_3D.cpp
+++ b/examples/fluid/meshing/panel_mesh_3D.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fluid/meshing/panel_mesh_3D.h
+++ b/examples/fluid/meshing/panel_mesh_3D.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fluid/meshing/panel_mesh_3D_half_domain.cpp
+++ b/examples/fluid/meshing/panel_mesh_3D_half_domain.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fluid/meshing/panel_mesh_3D_half_domain.h
+++ b/examples/fluid/meshing/panel_mesh_3D_half_domain.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fluid/meshing/ramp_mesh_2D.cpp
+++ b/examples/fluid/meshing/ramp_mesh_2D.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fluid/meshing/ramp_mesh_2D.h
+++ b/examples/fluid/meshing/ramp_mesh_2D.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fluid/meshing/shock_impingement_panel_mesh_2D.cpp
+++ b/examples/fluid/meshing/shock_impingement_panel_mesh_2D.cpp
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/fluid/meshing/shock_impingement_panel_mesh_2D.h
+++ b/examples/fluid/meshing/shock_impingement_panel_mesh_2D.h
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/fluid/panel_inviscid_analysis_2D/panel_inviscid_analysis_2d.cpp
+++ b/examples/fluid/panel_inviscid_analysis_2D/panel_inviscid_analysis_2d.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fluid/panel_inviscid_analysis_2D/panel_inviscid_analysis_2d.h
+++ b/examples/fluid/panel_inviscid_analysis_2D/panel_inviscid_analysis_2d.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fluid/panel_small_disturbance_frequency_domain_3D/panel_small_disturbance_frequency_domain_inviscid_analysis_3D.cpp
+++ b/examples/fluid/panel_small_disturbance_frequency_domain_3D/panel_small_disturbance_frequency_domain_inviscid_analysis_3D.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fluid/panel_small_disturbance_frequency_domain_3D/panel_small_disturbance_frequency_domain_inviscid_analysis_3D.h
+++ b/examples/fluid/panel_small_disturbance_frequency_domain_3D/panel_small_disturbance_frequency_domain_inviscid_analysis_3D.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fluid/panel_small_disturbance_frequency_domain_analysis_2D/panel_small_disturbance_frequency_domain_analysis_2d.cpp
+++ b/examples/fluid/panel_small_disturbance_frequency_domain_analysis_2D/panel_small_disturbance_frequency_domain_analysis_2d.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fluid/panel_small_disturbance_frequency_domain_analysis_2D/panel_small_disturbance_frequency_domain_analysis_2d.h
+++ b/examples/fluid/panel_small_disturbance_frequency_domain_analysis_2D/panel_small_disturbance_frequency_domain_analysis_2d.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fluid/ramp_laminar_analysis_2D/ramp_viscous_analysis_2d.cpp
+++ b/examples/fluid/ramp_laminar_analysis_2D/ramp_viscous_analysis_2d.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fluid/ramp_laminar_analysis_2D/ramp_viscous_analysis_2d.h
+++ b/examples/fluid/ramp_laminar_analysis_2D/ramp_viscous_analysis_2d.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/base/gaf_database.cpp
+++ b/examples/fsi/base/gaf_database.cpp
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/base/gaf_database.h
+++ b/examples/fsi/base/gaf_database.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/beam_aerothermoelastic_flutter_solution/beam_aerothermoelastic_flutter_solution.cpp
+++ b/examples/fsi/beam_aerothermoelastic_flutter_solution/beam_aerothermoelastic_flutter_solution.cpp
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/beam_aerothermoelastic_flutter_solution/beam_aerothermoelastic_flutter_solution.h
+++ b/examples/fsi/beam_aerothermoelastic_flutter_solution/beam_aerothermoelastic_flutter_solution.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/beam_flag_flutter_solution/beam_flag_euler_fsi_flutter_solution.cpp
+++ b/examples/fsi/beam_flag_flutter_solution/beam_flag_euler_fsi_flutter_solution.cpp
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/beam_flag_flutter_solution/beam_flag_euler_fsi_flutter_solution.h
+++ b/examples/fsi/beam_flag_flutter_solution/beam_flag_euler_fsi_flutter_solution.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/beam_flag_flutter_solution/beam_flag_frequency_domain_displacement.cpp
+++ b/examples/fsi/beam_flag_flutter_solution/beam_flag_frequency_domain_displacement.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/beam_flag_flutter_solution/beam_flag_frequency_domain_displacement.h
+++ b/examples/fsi/beam_flag_flutter_solution/beam_flag_frequency_domain_displacement.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/beam_flag_flutter_solution/beam_flag_frequency_domain_normal_rotation.cpp
+++ b/examples/fsi/beam_flag_flutter_solution/beam_flag_frequency_domain_normal_rotation.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/beam_flag_flutter_solution/beam_flag_frequency_domain_normal_rotation.h
+++ b/examples/fsi/beam_flag_flutter_solution/beam_flag_frequency_domain_normal_rotation.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/beam_flag_flutter_solution/beam_flag_frequency_domain_pressure_function.cpp
+++ b/examples/fsi/beam_flag_flutter_solution/beam_flag_frequency_domain_pressure_function.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/beam_flag_flutter_solution/beam_flag_frequency_domain_pressure_function.h
+++ b/examples/fsi/beam_flag_flutter_solution/beam_flag_frequency_domain_pressure_function.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/beam_flag_flutter_solution/beam_flag_pressure_function.cpp
+++ b/examples/fsi/beam_flag_flutter_solution/beam_flag_pressure_function.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/beam_flag_flutter_solution/beam_flag_pressure_function.h
+++ b/examples/fsi/beam_flag_flutter_solution/beam_flag_pressure_function.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/beam_flutter_nonuniform_aero_base_solution/beam_euler_fsi_flutter_nonuniform_aero_base_solution.cpp
+++ b/examples/fsi/beam_flutter_nonuniform_aero_base_solution/beam_euler_fsi_flutter_nonuniform_aero_base_solution.cpp
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/beam_flutter_nonuniform_aero_base_solution/beam_euler_fsi_flutter_nonuniform_aero_base_solution.h
+++ b/examples/fsi/beam_flutter_nonuniform_aero_base_solution/beam_euler_fsi_flutter_nonuniform_aero_base_solution.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/beam_flutter_optimization/beam_flutter_optimization.cpp
+++ b/examples/fsi/beam_flutter_optimization/beam_flutter_optimization.cpp
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/beam_flutter_optimization/beam_flutter_optimization.h
+++ b/examples/fsi/beam_flutter_optimization/beam_flutter_optimization.h
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/beam_flutter_solution/beam_euler_fsi_flutter_solution.cpp
+++ b/examples/fsi/beam_flutter_solution/beam_euler_fsi_flutter_solution.cpp
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/beam_flutter_solution/beam_euler_fsi_flutter_solution.h
+++ b/examples/fsi/beam_flutter_solution/beam_euler_fsi_flutter_solution.h
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/beam_flutter_solution/constrain_beam_dofs.cpp
+++ b/examples/fsi/beam_flutter_solution/constrain_beam_dofs.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/beam_flutter_solution/constrain_beam_dofs.h
+++ b/examples/fsi/beam_flutter_solution/constrain_beam_dofs.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/beam_fsi_flutter_high_order_convergence/beam_fsi_high_order_convergence.cpp
+++ b/examples/fsi/beam_fsi_flutter_high_order_convergence/beam_fsi_high_order_convergence.cpp
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/beam_fsi_flutter_high_order_convergence/beam_fsi_high_order_convergence.h
+++ b/examples/fsi/beam_fsi_flutter_high_order_convergence/beam_fsi_high_order_convergence.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/beam_fsi_solution/beam_euler_fsi_solution.h
+++ b/examples/fsi/beam_fsi_solution/beam_euler_fsi_solution.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/plate_flag_flutter_solution/plate_flag_euler_fsi_flutter_solution.cpp
+++ b/examples/fsi/plate_flag_flutter_solution/plate_flag_euler_fsi_flutter_solution.cpp
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/plate_flag_flutter_solution/plate_flag_euler_fsi_flutter_solution.h
+++ b/examples/fsi/plate_flag_flutter_solution/plate_flag_euler_fsi_flutter_solution.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/plate_flag_flutter_solution/plate_flag_frequency_domain_displacement.cpp
+++ b/examples/fsi/plate_flag_flutter_solution/plate_flag_frequency_domain_displacement.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/plate_flag_flutter_solution/plate_flag_frequency_domain_displacement.h
+++ b/examples/fsi/plate_flag_flutter_solution/plate_flag_frequency_domain_displacement.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/plate_flag_flutter_solution/plate_flag_frequency_domain_normal_rotation.cpp
+++ b/examples/fsi/plate_flag_flutter_solution/plate_flag_frequency_domain_normal_rotation.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/plate_flag_flutter_solution/plate_flag_frequency_domain_normal_rotation.h
+++ b/examples/fsi/plate_flag_flutter_solution/plate_flag_frequency_domain_normal_rotation.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/plate_flag_flutter_solution/plate_flag_frequency_domain_pressure_function.cpp
+++ b/examples/fsi/plate_flag_flutter_solution/plate_flag_frequency_domain_pressure_function.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/plate_flag_flutter_solution/plate_flag_frequency_domain_pressure_function.h
+++ b/examples/fsi/plate_flag_flutter_solution/plate_flag_frequency_domain_pressure_function.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/plate_flag_flutter_solution/plate_flag_pressure_function.cpp
+++ b/examples/fsi/plate_flag_flutter_solution/plate_flag_pressure_function.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/plate_flag_flutter_solution/plate_flag_pressure_function.h
+++ b/examples/fsi/plate_flag_flutter_solution/plate_flag_pressure_function.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/plate_flutter_optimization/plate_flutter_optimization.cpp
+++ b/examples/fsi/plate_flutter_optimization/plate_flutter_optimization.cpp
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/plate_flutter_optimization/plate_flutter_optimization.h
+++ b/examples/fsi/plate_flutter_optimization/plate_flutter_optimization.h
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/plate_flutter_solution/plate_euler_fsi_flutter_solution.cpp
+++ b/examples/fsi/plate_flutter_solution/plate_euler_fsi_flutter_solution.cpp
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/plate_flutter_solution/plate_euler_fsi_flutter_solution.h
+++ b/examples/fsi/plate_flutter_solution/plate_euler_fsi_flutter_solution.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/fsi/stiffened_plate_thermally_stressed_flutter_optimization/stiffened_plate_thermally_stressed_flutter_optimization.h
+++ b/examples/fsi/stiffened_plate_thermally_stressed_flutter_optimization/stiffened_plate_thermally_stressed_flutter_optimization.h
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/bar_extension/bar_extension.cpp
+++ b/examples/structural/bar_extension/bar_extension.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/bar_extension/bar_extension.h
+++ b/examples/structural/bar_extension/bar_extension.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/base/blade_stiffened_panel_mesh.cpp
+++ b/examples/structural/base/blade_stiffened_panel_mesh.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/base/blade_stiffened_panel_mesh.h
+++ b/examples/structural/base/blade_stiffened_panel_mesh.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/base/hat_stiffened_panel_mesh.cpp
+++ b/examples/structural/base/hat_stiffened_panel_mesh.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/base/hat_stiffened_panel_mesh.h
+++ b/examples/structural/base/hat_stiffened_panel_mesh.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/base/structural_example_1d.cpp
+++ b/examples/structural/base/structural_example_1d.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/base/structural_example_1d.h
+++ b/examples/structural/base/structural_example_1d.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/base/structural_example_2d.cpp
+++ b/examples/structural/base/structural_example_2d.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/base/structural_example_2d.h
+++ b/examples/structural/base/structural_example_2d.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/base/structural_example_base.cpp
+++ b/examples/structural/base/structural_example_base.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/base/structural_example_base.h
+++ b/examples/structural/base/structural_example_base.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/base/thermal_stress_jacobian_scaling_function.cpp
+++ b/examples/structural/base/thermal_stress_jacobian_scaling_function.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/base/thermal_stress_jacobian_scaling_function.h
+++ b/examples/structural/base/thermal_stress_jacobian_scaling_function.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/beam_bending/beam_bending.cpp
+++ b/examples/structural/beam_bending/beam_bending.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/beam_bending/beam_bending.h
+++ b/examples/structural/beam_bending/beam_bending.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/beam_bending_thermal_stress_with_offset/beam_bending_thermal_stress.cpp
+++ b/examples/structural/beam_bending_thermal_stress_with_offset/beam_bending_thermal_stress.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/beam_bending_thermal_stress_with_offset/beam_bending_thermal_stress.h
+++ b/examples/structural/beam_bending_thermal_stress_with_offset/beam_bending_thermal_stress.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/beam_buckling_prestress/beam_column_buckling.cpp
+++ b/examples/structural/beam_buckling_prestress/beam_column_buckling.cpp
@@ -72,7 +72,7 @@ namespace MAST {
         
         /*!
          *    calculates the value of the function at the specified point,
-         *    \par p, and time, \par t, and returns it in \p v.
+         *    \p p, and time, \p t, and returns it in \p v.
          */
         virtual void operator() (const libMesh::Point& p,
                                  const Real t,
@@ -85,7 +85,7 @@ namespace MAST {
         
         /*!
          *    calculates the value of the function at the specified point,
-         *    \par p, and time, \par t, and returns it in \p v.
+         *    \p p, and time, \p t, and returns it in \p v.
          */
         virtual void derivative (const MAST::FunctionBase& f,
                                  const libMesh::Point& p,

--- a/examples/structural/beam_modal_analysis/beam_modal_analysis.cpp
+++ b/examples/structural/beam_modal_analysis/beam_modal_analysis.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/beam_modal_analysis/beam_modal_analysis.h
+++ b/examples/structural/beam_modal_analysis/beam_modal_analysis.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/beam_optimization/beam_optimization.cpp
+++ b/examples/structural/beam_optimization/beam_optimization.cpp
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/beam_optimization/beam_optimization.h
+++ b/examples/structural/beam_optimization/beam_optimization.h
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/beam_optimization/beam_optimization_base.cpp
+++ b/examples/structural/beam_optimization/beam_optimization_base.cpp
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/beam_optimization/beam_optimization_base.h
+++ b/examples/structural/beam_optimization/beam_optimization_base.h
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/beam_optimization_section_offset/beam_optimization_section_offset.cpp
+++ b/examples/structural/beam_optimization_section_offset/beam_optimization_section_offset.cpp
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/beam_optimization_section_offset/beam_optimization_section_offset.h
+++ b/examples/structural/beam_optimization_section_offset/beam_optimization_section_offset.h
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/beam_optimization_single_stress_functional/beam_optimization.cpp
+++ b/examples/structural/beam_optimization_single_stress_functional/beam_optimization.cpp
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/beam_optimization_single_stress_functional/beam_optimization.h
+++ b/examples/structural/beam_optimization_single_stress_functional/beam_optimization.h
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/beam_optimization_thermal_stress/beam_optimization_thermal_stress.cpp
+++ b/examples/structural/beam_optimization_thermal_stress/beam_optimization_thermal_stress.cpp
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/beam_optimization_thermal_stress/beam_optimization_thermal_stress.h
+++ b/examples/structural/beam_optimization_thermal_stress/beam_optimization_thermal_stress.h
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/beam_oscillating_load/beam_oscillating_load.cpp
+++ b/examples/structural/beam_oscillating_load/beam_oscillating_load.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -36,7 +36,7 @@ namespace MAST {
         public:
             
             /*!
-             *   \par p is the distributed load and \par f is the circular frequency
+             *   \p p is the distributed load and \p f is the circular frequency
              */
             OscillatingDistributedLoad(MAST::Parameter& p,
                                        MAST::Parameter& f):
@@ -53,7 +53,7 @@ namespace MAST {
             
             /*!
              *    calculates the value of the function at the specified point,
-             *    \par p, and time, \par t, and returns it in \p v.
+             *    \p p, and time, \p t, and returns it in \p v.
              */
             virtual void operator() (const libMesh::Point& p,
                                      const Real t,
@@ -65,7 +65,7 @@ namespace MAST {
             
             /*!
              *    calculates the value of the function at the specified point,
-             *    \par p, and time, \par t, and returns it in \p v.
+             *    \p p, and time, \p t, and returns it in \p v.
              */
             virtual void derivative (const MAST::FunctionBase& f,
                                      const libMesh::Point& p,

--- a/examples/structural/beam_oscillating_load/beam_oscillating_load.h
+++ b/examples/structural/beam_oscillating_load/beam_oscillating_load.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/beam_piston_theory_flutter/beam_piston_theory_flutter.cpp
+++ b/examples/structural/beam_piston_theory_flutter/beam_piston_theory_flutter.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/beam_piston_theory_flutter/beam_piston_theory_flutter.h
+++ b/examples/structural/beam_piston_theory_flutter/beam_piston_theory_flutter.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/beam_piston_theory_time_accurate/beam_piston_theory_time_accurate.cpp
+++ b/examples/structural/beam_piston_theory_time_accurate/beam_piston_theory_time_accurate.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/beam_piston_theory_time_accurate/beam_piston_theory_time_accurate.h
+++ b/examples/structural/beam_piston_theory_time_accurate/beam_piston_theory_time_accurate.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/membrane_extension/membrane_extension.cpp
+++ b/examples/structural/membrane_extension/membrane_extension.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/membrane_extension/membrane_extension.h
+++ b/examples/structural/membrane_extension/membrane_extension.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/nastran_model_analysis/mast_interface.cpp
+++ b/examples/structural/nastran_model_analysis/mast_interface.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/nastran_model_analysis/mast_interface.h
+++ b/examples/structural/nastran_model_analysis/mast_interface.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/nastran_model_analysis/nastran_model_analysis.cpp
+++ b/examples/structural/nastran_model_analysis/nastran_model_analysis.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/nastran_model_analysis/nastran_model_analysis.h
+++ b/examples/structural/nastran_model_analysis/nastran_model_analysis.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/nonlinear_circular_cantilever/circular_cantilever.cpp
+++ b/examples/structural/nonlinear_circular_cantilever/circular_cantilever.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/nonlinear_circular_cantilever/circular_cantilever.h
+++ b/examples/structural/nonlinear_circular_cantilever/circular_cantilever.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/plate_bending/plate_bending.cpp
+++ b/examples/structural/plate_bending/plate_bending.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/plate_bending/plate_bending.h
+++ b/examples/structural/plate_bending/plate_bending.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/plate_bending_level_set/plate_bending_level_set.cpp
+++ b/examples/structural/plate_bending_level_set/plate_bending_level_set.cpp
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/plate_bending_level_set/plate_bending_level_set.h
+++ b/examples/structural/plate_bending_level_set/plate_bending_level_set.h
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/plate_buckling_prestress/plate_buckling_prestress.cpp
+++ b/examples/structural/plate_buckling_prestress/plate_buckling_prestress.cpp
@@ -75,7 +75,7 @@ namespace MAST {
         
         /*!
          *    calculates the value of the function at the specified point,
-         *    \par p, and time, \par t, and returns it in \p v.
+         *    \p p, and time, \p t, and returns it in \p v.
          */
         virtual void operator() (const libMesh::Point& p,
                                  const Real t,
@@ -88,7 +88,7 @@ namespace MAST {
         
         /*!
          *    calculates the value of the function at the specified point,
-         *    \par p, and time, \par t, and returns it in \p v.
+         *    \p p, and time, \p t, and returns it in \p v.
          */
         virtual void derivative (const MAST::FunctionBase& f,
                                  const libMesh::Point& p,

--- a/examples/structural/plate_optimization/plate_optimization.h
+++ b/examples/structural/plate_optimization/plate_optimization.h
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/plate_optimization/plate_optimization_base.cpp
+++ b/examples/structural/plate_optimization/plate_optimization_base.cpp
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/plate_optimization/plate_optimization_base.h
+++ b/examples/structural/plate_optimization/plate_optimization_base.h
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/plate_optimization_section_offset/plate_section_offset_optimization.h
+++ b/examples/structural/plate_optimization_section_offset/plate_section_offset_optimization.h
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/plate_optimization_single_stress_functional/plate_optimization_single_functional.h
+++ b/examples/structural/plate_optimization_single_stress_functional/plate_optimization_single_functional.h
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/plate_optimization_thermal_stress/plate_thermal_stress_optimization.h
+++ b/examples/structural/plate_optimization_thermal_stress/plate_thermal_stress_optimization.h
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/plate_oscillating_load/plate_oscillating_load.cpp
+++ b/examples/structural/plate_oscillating_load/plate_oscillating_load.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -35,7 +35,7 @@ namespace MAST {
         public:
             
             /*!
-             *   \par p is the distributed load and \par f is the circular frequency
+             *   \p p is the distributed load and \p f is the circular frequency
              */
             OscillatingDistributedLoad(MAST::Parameter& p,
                                        MAST::Parameter& f):
@@ -52,7 +52,7 @@ namespace MAST {
             
             /*!
              *    calculates the value of the function at the specified point,
-             *    \par p, and time, \par t, and returns it in \p v.
+             *    \p p, and time, \p t, and returns it in \p v.
              */
             virtual void operator() (const libMesh::Point& p,
                                      const Real t,
@@ -64,7 +64,7 @@ namespace MAST {
             
             /*!
              *    calculates the value of the function at the specified point,
-             *    \par p, and time, \par t, and returns it in \p v.
+             *    \p p, and time, \p t, and returns it in \p v.
              */
             virtual void derivative (const MAST::FunctionBase& f,
                                      const libMesh::Point& p,

--- a/examples/structural/plate_oscillating_load/plate_oscillating_load.h
+++ b/examples/structural/plate_oscillating_load/plate_oscillating_load.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/plate_piston_theory_flutter/plate_piston_theory_flutter.cpp
+++ b/examples/structural/plate_piston_theory_flutter/plate_piston_theory_flutter.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/plate_piston_theory_flutter/plate_piston_theory_flutter.h
+++ b/examples/structural/plate_piston_theory_flutter/plate_piston_theory_flutter.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/plate_thermally_stressed_piston_theory_flutter/plate_thermally_stressed_piston_theory_flutter.h
+++ b/examples/structural/plate_thermally_stressed_piston_theory_flutter/plate_thermally_stressed_piston_theory_flutter.h
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/stiffened_plate_bending_thermal_stress/stiffened_plate_bending_thermal_stress.h
+++ b/examples/structural/stiffened_plate_bending_thermal_stress/stiffened_plate_bending_thermal_stress.h
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/stiffened_plate_optimization/stiffened_plate_optimization.h
+++ b/examples/structural/stiffened_plate_optimization/stiffened_plate_optimization.h
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/stiffened_plate_optimization/stiffened_plate_optimization_base.cpp
+++ b/examples/structural/stiffened_plate_optimization/stiffened_plate_optimization_base.cpp
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/stiffened_plate_optimization/stiffened_plate_optimization_base.h
+++ b/examples/structural/stiffened_plate_optimization/stiffened_plate_optimization_base.h
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/stiffened_plate_optimization_piston_theory_flutter/stiffened_plate_piston_theory_flutter_optimization.h
+++ b/examples/structural/stiffened_plate_optimization_piston_theory_flutter/stiffened_plate_piston_theory_flutter_optimization.h
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/stiffened_plate_optimization_thermal_stress/stiffened_plate_thermal_stress_optimization.h
+++ b/examples/structural/stiffened_plate_optimization_thermal_stress/stiffened_plate_thermal_stress_optimization.h
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/stiffened_plate_optimization_thermally_stressed_piston_theory_flutter/stiffened_plate_thermally_stressed_piston_theory_flutter_optimization.h
+++ b/examples/structural/stiffened_plate_optimization_thermally_stressed_piston_theory_flutter/stiffened_plate_thermally_stressed_piston_theory_flutter_optimization.h
@@ -1,6 +1,6 @@
 ///*
 // * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
-// * Copyright (C) 2013-2018  Manav Bhatia
+// * Copyright (C) 2013-2019  Manav Bhatia
 // *
 // * This library is free software; you can redistribute it and/or
 // * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/thermoelasticity_topology_optim_2D/thermoelasticity_topology_optim_2D.cpp
+++ b/examples/structural/thermoelasticity_topology_optim_2D/thermoelasticity_topology_optim_2D.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/thermoelasticity_topology_optim_2D/thermoelasticity_topology_optim_2D.h
+++ b/examples/structural/thermoelasticity_topology_optim_2D/thermoelasticity_topology_optim_2D.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -42,7 +42,7 @@ namespace MAST  {
             virtual ~ThermoelasticityTopologyOptimizationLevelSet2D();
 
             /*!
-             *   \par grads(k): Derivative of f_i(x) with respect
+             *   \p grads(k): Derivative of f_i(x) with respect
              *   to x_j, where k = (j-1)*M + i.
              */
             virtual void evaluate(const std::vector<Real>& dvars,

--- a/examples/structural/topology_optim_2D/topology_optim_2D.cpp
+++ b/examples/structural/topology_optim_2D/topology_optim_2D.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/topology_optim_2D/topology_optim_2D.h
+++ b/examples/structural/topology_optim_2D/topology_optim_2D.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -122,7 +122,7 @@ namespace MAST  {
                                    std::vector<Real>& xmax);
             
             /*!
-             *   \par grads(k): Derivative of f_i(x) with respect
+             *   \p grads(k): Derivative of f_i(x) with respect
              *   to x_j, where k = (j-1)*M + i.
              */
             virtual void evaluate(const std::vector<Real>& dvars,

--- a/examples/structural/topology_optim_L_bracket/topology_optimization_L_bracket.cpp
+++ b/examples/structural/topology_optim_L_bracket/topology_optimization_L_bracket.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/topology_optim_L_bracket/topology_optimization_L_bracket.h
+++ b/examples/structural/topology_optim_L_bracket/topology_optimization_L_bracket.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/topology_optim_plate/topology_optim_plate.cpp
+++ b/examples/structural/topology_optim_plate/topology_optim_plate.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/structural/topology_optim_plate/topology_optim_plate.h
+++ b/examples/structural/topology_optim_plate/topology_optim_plate.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/thermal/base/thermal_example_1d.cpp
+++ b/examples/thermal/base/thermal_example_1d.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/thermal/base/thermal_example_1d.h
+++ b/examples/thermal/base/thermal_example_1d.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/thermal/base/thermal_example_2d.cpp
+++ b/examples/thermal/base/thermal_example_2d.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/thermal/base/thermal_example_2d.h
+++ b/examples/thermal/base/thermal_example_2d.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/thermal/base/thermal_example_base.cpp
+++ b/examples/thermal/base/thermal_example_base.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/examples/thermal/base/thermal_example_base.h
+++ b/examples/thermal/base/thermal_example_base.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/aeroelasticity/flutter_root_base.cpp
+++ b/src/aeroelasticity/flutter_root_base.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/aeroelasticity/flutter_root_base.h
+++ b/src/aeroelasticity/flutter_root_base.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/aeroelasticity/flutter_root_crossover_base.cpp
+++ b/src/aeroelasticity/flutter_root_crossover_base.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/aeroelasticity/flutter_root_crossover_base.h
+++ b/src/aeroelasticity/flutter_root_crossover_base.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/aeroelasticity/flutter_solution_base.cpp
+++ b/src/aeroelasticity/flutter_solution_base.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/aeroelasticity/flutter_solution_base.h
+++ b/src/aeroelasticity/flutter_solution_base.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/aeroelasticity/flutter_solver_base.cpp
+++ b/src/aeroelasticity/flutter_solver_base.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/aeroelasticity/flutter_solver_base.h
+++ b/src/aeroelasticity/flutter_solver_base.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -131,7 +131,7 @@ namespace MAST {
         
         
         /*!
-         *   Prints the sorted roots to the \par output
+         *   Prints the sorted roots to the \p output
          */
         virtual void print_sorted_roots() = 0;
         

--- a/src/aeroelasticity/frequency_function.cpp
+++ b/src/aeroelasticity/frequency_function.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/aeroelasticity/frequency_function.h
+++ b/src/aeroelasticity/frequency_function.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/aeroelasticity/pk_flutter_root.cpp
+++ b/src/aeroelasticity/pk_flutter_root.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/aeroelasticity/pk_flutter_root.h
+++ b/src/aeroelasticity/pk_flutter_root.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -46,7 +46,7 @@ namespace MAST {
                           const ComplexVectorX& evec_left);
         
 //        /*!
-//         *    @returns true if the \par r is the conjugate of \par this
+//         *    @returns true if the \p r is the conjugate of \p this
 //         */
 //        bool is_similar(MAST::FlutterRootBase& r) const;
         

--- a/src/aeroelasticity/pk_flutter_root_crossover.cpp
+++ b/src/aeroelasticity/pk_flutter_root_crossover.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/aeroelasticity/pk_flutter_root_crossover.h
+++ b/src/aeroelasticity/pk_flutter_root_crossover.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/aeroelasticity/pk_flutter_solution.cpp
+++ b/src/aeroelasticity/pk_flutter_solution.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/aeroelasticity/pk_flutter_solution.h
+++ b/src/aeroelasticity/pk_flutter_solution.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/aeroelasticity/pk_flutter_solver.cpp
+++ b/src/aeroelasticity/pk_flutter_solver.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/aeroelasticity/pk_flutter_solver.h
+++ b/src/aeroelasticity/pk_flutter_solver.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -78,7 +78,7 @@ namespace MAST {
         
         
         /*!
-         *   returns the \par n th root in terms of ascending velocity that is
+         *   returns the \p n th root in terms of ascending velocity that is
          *   found by the solver
          */
         const MAST::FlutterRootBase& get_root(const unsigned int n) const;
@@ -108,7 +108,7 @@ namespace MAST {
 
         
         /*!
-         *   Prints the sorted roots to the \par output
+         *   Prints the sorted roots to the \p output
          */
         virtual void print_sorted_roots();
         
@@ -129,7 +129,7 @@ namespace MAST {
         
         /*!
          *   Calculate the sensitivity of the flutter root with respect to the
-         *   parameter \par f
+         *   parameter \p f
          */
         virtual void calculate_sensitivity(MAST::FlutterRootBase& root,
                                            const MAST::FunctionBase& f);
@@ -164,7 +164,7 @@ namespace MAST {
          *   performs an eigensolution at the specified reduced frequency, and
          *   sort the roots based on the provided solution pointer. If the
          *   pointer is nullptr, then no sorting is performed
-         *   solve the eigenproblem  \f\[ L x = lambda R x \f\]
+         *   solve the eigenproblem  \f[ L x = \lambda R x \f]
          */
         virtual std::unique_ptr<MAST::FlutterSolutionBase>
         _analyze(const Real k_red,
@@ -186,7 +186,7 @@ namespace MAST {
         
         /*!
          *    Assembles the reduced order system structural and aerodynmaic
-         *    matrices for specified flight velocity \par U_inf.
+         *    matrices for specified flight velocity \p U_inf.
          */
         void
         _initialize_matrix_sensitivity_for_param(const MAST::FunctionBase& f,

--- a/src/aeroelasticity/time_domain_flutter_root.cpp
+++ b/src/aeroelasticity/time_domain_flutter_root.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/aeroelasticity/time_domain_flutter_root.h
+++ b/src/aeroelasticity/time_domain_flutter_root.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/aeroelasticity/time_domain_flutter_root_crossover.cpp
+++ b/src/aeroelasticity/time_domain_flutter_root_crossover.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/aeroelasticity/time_domain_flutter_root_crossover.h
+++ b/src/aeroelasticity/time_domain_flutter_root_crossover.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/aeroelasticity/time_domain_flutter_solution.cpp
+++ b/src/aeroelasticity/time_domain_flutter_solution.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/aeroelasticity/time_domain_flutter_solution.h
+++ b/src/aeroelasticity/time_domain_flutter_solution.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -56,7 +56,7 @@ namespace MAST {
         
         /*!
          *   number of unstable roots in this solution. Only roots with damping
-         *   greater than \par tol will be considered unstable.
+         *   greater than \p tol will be considered unstable.
          */
         unsigned int n_unstable_roots_in_upper_complex_half (Real tol) const;
         

--- a/src/aeroelasticity/time_domain_flutter_solver.cpp
+++ b/src/aeroelasticity/time_domain_flutter_solver.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/aeroelasticity/time_domain_flutter_solver.h
+++ b/src/aeroelasticity/time_domain_flutter_solver.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -87,7 +87,7 @@ namespace MAST {
         
         
         /*!
-         *   returns the \par n th root in terms of ascending velocity that is
+         *   returns the \p n th root in terms of ascending velocity that is
          *   found by the solver
          */
         const MAST::FlutterRootBase& get_root(const unsigned int n) const;
@@ -130,13 +130,13 @@ namespace MAST {
         
         /*!
          *   Calculate the sensitivity of the flutter root with respect to the
-         *   \par f parameter. If the base solution has a sensitivity
+         *   \p f parameter. If the base solution has a sensitivity
          *   with respect to the parameter, then that should be provided 
-         *   through \par dXdp. The sensitivity solution also requires
+         *   through \p dXdp. The sensitivity solution also requires
          *   sensitivity of the eigenvalue wrt velocity, which is 
          *   defined as a parameter. Hence, the sensitivity of the 
          *   static solution is also required wrt the velocity parameter. 
-         *   If \par dXdV is \par nullptr, then zero value is assumed. 
+         *   If \p dXdV is \p nullptr, then zero value is assumed. 
          */
         virtual void
         calculate_sensitivity(MAST::FlutterRootBase& root,
@@ -146,7 +146,7 @@ namespace MAST {
         
         
         /*!
-         *   Prints the sorted roots to the \par output
+         *   Prints the sorted roots to the \p output
          */
         virtual void print_sorted_roots();
         
@@ -193,7 +193,7 @@ namespace MAST {
         
         /*!
          *    Assembles the reduced order system structural and aerodynmaic 
-         *    matrices for specified flight velocity \par U_inf.
+         *    matrices for specified flight velocity \p U_inf.
          */
         void _initialize_matrices(Real U_inf,
                                   RealMatrixX& A,
@@ -202,7 +202,7 @@ namespace MAST {
         
         /*!
          *    Assembles the reduced order system structural and aerodynmaic
-         *    matrices for specified flight velocity \par U_inf.
+         *    matrices for specified flight velocity \p U_inf.
          */
         void
         _initialize_matrix_sensitivity_for_param(const MAST::FunctionBase& f,

--- a/src/aeroelasticity/ug_flutter_root.cpp
+++ b/src/aeroelasticity/ug_flutter_root.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/aeroelasticity/ug_flutter_root.h
+++ b/src/aeroelasticity/ug_flutter_root.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/aeroelasticity/ug_flutter_root_crossover.cpp
+++ b/src/aeroelasticity/ug_flutter_root_crossover.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/aeroelasticity/ug_flutter_root_crossover.h
+++ b/src/aeroelasticity/ug_flutter_root_crossover.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/aeroelasticity/ug_flutter_solution.cpp
+++ b/src/aeroelasticity/ug_flutter_solution.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/aeroelasticity/ug_flutter_solution.h
+++ b/src/aeroelasticity/ug_flutter_solution.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/aeroelasticity/ug_flutter_solver.cpp
+++ b/src/aeroelasticity/ug_flutter_solver.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/aeroelasticity/ug_flutter_solver.h
+++ b/src/aeroelasticity/ug_flutter_solver.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -86,7 +86,7 @@ namespace MAST {
         
         
         /*!
-         *   returns the \par n th root in terms of ascending velocity that is
+         *   returns the \p n th root in terms of ascending velocity that is
          *   found by the solver
          */
         const MAST::FlutterRootBase& get_root(const unsigned int n) const;
@@ -117,13 +117,13 @@ namespace MAST {
         
         /*!
          *   Calculate the sensitivity of the flutter root with respect to the
-         *   \par f parameter. If the base solution has a sensitivity
+         *   \p f parameter. If the base solution has a sensitivity
          *   with respect to the parameter, then that should be provided
-         *   through \par dXdp. The sensitivity solution also requires
+         *   through \p dXdp. The sensitivity solution also requires
          *   sensitivity of the eigenvalue wrt velocity, which is
          *   defined as a parameter. Hence, the sensitivity of the
          *   static solution is also required wrt the velocity parameter.
-         *   If \par dXdV is \par nullptr, then zero value is assumed.
+         *   If \p dXdV is \p nullptr, then zero value is assumed.
          */
         virtual void
         calculate_sensitivity(MAST::FlutterRootBase& root,
@@ -133,7 +133,7 @@ namespace MAST {
         
         
         /*!
-         *   Prints the sorted roots to the \par output
+         *   Prints the sorted roots to the \p output
          */
         virtual void print_sorted_roots();
         
@@ -180,7 +180,7 @@ namespace MAST {
         
         /*!
          *    Assembles the reduced order system structural and aerodynmaic
-         *    matrices for specified reduced freq \par kr.
+         *    matrices for specified reduced freq \p kr.
          */
         void _initialize_matrices(Real kr,
                                   ComplexMatrixX& A,
@@ -189,7 +189,7 @@ namespace MAST {
         
         /*!
          *    Assembles the reduced order system structural and aerodynmaic
-         *    matrices for specified flight velocity \par U_inf.
+         *    matrices for specified flight velocity \p U_inf.
          */
         void
         _initialize_matrix_sensitivity_for_param(const MAST::FunctionBase& f,

--- a/src/base/assembly_base.cpp
+++ b/src/base/assembly_base.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/base/assembly_base.h
+++ b/src/base/assembly_base.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -186,7 +186,7 @@ namespace MAST {
          * to assemble the RHS of the sensitivity equations (which is -1 times
          * sensitivity of system residual) prior to a solve and must
          * be provided by the user in a derived class. The method provides dR/dp
-         * for \par f parameter.
+         * for \p f parameter.
          *
          * If the routine is not able to provide sensitivity for this parameter,
          * then it should return false, and the system will attempt to use
@@ -217,12 +217,12 @@ namespace MAST {
         
         /*!
          *   evaluates the sensitivity of the outputs in the attached
-         *   discipline with respect to the parametrs in \par params.
-         *   The base solution should be provided in \par X. If total sensitivity
-         *   is desired, then \par dXdp should contain the sensitivity of
-         *   solution wrt the parameter \par p. If this \par dXdp is zero,
+         *   discipline with respect to the parametrs in \p params.
+         *   The base solution should be provided in \p X. If total sensitivity
+         *   is desired, then \p dXdp should contain the sensitivity of
+         *   solution wrt the parameter \p p. If this \p dXdp is zero,
          *   the calculated sensitivity will be the partial derivarive of
-         *   \par output wrt \par p.
+         *   \p output wrt \p p.
          */
         virtual void
         calculate_output_direct_sensitivity(const libMesh::NumericVector<Real>& X,
@@ -232,9 +232,9 @@ namespace MAST {
 
         
         /*!
-         *   Evaluates the total sensitivity of \par output wrt \par p using
-         *   the adjoint solution provided in \par dq_dX for a linearization
-         *   about solution \par X.
+         *   Evaluates the total sensitivity of \p output wrt \p p using
+         *   the adjoint solution provided in \p dq_dX for a linearization
+         *   about solution \p X.
          */
         virtual Real
         calculate_output_adjoint_sensitivity(const libMesh::NumericVector<Real>& X,

--- a/src/base/assembly_elem_operation.cpp
+++ b/src/base/assembly_elem_operation.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/base/assembly_elem_operation.h
+++ b/src/base/assembly_elem_operation.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/base/boundary_condition_base.h
+++ b/src/base/boundary_condition_base.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/base/complex_assembly_base.cpp
+++ b/src/base/complex_assembly_base.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/base/complex_assembly_base.h
+++ b/src/base/complex_assembly_base.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -63,7 +63,7 @@ namespace MAST {
         /*!
          *   if the problem is defined about a non-zero base solution,
          *   then this method provides the object with the base solution.
-         *   The flag \par if_sens tells the method if \par sol
+         *   The flag \p if_sens tells the method if \p sol
          *   is the sensitivity of the base solution for the current parameter
          *   being solved for
          */
@@ -73,7 +73,7 @@ namespace MAST {
         
         /*!
          *   Clears pointer to the solution vector
-         *   The flag \par if_sens tells the method to clear pointer of the 
+         *   The flag \p if_sens tells the method to clear pointer of the 
          *   solution sensitivity
          */
         void clear_base_solution(bool if_sens = false);
@@ -88,7 +88,7 @@ namespace MAST {
         
         /*!
          *   @returns a const reference to the base solution (or
-         *   its sensitivity when \par if_sens is true) about which
+         *   its sensitivity when \p if_sens is true) about which
          *   the Eigen problem was linearized.
          */
         const libMesh::NumericVector<Real>& base_sol(bool if_sens = false) const;
@@ -104,10 +104,10 @@ namespace MAST {
 
         /*!
          *   Assembles the residual and Jacobian of the N complex system of equations
-         *   split into 2N real system of equations. The solution vector \par X
+         *   split into 2N real system of equations. The solution vector \p X
          *   is the current complex solution with the real and imaginary parts 
          *   of each element stored as adjacent entries. Likewise, the Jaacobian
-         *   matrix has a 2x2 block storage. If \par p is provided, then \par R
+         *   matrix has a 2x2 block storage. If \p p is provided, then \p R
          *   will return the sensitivity of the residual vector.
          */
         void
@@ -121,7 +121,7 @@ namespace MAST {
          * to assemble the RHS of the sensitivity equations (which is -1 times
          * sensitivity of system residual) prior to a solve and must
          * be provided by the user in a derived class. The method provides dR/dp
-         * for \par f parameter.
+         * for \p f parameter.
          *
          * If the routine is not able to provide sensitivity for this parameter,
          * then it should return false, and the system will attempt to use

--- a/src/base/complex_assembly_elem_operations.cpp
+++ b/src/base/complex_assembly_elem_operations.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/base/complex_assembly_elem_operations.h
+++ b/src/base/complex_assembly_elem_operations.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -46,9 +46,9 @@ namespace MAST {
 
 
         /*!
-         *   performs the element calculations over \par elem, and returns
-         *   the element vector and matrix quantities in \par mat and
-         *   \par vec, respectively. \par if_jac tells the method to also
+         *   performs the element calculations over \p elem, and returns
+         *   the element vector and matrix quantities in \p mat and
+         *   \p vec, respectively. \p if_jac tells the method to also
          *   assemble the Jacobian, in addition to the residual vector.
          */
         virtual void elem_calculations(bool if_jac,
@@ -56,8 +56,8 @@ namespace MAST {
                                        ComplexMatrixX& mat) = 0;
         
         /*!
-         *   performs the element sensitivity calculations over \par elem,
-         *   and returns the element residual sensitivity in \par vec .
+         *   performs the element sensitivity calculations over \p elem,
+         *   and returns the element residual sensitivity in \p vec .
          */
         virtual void elem_sensitivity_calculations(const MAST::FunctionBase& f,
                                                    ComplexVectorX& vec) = 0;

--- a/src/base/complex_mesh_field_function.cpp
+++ b/src/base/complex_mesh_field_function.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/base/complex_mesh_field_function.h
+++ b/src/base/complex_mesh_field_function.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/base/constant_field_function.cpp
+++ b/src/base/constant_field_function.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/base/constant_field_function.h
+++ b/src/base/constant_field_function.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -43,14 +43,14 @@ namespace MAST {
         
         /*!
          *    calculates the value of the function at the specified point,
-         *    \par p, and time, \par t, and returns it in \p v.
+         *    \p p, and time, \p t, and returns it in \p v.
          */
         virtual void operator() (Real& v) const;
         
         
         /*!
          *    calculates the value of the function at the specified point,
-         *    \par p, and time, \par t, and returns it in \p v.
+         *    \p p, and time, \p t, and returns it in \p v.
          */
         virtual void derivative (const MAST::FunctionBase& f,
                                  Real& v) const;
@@ -59,7 +59,7 @@ namespace MAST {
         
         /*!
          *    calculates the value of the function at the specified point,
-         *    \par p, and time, \par t, and returns it in \p v.
+         *    \p p, and time, \p t, and returns it in \p v.
          */
         virtual void operator() (const libMesh::Point& p,
                                  const Real t,
@@ -68,7 +68,7 @@ namespace MAST {
         
         /*!
          *    calculates the value of the function at the specified point,
-         *    \par p, and time, \par t, and returns it in \p v.
+         *    \p p, and time, \p t, and returns it in \p v.
          */
         virtual void derivative (const MAST::FunctionBase& f,
                                  const libMesh::Point& p,

--- a/src/base/eigenproblem_assembly.cpp
+++ b/src/base/eigenproblem_assembly.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/base/eigenproblem_assembly.h
+++ b/src/base/eigenproblem_assembly.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -78,7 +78,7 @@ namespace MAST {
         /**
          * Assembly function.  This function will be called
          * to assemble the sensitivity of eigenproblem matrices.
-         * The method provides dA/dp and dB/dp for \par f parameter.
+         * The method provides dA/dp and dB/dp for \p f parameter.
          *
          * If the routine is not able to provide sensitivity for this parameter,
          * then it should return false, and the system will attempt to use
@@ -93,7 +93,7 @@ namespace MAST {
         /*!
          *   if the eigenproblem is defined about a non-zero base solution,
          *   then this method provides the object with the base solution.
-         *   The flag \par if_sens tells the method if \par sol
+         *   The flag \p if_sens tells the method if \p sol
          *   is the sensitivity of the base solution for the current parameter
          *   being solved for
          */
@@ -103,7 +103,7 @@ namespace MAST {
         
         /*!
          *   Clears the pointer to the solution.
-         *   The flag \par if_sens tells the method to clear the pointer 
+         *   The flag \p if_sens tells the method to clear the pointer 
          *   the solution sensitivity vector.
          */
         void clear_base_solution(bool if_sens = false);
@@ -118,7 +118,7 @@ namespace MAST {
         
         /*!
          *   @returns a const reference to the base solution (or
-         *   its sensitivity when \par if_sens is true) about which
+         *   its sensitivity when \p if_sens is true) about which
          *   the Eigen problem was linearized.
          */
         const libMesh::NumericVector<Real>&
@@ -127,7 +127,7 @@ namespace MAST {
 
         /*!
          *   @returns a non-const reference to the base solution (or
-         *   its sensitivity when \par if_sens is true) about which
+         *   its sensitivity when \p if_sens is true) about which
          *   the Eigen problem was linearized.
          */
         libMesh::NumericVector<Real>& base_sol(bool if_sens = false);

--- a/src/base/eigenproblem_assembly_elem_operations.cpp
+++ b/src/base/eigenproblem_assembly_elem_operations.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/base/eigenproblem_assembly_elem_operations.h
+++ b/src/base/eigenproblem_assembly_elem_operations.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -40,7 +40,7 @@ namespace MAST {
         
         
         /*!
-         *   performs the element calculations over \par elem, and returns
+         *   performs the element calculations over \p elem, and returns
          *   the element matrices for the eigenproblem
          *   \f$ A x = \lambda B x \f$.
          */
@@ -49,7 +49,7 @@ namespace MAST {
                           RealMatrixX& mat_B) = 0;
         
         /*!
-         *   performs the element sensitivity calculations over \par elem,
+         *   performs the element sensitivity calculations over \p elem,
          *   and returns the element matrices for the eigenproblem
          *   \f$ A x = \lambda B x \f$.
          */
@@ -60,7 +60,7 @@ namespace MAST {
                                       RealMatrixX& mat_B) = 0;
 
         /*!
-         *   performs the element topology sensitivity calculations over \par elem.
+         *   performs the element topology sensitivity calculations over \p elem.
          */
         virtual void
         elem_topology_sensitivity_calculations(const MAST::FunctionBase& f,

--- a/src/base/elem_base.cpp
+++ b/src/base/elem_base.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/base/elem_base.h
+++ b/src/base/elem_base.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/base/field_function_base.h
+++ b/src/base/field_function_base.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -84,7 +84,7 @@ namespace MAST {
         
         /*!
          *    calculates the value of the function at the specified point,
-         *    \par p, and time, \par t, and returns it in \p v.
+         *    \p p, and time, \p t, and returns it in \p v.
          */
         virtual void operator() (const libMesh::Point& p,
                                  const Real t,
@@ -96,7 +96,7 @@ namespace MAST {
         
         /*!
          *    calculates the value of a perturbation in function at the 
-         *    specified point, \par p, and time, \par t, and returns it 
+         *    specified point, \p p, and time, \p t, and returns it
          *    in \p v.
          */
         virtual void perturbation (const libMesh::Point& p,
@@ -109,8 +109,8 @@ namespace MAST {
         
         /*!
          *    calculates the value of the derivative of function with respect to
-         *    the function \p f at the specified point, \par p, and time, 
-         *    \par t, and returns it in \p v.
+         *    the function \p f at the specified point, \p p, and time,
+         *    \p t, and returns it in \p v.
          */
         virtual void derivative (const MAST::FunctionBase& f,
                                  const libMesh::Point& p,

--- a/src/base/function_base.cpp
+++ b/src/base/function_base.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/base/function_base.h
+++ b/src/base/function_base.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/base/function_set_base.cpp
+++ b/src/base/function_set_base.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/base/function_set_base.h
+++ b/src/base/function_set_base.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/base/mast_config.h.in
+++ b/src/base/mast_config.h.in
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/base/mast_data_types.h
+++ b/src/base/mast_data_types.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/base/mesh_field_function.cpp
+++ b/src/base/mesh_field_function.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/base/mesh_field_function.h
+++ b/src/base/mesh_field_function.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -59,7 +59,7 @@ namespace MAST {
        
         /*!
          *    calculates the value of the function at the specified point,
-         *    \par p, and time, \par t, and returns it in \p v.
+         *    \p p, and time, \p t, and returns it in \p v.
          */
         virtual void operator() (const libMesh::Point& p,
                                  const Real t,
@@ -67,7 +67,7 @@ namespace MAST {
         
         /*!
          *    calculates the gradient of value of the function at the specified
-         *    point, \par p, and time, \par t, and returns it in \p g.
+         *    point, \p p, and time, \p t, and returns it in \p g.
          *    g(i,j) = dv(i)/dx(j)
          */
         virtual void gradient(const libMesh::Point& p,
@@ -76,7 +76,7 @@ namespace MAST {
 
         /*!
          *    calculates the value of perturbation in the function at
-         *    the specified point, \par p, and time, \par t, and returns it
+         *    the specified point, \p p, and time, \p t, and returns it
          *    in \p v.
          */
         virtual void perturbation (const libMesh::Point& p,
@@ -86,7 +86,7 @@ namespace MAST {
         
         /*!
          *    calculates the value of the function at the specified point,
-         *    \par p, and time, \par t, and returns it in \p v.
+         *    \p p, and time, \p t, and returns it in \p v.
          */
         virtual void derivative (const MAST::FunctionBase& f,
                                  const libMesh::Point& p,
@@ -96,7 +96,7 @@ namespace MAST {
         
         /*!
          *   initializes the data structures to perform the interpolation 
-         *   function of \par sol. If \p dsol is provided, then it is used
+         *   function of \p sol. If \p dsol is provided, then it is used
          *   as the perturbation of \p sol.
          */
         void init(const libMesh::NumericVector<Real>& sol,

--- a/src/base/nonlinear_implicit_assembly.cpp
+++ b/src/base/nonlinear_implicit_assembly.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/base/nonlinear_implicit_assembly.h
+++ b/src/base/nonlinear_implicit_assembly.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -133,7 +133,7 @@ namespace MAST {
          * to assemble the RHS of the sensitivity equations (which is -1 times
          * sensitivity of system residual) prior to a solve and must
          * be provided by the user in a derived class. The method provides dR/dp
-         * for \par f parameter.
+         * for \p f parameter.
          *
          * If the routine is not able to provide sensitivity for this parameter,
          * then it should return false, and the system will attempt to use

--- a/src/base/nonlinear_implicit_assembly_elem_operations.cpp
+++ b/src/base/nonlinear_implicit_assembly_elem_operations.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/base/nonlinear_implicit_assembly_elem_operations.h
+++ b/src/base/nonlinear_implicit_assembly_elem_operations.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -42,9 +42,9 @@ namespace MAST {
         
         
         /*!
-         *   performs the element calculations over \par elem, and returns
-         *   the element vector and matrix quantities in \par mat and
-         *   \par vec, respectively. \par if_jac tells the method to also
+         *   performs the element calculations over \p elem, and returns
+         *   the element vector and matrix quantities in \p mat and
+         *   \p vec, respectively. \p if_jac tells the method to also
          *   assemble the Jacobian, in addition to the residual vector.
          */
         virtual void elem_calculations(bool if_jac,
@@ -53,9 +53,9 @@ namespace MAST {
         
         
         /*!
-         *   performs the element calculations over \par elem, and returns
-         *   the element vector quantity in \par vec. The vector quantity only
-         *   include the \f$ [J] \{dX\} f$ components, so the inherited classes
+         *   performs the element calculations over \p elem, and returns
+         *   the element vector quantity in \p vec. The vector quantity only
+         *   include the \f$ [J] \{dX\} \f$ components, so the inherited classes
          *   must ensure that no component of constant forces (traction/body
          *   forces/etc.) are added to this vector.
          */
@@ -64,24 +64,24 @@ namespace MAST {
         
         
         /*!
-         *   performs the element sensitivity calculations over \par elem,
-         *   and returns the element residual sensitivity in \par vec .
+         *   performs the element sensitivity calculations over \p elem,
+         *   and returns the element residual sensitivity in \p vec .
          */
         virtual void
         elem_sensitivity_calculations(const MAST::FunctionBase& f,
                                       RealVectorX& vec) = 0;
 
         /*!
-         *   performs the element shape sensitivity calculations over \par elem,
-         *   and returns the element residual sensitivity in \par vec .
+         *   performs the element shape sensitivity calculations over \p elem,
+         *   and returns the element residual sensitivity in \p vec .
          */
         virtual void
         elem_shape_sensitivity_calculations(const MAST::FunctionBase& f,
                                             RealVectorX& vec) = 0;
 
         /*!
-         *   performs the element topology sensitivity calculations over \par elem,
-         *   and returns the element residual sensitivity in \par vec .
+         *   performs the element topology sensitivity calculations over \p elem,
+         *   and returns the element residual sensitivity in \p vec .
          */
         virtual void
         elem_topology_sensitivity_calculations(const MAST::FunctionBase& f,
@@ -90,8 +90,8 @@ namespace MAST {
                                                RealVectorX& vec) = 0;
 
         /*!
-         *   calculates \f$ d ([J] \{\Delta X\})/ dX  \f$ over \par elem,
-         *   and returns the matrix in \par vec .
+         *   calculates \f$ d ([J] \{\Delta X\})/ dX  \f$ over \p elem,
+         *   and returns the matrix in \p vec .
          */
         virtual void
         elem_second_derivative_dot_solution_assembly(RealMatrixX& mat) = 0;

--- a/src/base/nonlinear_system.cpp
+++ b/src/base/nonlinear_system.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/base/nonlinear_system.h
+++ b/src/base/nonlinear_system.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -120,7 +120,7 @@ namespace MAST {
         /*!
          *   Solves the sensitivity problem for the provided parameter.
          *   The Jacobian will be assembled before adjoint solve if
-         *   \par if_assemble_jacobian is \p true.
+         *   \p if_assemble_jacobian is \p true.
          */
         virtual void sensitivity_solve(MAST::AssemblyElemOperations&   elem_ops,
                                        MAST::AssemblyBase&             assembly,
@@ -131,7 +131,7 @@ namespace MAST {
         /*!
          *   solves the adjoint problem for the provided output function.
          *   The Jacobian will be assembled before adjoint solve if
-         *   \par if_assemble_jacobian is \p true.
+         *   \p if_assemble_jacobian is \p true.
          */
         virtual void adjoint_solve(MAST::AssemblyElemOperations&       elem_ops,
                                    MAST::OutputAssemblyElemOperations& output,

--- a/src/base/output_assembly_elem_operations.cpp
+++ b/src/base/output_assembly_elem_operations.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/base/output_assembly_elem_operations.h
+++ b/src/base/output_assembly_elem_operations.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -117,7 +117,7 @@ namespace MAST {
 
         /*!
          *   returns the output quantity derivative with respect to
-         *   state vector in \par dq_dX.
+         *   state vector in \p dq_dX.
          *   This method calculates the quantity
          *    \f[ \frac{\partial q(X, p)}{\partial X} \f] for this
          *    output function. This is returned for the element for which
@@ -196,7 +196,7 @@ namespace MAST {
 
         /*!
          *    @returns the set of elements for which data will be stored. This
-         *    is set using the \par set_participating_elements() method.
+         *    is set using the \p set_participating_elements() method.
          */
         const std::set<const libMesh::Elem*>&
         get_participating_elements() const;
@@ -204,7 +204,7 @@ namespace MAST {
 
         /*!
          *    @returns the set of subdomain ids for which data will be stored.
-         *    This is set using the \par set_participating_subdomains() method.
+         *    This is set using the \p set_participating_subdomains() method.
          */
         const std::set<libMesh::subdomain_id_type>&
         get_participating_subdomains();
@@ -212,7 +212,7 @@ namespace MAST {
         
         /*!
          *    @returns the set of boundary ids for which data will be stored.
-         *    This is set using the \par set_participating_boundaries() method.
+         *    This is set using the \p set_participating_boundaries() method.
          */
         const std::set<libMesh::boundary_id_type>&
         get_participating_boundaries();

--- a/src/base/parameter.h
+++ b/src/base/parameter.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -71,7 +71,7 @@ namespace MAST {
         
         
         /*!
-         *    @eturns the pointer to value of this function.
+         *    @returns the pointer to value of this function.
          */
         Real* ptr()
         {   return _val; }

--- a/src/base/physics_discipline_base.cpp
+++ b/src/base/physics_discipline_base.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/base/physics_discipline_base.h
+++ b/src/base/physics_discipline_base.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -198,7 +198,7 @@ namespace MAST {
         const MAST::ElementPropertyCardBase& get_property_card(const libMesh::Elem& elem) const;
         
         /*!
-         *    get property card for the specified subdomain id \par i
+         *    get property card for the specified subdomain id \p i
          */
         const MAST::ElementPropertyCardBase& get_property_card(const unsigned int sid) const;
         

--- a/src/base/system_initialization.cpp
+++ b/src/base/system_initialization.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/base/system_initialization.h
+++ b/src/base/system_initialization.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -41,8 +41,8 @@ namespace MAST {
     class SystemInitialization {
     public:
         /*!
-         *   initialize the variables in the provided system \par sys
-         *   of \par order and \par family. Uses \par prefix for
+         *   initialize the variables in the provided system \p sys
+         *   of \p order and \p family. Uses \p prefix for
          *   all variables name.
          */
         SystemInitialization (MAST::NonlinearSystem& sys,
@@ -60,7 +60,7 @@ namespace MAST {
         unsigned int n_vars() const;
         
         /*!
-         *   @returns the FEType object for variable \par i,
+         *   @returns the FEType object for variable \p i,
          *   that defines the finite element family and order.
          */
         const libMesh::FEType& fetype(unsigned int i) const;
@@ -100,13 +100,13 @@ namespace MAST {
 
         /*!
          *    initializes the FE solution vector to the constant
-         *    solution provided in \par sol.
+         *    solution provided in \p sol.
          */
         void initialize_solution(const RealVectorX& sol);
 
         /*!
          *    initializes the FE solution vector to the function
-         *    solution provided in \par sol.
+         *    solution provided in \p sol.
          */
         void initialize_solution(const MAST::FieldFunction<RealVectorX>& sol);
 

--- a/src/base/transient_assembly.cpp
+++ b/src/base/transient_assembly.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/base/transient_assembly.h
+++ b/src/base/transient_assembly.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -80,7 +80,7 @@ namespace MAST {
          * Assembly function.  This function will be called
          * to assemble the sensitivity of system residual prior to a solve and must
          * be provided by the user in a derived class. The method provides dR/dp_i
-         * for \par i ^th parameter in the vector \par parameters.
+         * for \p i ^th parameter in the vector \p parameters.
          *
          * If the routine is not able to provide sensitivity for this parameter,
          * then it should return false, and the system will attempt to use

--- a/src/base/transient_assembly_elem_operations.cpp
+++ b/src/base/transient_assembly_elem_operations.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/base/transient_assembly_elem_operations.h
+++ b/src/base/transient_assembly_elem_operations.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -36,7 +36,7 @@ namespace MAST {
         virtual ~TransientAssemblyElemOperations();
         
         /*!
-         *   performs the element calculations over \par elem, for a
+         *   performs the element calculations over \p elem, for a
          *   system of the form
          *   \f[ f_m(x,\dot{x}) + f_x(x) = 0 \f].
          *   \param f_x     = \f$ f(x) \f$
@@ -44,8 +44,7 @@ namespace MAST {
          *   \param f_m_jac_xdot = \f$ \frac{\partial (f_m(x)}{\partial \dot{x}} \f$
          *   \param f_m_jac = \f$ \frac{\partial (f_m(x)}{\partial x} \f$
          *   \param f_x_jac = \f$ \frac{\partial (f(x)}{\partial x} \f$
-         *   the element vector and matrix quantities in \par mat and
-         *   \par vec, respectively. \par if_jac tells the method to also
+         *   \p if_jac tells the method to also
          *   assemble the Jacobian, in addition to the residual vector.
          */
         virtual void elem_calculations(bool if_jac,
@@ -58,7 +57,7 @@ namespace MAST {
         
         
         /*!
-         *   performs the element calculations over \par elem, for a
+         *   performs the element calculations over \p elem, for a
          *   system of the form
          *   \f[ f_m(x,\ddot{x}, \dot{x}) + f_x(x, \dot{x}) = 0 \f].
          *   \param f_x     = \f$ f(x,\dot{x})  \f$
@@ -68,8 +67,7 @@ namespace MAST {
          *   \param f_m_jac = \f$ \frac{\partial (f_m(x)}{\partial x} \f$
          *   \param f_x_jac_xdot = \f$ \frac{\partial (f(x)}{\partial \dot{x}} \f$
          *   \param f_x_jac = \f$ \frac{\partial (f(x)}{\partial x} \f$
-         *   the element vector and matrix quantities in \par mat and
-         *   \par vec, respectively. \par if_jac tells the method to also
+         *   \p if_jac tells the method to also
          *   assemble the Jacobian, in addition to the residual vector.
          */
         virtual void elem_calculations(bool if_jac,
@@ -94,9 +92,9 @@ namespace MAST {
         
         
         /*!
-         *   performs the element sensitivity calculations over \par elem,
+         *   performs the element sensitivity calculations over \p elem,
          *   and returns the component of  element residual sensitivity in
-         *   \par f_m and \par f_x.
+         *   \p f_m and \p f_x.
          */
         virtual void elem_sensitivity_calculations(const MAST::FunctionBase& f,
                                                    RealVectorX& f_m,

--- a/src/boundary_condition/dirichlet_boundary_condition.cpp
+++ b/src/boundary_condition/dirichlet_boundary_condition.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/boundary_condition/dirichlet_boundary_condition.h
+++ b/src/boundary_condition/dirichlet_boundary_condition.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/boundary_condition/point_load_condition.cpp
+++ b/src/boundary_condition/point_load_condition.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/boundary_condition/point_load_condition.h
+++ b/src/boundary_condition/point_load_condition.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/coordinates/basis_matrix_coordinate.cpp
+++ b/src/coordinates/basis_matrix_coordinate.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/coordinates/basis_matrix_coordinate.h
+++ b/src/coordinates/basis_matrix_coordinate.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -44,7 +44,7 @@ namespace MAST {
         
         /*!
          *    calculates the value of the function at the specified point,
-         *    \par p, and time, \par t, and returns it in \p v.
+         *    \p p, and time, \p t, and returns it in \p v.
          */
         virtual void operator() (const libMesh::Point& p,
                                  const Real t,
@@ -53,7 +53,7 @@ namespace MAST {
         
         /*!
          *    calculates the value of the function at the specified point,
-         *    \par p, and time, \par t, and returns it in \p v.
+         *    \p p, and time, \p t, and returns it in \p v.
          */
         virtual void derivative (const MAST::FunctionBase& f,
                                  const libMesh::Point& p,

--- a/src/coordinates/coordinate_base.cpp
+++ b/src/coordinates/coordinate_base.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/coordinates/coordinate_base.h
+++ b/src/coordinates/coordinate_base.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -41,7 +41,7 @@ namespace MAST {
         CoordinateBase(const std::string& nm);
 
         /*!
-         *   prepares the matrix \mat that transforms stress and strain tensors
+         *   prepares the matrix \p mat that transforms stress and strain tensors
          *   represented in a 6x1 vector from the coordinate system in _orient
          *   to the global coordinate system. Note that the shear straints in
          *   the strain tensor vector should be represented in the tensor quantities,

--- a/src/coordinates/polar_coordinate.cpp
+++ b/src/coordinates/polar_coordinate.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/coordinates/polar_coordinate.h
+++ b/src/coordinates/polar_coordinate.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -44,7 +44,7 @@ namespace MAST {
         
         /*!
          *    calculates the value of the function at the specified point,
-         *    \par p, and time, \par t, and returns it in \p v.
+         *    \p p, and time, \p t, and returns it in \p v.
          */
         virtual void operator() (const libMesh::Point& p,
                                  const Real t,
@@ -53,7 +53,7 @@ namespace MAST {
         
         /*!
          *    calculates the value of the function at the specified point,
-         *    \par p, and time, \par t, and returns it in \p v.
+         *    \p p, and time, \p t, and returns it in \p v.
          */
         virtual void derivative (const MAST::FunctionBase& f,
                                  const libMesh::Point& p,

--- a/src/elasticity/bending_operator.cpp
+++ b/src/elasticity/bending_operator.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/bending_operator.h
+++ b/src/elasticity/bending_operator.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/bending_structural_element.cpp
+++ b/src/elasticity/bending_structural_element.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/bending_structural_element.h
+++ b/src/elasticity/bending_structural_element.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/bernoulli_bending_operator.h
+++ b/src/elasticity/bernoulli_bending_operator.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/complex_normal_rotation_mesh_function.cpp
+++ b/src/elasticity/complex_normal_rotation_mesh_function.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/complex_normal_rotation_mesh_function.h
+++ b/src/elasticity/complex_normal_rotation_mesh_function.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/dkt_bending_operator.h
+++ b/src/elasticity/dkt_bending_operator.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/fluid_structure_assembly_elem_operations.cpp
+++ b/src/elasticity/fluid_structure_assembly_elem_operations.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/fluid_structure_assembly_elem_operations.h
+++ b/src/elasticity/fluid_structure_assembly_elem_operations.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/fsi_generalized_aero_force_assembly.cpp
+++ b/src/elasticity/fsi_generalized_aero_force_assembly.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/fsi_generalized_aero_force_assembly.h
+++ b/src/elasticity/fsi_generalized_aero_force_assembly.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -60,9 +60,9 @@ namespace MAST {
          *    initializes for the given fluid and structural components. The
          *    structural and fluid communicator objects should provide valid 
          *    MPI communicators on ranks that store the respective 
-         *    disciplinary data structures. \par complex_solver and
-         *    \par pressure_function should be non-null pointers only on nodes
-         *    with a valid fluid communicator. \par motion_func should be
+         *    disciplinary data structures. \p complex_solver and
+         *    \p pressure_function should be non-null pointers only on nodes
+         *    with a valid fluid communicator. \p motion_func should be
          *   a non-null pointer only when structural_comm is a valid 
          *   communicator.
          */
@@ -84,7 +84,7 @@ namespace MAST {
         
         /*!
          *   calculates the reduced order matrix given the basis provided in
-         *   \par basis. \par X is the steady state solution about which
+         *   \p basis. \p X is the steady state solution about which
          *   the quantity is calculated.
          */
         virtual void

--- a/src/elasticity/level_set_stress_assembly.cpp
+++ b/src/elasticity/level_set_stress_assembly.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/level_set_stress_assembly.h
+++ b/src/elasticity/level_set_stress_assembly.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/mindlin_bending_operator.cpp
+++ b/src/elasticity/mindlin_bending_operator.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/mindlin_bending_operator.h
+++ b/src/elasticity/mindlin_bending_operator.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/normal_rotation_function_base.h
+++ b/src/elasticity/normal_rotation_function_base.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/normal_rotation_mesh_function.cpp
+++ b/src/elasticity/normal_rotation_mesh_function.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/normal_rotation_mesh_function.h
+++ b/src/elasticity/normal_rotation_mesh_function.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/piston_theory_boundary_condition.cpp
+++ b/src/elasticity/piston_theory_boundary_condition.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/piston_theory_boundary_condition.h
+++ b/src/elasticity/piston_theory_boundary_condition.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/solid_element_3d.cpp
+++ b/src/elasticity/solid_element_3d.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/solid_element_3d.h
+++ b/src/elasticity/solid_element_3d.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -63,7 +63,7 @@ namespace MAST {
                                        RealMatrixX& jac);
         
         /*!
-         *   calculates the term on side \par s:
+         *   calculates the term on side \p s:
          *   \f$ \int_\Gamma a(\delta u, u) v_n ~d\Gamma \f$.
          *
          */

--- a/src/elasticity/stress_assembly.cpp
+++ b/src/elasticity/stress_assembly.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/stress_assembly.h
+++ b/src/elasticity/stress_assembly.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/stress_output_base.cpp
+++ b/src/elasticity/stress_output_base.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/stress_output_base.h
+++ b/src/elasticity/stress_output_base.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -516,7 +516,7 @@ namespace MAST {
 
         /*!
          *   calculates and returns the sensitivity of von Mises p-norm
-         *   functional for the element \par e.
+         *   functional for the element \p e.
          */
         void
         von_Mises_p_norm_functional_sensitivity_for_elem
@@ -527,7 +527,7 @@ namespace MAST {
         
         /*!
          *   calculates and returns the boundary sensitivity of von Mises p-norm
-         *   functional for the element \par e.
+         *   functional for the element \p e.
          */
         void
         von_Mises_p_norm_functional_boundary_sensitivity_for_elem

--- a/src/elasticity/stress_temperature_adjoint.cpp
+++ b/src/elasticity/stress_temperature_adjoint.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/stress_temperature_adjoint.h
+++ b/src/elasticity/stress_temperature_adjoint.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/structural_assembly.cpp
+++ b/src/elasticity/structural_assembly.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/structural_assembly.h
+++ b/src/elasticity/structural_assembly.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/structural_buckling_eigenproblem_assembly.cpp
+++ b/src/elasticity/structural_buckling_eigenproblem_assembly.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/structural_buckling_eigenproblem_assembly.h
+++ b/src/elasticity/structural_buckling_eigenproblem_assembly.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/structural_buckling_eigenproblem_elem_operations.cpp
+++ b/src/elasticity/structural_buckling_eigenproblem_elem_operations.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/structural_buckling_eigenproblem_elem_operations.h
+++ b/src/elasticity/structural_buckling_eigenproblem_elem_operations.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -46,7 +46,7 @@ namespace MAST {
         init(const libMesh::Elem& elem);
         
         /*!
-         *   performs the element calculations over \par elem, and returns
+         *   performs the element calculations over \p elem, and returns
          *   the element matrices for the eigenproblem
          *   \f$ A x = \lambda B x \f$.
          */
@@ -55,7 +55,7 @@ namespace MAST {
                           RealMatrixX& mat_B);
         
         /*!
-         *   performs the element sensitivity calculations over \par elem,
+         *   performs the element sensitivity calculations over \p elem,
          *   and returns the element matrices for the eigenproblem
          *   \f$ A x = \lambda B x \f$.
          */

--- a/src/elasticity/structural_element_1d.cpp
+++ b/src/elasticity/structural_element_1d.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/structural_element_1d.h
+++ b/src/elasticity/structural_element_1d.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -80,7 +80,7 @@ namespace MAST {
                                                    RealMatrixX& jac);
         
         /*!
-         *   calculates the term on side \par s:
+         *   calculates the term on side \p s:
          *   \f$ \int_\Gamma a(\delta u, u) v_n ~d\Gamma \f$.
          *
          */
@@ -325,7 +325,7 @@ namespace MAST {
                                                        MAST::FEMOperatorMatrix& Bmat);
         
         /*!
-         *   initialze the von Karman strain in \par vK_strain, the operator
+         *   initialze the von Karman strain in \p vK_strain, the operator
          *   matrices needed for Jacobian calculation.
          *   vk_strain = [dw/dx 0; 0 dw/dy; dw/dy dw/dx]
          *   Bmat_vk   = [dw/dx; dw/dy]

--- a/src/elasticity/structural_element_2d.cpp
+++ b/src/elasticity/structural_element_2d.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/structural_element_2d.h
+++ b/src/elasticity/structural_element_2d.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -88,7 +88,7 @@ namespace MAST {
         internal_residual_jac_dot_state_sensitivity (RealMatrixX& jac);
         
         /*!
-         *   calculates the term on side \par s:
+         *   calculates the term on side \p s:
          *   \f$ \int_\Gamma a(\delta u, u) v_n ~d\Gamma \f$.
          *
          */
@@ -194,7 +194,7 @@ namespace MAST {
                                                   MAST::BoundaryConditionBase& bc);
 
         /*!
-         *   calculates the term on side \par s:
+         *   calculates the term on side \p s:
          *   \f$ \int_\Gamma a(\delta u, u) v_n ~d\Gamma \f$.
          *
          */
@@ -300,7 +300,7 @@ namespace MAST {
         
 
         /*!
-         *   initialze the von Karman strain in \par vK_strain, the operator
+         *   initialze the von Karman strain in \p vK_strain, the operator
          *   matrices needed for Jacobian calculation.
          *   vk_strain = [dw/dx 0; 0 dw/dy; dw/dy dw/dx]
          *   Bmat_vk   = [dw/dx; dw/dy]

--- a/src/elasticity/structural_element_base.cpp
+++ b/src/elasticity/structural_element_base.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/structural_element_base.h
+++ b/src/elasticity/structural_element_base.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -105,7 +105,7 @@ namespace MAST {
         
         /*!
          *  @returns a constant reference to the element solution 
-         *  (or its derivative if \par if_sens is true) in the local
+         *  (or its derivative if \p if_sens is true) in the local
          *  element coordinate system
          */
         const RealVectorX& local_solution(bool if_sens = false) const {
@@ -141,7 +141,7 @@ namespace MAST {
                                       RealMatrixX& jac);
 
         /*!
-         *   calculates the term on side \par s:
+         *   calculates the term on side \p s:
          *   \f$ \int_\Gamma a(\delta u, u) v_n ~d\Gamma \f$.
          *
          */

--- a/src/elasticity/structural_fluid_interaction_assembly.cpp
+++ b/src/elasticity/structural_fluid_interaction_assembly.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/structural_fluid_interaction_assembly.h
+++ b/src/elasticity/structural_fluid_interaction_assembly.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -66,7 +66,7 @@ namespace MAST {
         /*!
          *   if the eigenproblem is defined about a non-zero base solution,
          *   then this method provides the object with the base solution.
-         *   The flag \par if_sens tells the method if \par sol
+         *   The flag \p if_sens tells the method if \p sol
          *   is the sensitivity of the base solution for the current parameter
          *   being solved for
          */
@@ -76,7 +76,7 @@ namespace MAST {
         
         /*!
          *   Clears the pointer to base solution.
-         *   The flag \par if_sens tells the method to clear the pointer to the
+         *   The flag \p if_sens tells the method to clear the pointer to the
          *   sensitivity vector instead.
          */
         void clear_base_solution(bool if_sens = false);
@@ -90,7 +90,7 @@ namespace MAST {
         
         /*!
          *   @returns a const reference to the base solution (or
-         *   its sensitivity when \par if_sens is true) about which
+         *   its sensitivity when \p if_sens is true) about which
          *   the Eigen problem was linearized.
          */
         const libMesh::NumericVector<Real>&
@@ -99,7 +99,7 @@ namespace MAST {
         
         /*!
          *   calculates the reduced order matrix given the basis provided in
-         *   \par basis. \par X is the steady state solution about which
+         *   \p basis. \p X is the steady state solution about which
          *   the quantity is calculated.
          */
         virtual void
@@ -111,9 +111,9 @@ namespace MAST {
         
         /*!
          *   calculates the sensitivity of reduced order matrix given the basis 
-         *   provided in \par basis. \par X is the steady state solution about which
-         *   the quantity is calculated, and \par dX_dp is the sensitivity of 
-         *   \par X wrt the parameter identified as \par parameters[i]
+         *   provided in \p basis. \p X is the steady state solution about which
+         *   the quantity is calculated, and \p dX_dp is the sensitivity of 
+         *   \p X wrt the parameter identified as \p parameters[i]
          */
         virtual void
         assemble_reduced_order_quantity_sensitivity

--- a/src/elasticity/structural_modal_eigenproblem_assembly.cpp
+++ b/src/elasticity/structural_modal_eigenproblem_assembly.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/structural_modal_eigenproblem_assembly.h
+++ b/src/elasticity/structural_modal_eigenproblem_assembly.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -69,7 +69,7 @@ namespace MAST {
         set_elem_solution_sensitivity(const RealVectorX& sol);
 
         /*!
-         *   performs the element calculations over \par elem, and returns
+         *   performs the element calculations over \p elem, and returns
          *   the element matrices for the eigenproblem
          *   \f$ A x = \lambda B x \f$.
          */
@@ -78,7 +78,7 @@ namespace MAST {
                           RealMatrixX& mat_B);
         
         /*!
-         *   performs the element sensitivity calculations over \par elem,
+         *   performs the element sensitivity calculations over \p elem,
          *   and returns the element matrices for the eigenproblem
          *   \f$ A x = \lambda B x \f$.
          */
@@ -89,7 +89,7 @@ namespace MAST {
                                       RealMatrixX& mat_B);
 
         /*!
-         *   performs the element topology sensitivity calculations over \par elem.
+         *   performs the element topology sensitivity calculations over \p elem.
          */
         virtual void
         elem_topology_sensitivity_calculations(const MAST::FunctionBase& f,

--- a/src/elasticity/structural_near_null_vector_space.cpp
+++ b/src/elasticity/structural_near_null_vector_space.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/structural_near_null_vector_space.h
+++ b/src/elasticity/structural_near_null_vector_space.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/structural_nonlinear_assembly.cpp
+++ b/src/elasticity/structural_nonlinear_assembly.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/structural_nonlinear_assembly.h
+++ b/src/elasticity/structural_nonlinear_assembly.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -66,9 +66,9 @@ namespace MAST {
         virtual void set_elem_solution(const RealVectorX& sol);
         
         /*!
-         *   performs the element calculations over \par elem, and returns
-         *   the element vector and matrix quantities in \par mat and
-         *   \par vec, respectively. \par if_jac tells the method to also
+         *   performs the element calculations over \p elem, and returns
+         *   the element vector and matrix quantities in \p mat and
+         *   \p vec, respectively. \p if_jac tells the method to also
          *   assemble the Jacobian, in addition to the residual vector.
          */
         virtual void elem_calculations(bool if_jac,
@@ -77,9 +77,9 @@ namespace MAST {
         
         
         /*!
-         *   performs the element calculations over \par elem, and returns
-         *   the element vector quantity in \par vec. The vector quantity only
-         *   include the \f$ [J] \{dX\} f$ components, so the inherited classes
+         *   performs the element calculations over \p elem, and returns
+         *   the element vector quantity in \p vec. The vector quantity only
+         *   include the \f$ [J] \{dX\} \f$ components, so the inherited classes
          *   must ensure that no component of constant forces (traction/body
          *   forces/etc.) are added to this vector.
          */
@@ -88,15 +88,15 @@ namespace MAST {
         
         
         /*!
-         *   performs the element sensitivity calculations over \par elem,
-         *   and returns the element residual sensitivity in \par vec .
+         *   performs the element sensitivity calculations over \p elem,
+         *   and returns the element residual sensitivity in \p vec .
          */
         virtual void elem_sensitivity_calculations(const MAST::FunctionBase& f,
                                                    RealVectorX& vec);
         
         /*!
-         *   performs the element shape sensitivity calculations over \par elem,
-         *   and returns the element residual sensitivity in \par vec .
+         *   performs the element shape sensitivity calculations over \p elem,
+         *   and returns the element residual sensitivity in \p vec .
          */
         virtual void
         elem_shape_sensitivity_calculations(const MAST::FunctionBase& f,
@@ -105,8 +105,8 @@ namespace MAST {
         }
         
         /*!
-         *   performs the element topology sensitivity calculations over \par elem,
-         *   and returns the element residual sensitivity in \par vec .
+         *   performs the element topology sensitivity calculations over \p elem,
+         *   and returns the element residual sensitivity in \p vec .
          */
         virtual void
         elem_topology_sensitivity_calculations(const MAST::FunctionBase& f,
@@ -115,8 +115,8 @@ namespace MAST {
                                                RealVectorX& vec);
 
         /*!
-         *   calculates \f$ d ([J] \{\Delta X\})/ dX  \f$ over \par elem,
-         *   and returns the matrix in \par vec .
+         *   calculates \f$ d ([J] \{\Delta X\})/ dX  \f$ over \p elem,
+         *   and returns the matrix in \p vec .
          */
         virtual void
         elem_second_derivative_dot_solution_assembly(RealMatrixX& mat);

--- a/src/elasticity/structural_system.cpp
+++ b/src/elasticity/structural_system.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/structural_system.h
+++ b/src/elasticity/structural_system.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/structural_system_initialization.cpp
+++ b/src/elasticity/structural_system_initialization.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/structural_system_initialization.h
+++ b/src/elasticity/structural_system_initialization.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/structural_transient_assembly.cpp
+++ b/src/elasticity/structural_transient_assembly.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/structural_transient_assembly.h
+++ b/src/elasticity/structural_transient_assembly.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -62,9 +62,9 @@ namespace MAST {
                                        RealMatrixX& f_x_jac);
         
         /*!
-         *   performs the element calculations over \par elem, and returns
-         *   the element vector and matrix quantities in \par mat and
-         *   \par vec, respectively. \par if_jac tells the method to also
+         *   performs the element calculations over \p elem, and returns
+         *   the element vector and matrix quantities in \p mat and
+         *   \p vec, respectively. \p if_jac tells the method to also
          *   assemble the Jacobian, in addition to the residual vector.
          */
         virtual void elem_calculations(bool if_jac,
@@ -89,17 +89,17 @@ namespace MAST {
 
         
         /*!
-         *   performs the element sensitivity calculations over \par elem,
+         *   performs the element sensitivity calculations over \p elem,
          *   and returns the component of  element residual sensitivity in
-         *   \par f_m and \par f_x.
+         *   \p f_m and \p f_x.
          */
         virtual void elem_sensitivity_calculations(const MAST::FunctionBase& f,
                                                    RealVectorX& f_m,
                                                    RealVectorX& f_x);
         
         /*!
-         *   calculates \f$ d ([J] \{\Delta X\})/ dX  \f$ over \par elem,
-         *   and returns the matrix in \par vec .
+         *   calculates \f$ d ([J] \{\Delta X\})/ dX  \f$ over \p elem,
+         *   and returns the matrix in \p vec .
          */
         virtual void
         elem_second_derivative_dot_solution_assembly(RealMatrixX& mat);

--- a/src/elasticity/timoshenko_bending_operator.cpp
+++ b/src/elasticity/timoshenko_bending_operator.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/elasticity/timoshenko_bending_operator.h
+++ b/src/elasticity/timoshenko_bending_operator.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fluid/conservative_fluid_discipline.cpp
+++ b/src/fluid/conservative_fluid_discipline.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fluid/conservative_fluid_discipline.h
+++ b/src/fluid/conservative_fluid_discipline.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fluid/conservative_fluid_element_base.cpp
+++ b/src/fluid/conservative_fluid_element_base.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fluid/conservative_fluid_element_base.h
+++ b/src/fluid/conservative_fluid_element_base.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fluid/conservative_fluid_system_initialization.cpp
+++ b/src/fluid/conservative_fluid_system_initialization.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fluid/conservative_fluid_system_initialization.h
+++ b/src/fluid/conservative_fluid_system_initialization.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fluid/conservative_fluid_transient_assembly.cpp
+++ b/src/fluid/conservative_fluid_transient_assembly.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fluid/conservative_fluid_transient_assembly.h
+++ b/src/fluid/conservative_fluid_transient_assembly.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -50,9 +50,9 @@ namespace MAST {
         
         
         /*!
-         *   performs the element calculations over \par elem, and returns
-         *   the element vector and matrix quantities in \par mat and
-         *   \par vec, respectively. \par if_jac tells the method to also
+         *   performs the element calculations over \p elem, and returns
+         *   the element vector and matrix quantities in \p mat and
+         *   \p vec, respectively. \p if_jac tells the method to also
          *   assemble the Jacobian, in addition to the residual vector.
          */
         virtual void elem_calculations(bool if_jac,
@@ -93,8 +93,8 @@ namespace MAST {
         
         
         /*!
-         *   performs the element sensitivity calculations over \par elem,
-         *   and returns the element residual sensitivity in \par vec .
+         *   performs the element sensitivity calculations over \p elem,
+         *   and returns the element residual sensitivity in \p vec .
          */
         virtual void
         elem_sensitivity_calculations(const MAST::FunctionBase& f,
@@ -103,8 +103,8 @@ namespace MAST {
         
         
         /*!
-         *   calculates \f$ d ([J] \{\Delta X\})/ dX  \f$ over \par elem,
-         *   and returns the matrix in \par vec .
+         *   calculates \f$ d ([J] \{\Delta X\})/ dX  \f$ over \p elem,
+         *   and returns the matrix in \p vec .
          */
         virtual void
         elem_second_derivative_dot_solution_assembly(RealMatrixX& mat);

--- a/src/fluid/flight_condition.h
+++ b/src/fluid/flight_condition.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fluid/fluid_elem_base.cpp
+++ b/src/fluid/fluid_elem_base.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fluid/fluid_elem_base.h
+++ b/src/fluid/fluid_elem_base.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fluid/frequency_domain_linearized_complex_assembly.cpp
+++ b/src/fluid/frequency_domain_linearized_complex_assembly.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fluid/frequency_domain_linearized_complex_assembly.h
+++ b/src/fluid/frequency_domain_linearized_complex_assembly.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -62,9 +62,9 @@ namespace MAST {
         virtual void clear_frequency_function();
 
         /*!
-         *   performs the element calculations over \par elem, and returns
-         *   the element vector and matrix quantities in \par mat and
-         *   \par vec, respectively. \par if_jac tells the method to also
+         *   performs the element calculations over \p elem, and returns
+         *   the element vector and matrix quantities in \p mat and
+         *   \p vec, respectively. \p if_jac tells the method to also
          *   assemble the Jacobian, in addition to the residual vector.
          */
         virtual void elem_calculations(bool if_jac,
@@ -72,8 +72,8 @@ namespace MAST {
                                        ComplexMatrixX& mat);
         
         /*!
-         *   performs the element sensitivity calculations over \par elem,
-         *   and returns the element residual sensitivity in \par vec .
+         *   performs the element sensitivity calculations over \p elem,
+         *   and returns the element residual sensitivity in \p vec .
          */
         virtual void elem_sensitivity_calculations(const MAST::FunctionBase& f,
                                                    ComplexVectorX& vec);

--- a/src/fluid/frequency_domain_linearized_conservative_fluid_elem.cpp
+++ b/src/fluid/frequency_domain_linearized_conservative_fluid_elem.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fluid/frequency_domain_linearized_conservative_fluid_elem.h
+++ b/src/fluid/frequency_domain_linearized_conservative_fluid_elem.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -56,8 +56,8 @@ namespace MAST {
 
         /*!
          *   sensitivity of internal force contribution to system residual. 
-         *   If \par request_jacobian is true, then the sensitivity of 
-         *   Jacobian is retured in \par jac.
+         *   If \p request_jacobian is true, then the sensitivity of 
+         *   Jacobian is retured in \p jac.
          */
         virtual bool
         internal_residual_sensitivity (const MAST::FunctionBase& p,
@@ -78,8 +78,8 @@ namespace MAST {
         
         /*!
          *   sensitivity of internal force contribution to system residual.
-         *   If \par request_jacobian is true, then the sensitivity of
-         *   Jacobian is retured in \par jac.
+         *   If \p request_jacobian is true, then the sensitivity of
+         *   Jacobian is retured in \p jac.
          */
         virtual bool
         side_external_residual_sensitivity (const MAST::FunctionBase& p,
@@ -111,8 +111,8 @@ namespace MAST {
         
         /*!
          *    sensitivity of residual of the slip wall that may be oscillating.
-         *    If \par request_jacobian is true, then the sensitivity of the 
-         *    Jacobian is returned in \par jac.
+         *    If \p request_jacobian is true, then the sensitivity of the 
+         *    Jacobian is returned in \p jac.
          */
         virtual bool
         slip_wall_surface_residual_sensitivity(const MAST::FunctionBase& p,

--- a/src/fluid/frequency_domain_pressure_function.cpp
+++ b/src/fluid/frequency_domain_pressure_function.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fluid/frequency_domain_pressure_function.h
+++ b/src/fluid/frequency_domain_pressure_function.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fluid/gas_property.h
+++ b/src/fluid/gas_property.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fluid/integrated_force_output.cpp
+++ b/src/fluid/integrated_force_output.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fluid/integrated_force_output.h
+++ b/src/fluid/integrated_force_output.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -100,7 +100,7 @@ namespace MAST {
         
         /*!
          *   returns the output quantity derivative with respect to
-         *   state vector in \par dq_dX.
+         *   state vector in \p dq_dX.
          *   This method calculates the quantity
          *    \f[ \frac{\partial q(X, p)}{\partial X} \f] for this
          *    output function. This is returned for the element for which

--- a/src/fluid/pressure_function.cpp
+++ b/src/fluid/pressure_function.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fluid/pressure_function.h
+++ b/src/fluid/pressure_function.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fluid/primitive_fluid_solution.cpp
+++ b/src/fluid/primitive_fluid_solution.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fluid/primitive_fluid_solution.h
+++ b/src/fluid/primitive_fluid_solution.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fluid/small_disturbance_primitive_fluid_solution.cpp
+++ b/src/fluid/small_disturbance_primitive_fluid_solution.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fluid/small_disturbance_primitive_fluid_solution.h
+++ b/src/fluid/small_disturbance_primitive_fluid_solution.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fluid/surface_integrated_pressure_output.cpp
+++ b/src/fluid/surface_integrated_pressure_output.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fluid/surface_integrated_pressure_output.h
+++ b/src/fluid/surface_integrated_pressure_output.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/heat_conduction/heat_conduction_elem_base.cpp
+++ b/src/heat_conduction/heat_conduction_elem_base.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/heat_conduction/heat_conduction_elem_base.h
+++ b/src/heat_conduction/heat_conduction_elem_base.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -176,7 +176,7 @@ namespace MAST {
         
         /*!
          *    Calculates the residual vector and Jacobian due to surface flux
-         *    on element side \par s.
+         *    on element side \p s.
          */
         virtual void surface_flux_residual(bool request_jacobian,
                                            RealVectorX& f,
@@ -196,7 +196,7 @@ namespace MAST {
         
         /*!
          *    Calculates the residual vector sensitivity and Jacobian due to
-         *    surface flux on element side \par s.
+         *    surface flux on element side \p s.
          */
         virtual void surface_flux_residual_sensitivity(const MAST::FunctionBase& p,
                                                        RealVectorX& f,

--- a/src/heat_conduction/heat_conduction_nonlinear_assembly.cpp
+++ b/src/heat_conduction/heat_conduction_nonlinear_assembly.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/heat_conduction/heat_conduction_nonlinear_assembly.h
+++ b/src/heat_conduction/heat_conduction_nonlinear_assembly.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -46,9 +46,9 @@ namespace MAST {
         virtual ~HeatConductionNonlinearAssemblyElemOperations();
         
         /*!
-         *   performs the element calculations over \par elem, and returns
-         *   the element vector and matrix quantities in \par mat and
-         *   \par vec, respectively. \par if_jac tells the method to also
+         *   performs the element calculations over \p elem, and returns
+         *   the element vector and matrix quantities in \p mat and
+         *   \p vec, respectively. \p if_jac tells the method to also
          *   assemble the Jacobian, in addition to the residual vector.
          */
         virtual void
@@ -57,16 +57,16 @@ namespace MAST {
                           RealMatrixX& mat);
         
         /*!
-         *   performs the element sensitivity calculations over \par elem,
-         *   and returns the element residual sensitivity in \par vec .
+         *   performs the element sensitivity calculations over \p elem,
+         *   and returns the element residual sensitivity in \p vec .
          */
         virtual void
         elem_sensitivity_calculations(const MAST::FunctionBase& f,
                                       RealVectorX& vec);
         
         /*!
-         *   performs the element shape sensitivity calculations over \par elem,
-         *   and returns the element residual sensitivity in \par vec .
+         *   performs the element shape sensitivity calculations over \p elem,
+         *   and returns the element residual sensitivity in \p vec .
          */
         virtual void
         elem_shape_sensitivity_calculations(const MAST::FunctionBase& f,
@@ -75,8 +75,8 @@ namespace MAST {
         }
         
         /*!
-         *   performs the element topology sensitivity calculations over \par elem,
-         *   and returns the element residual sensitivity in \par vec .
+         *   performs the element topology sensitivity calculations over \p elem,
+         *   and returns the element residual sensitivity in \p vec .
          */
         virtual void
         elem_topology_sensitivity_calculations(const MAST::FunctionBase& f,
@@ -85,8 +85,8 @@ namespace MAST {
                                                RealVectorX& vec);
 
         /*!
-         *   calculates \f$ d ([J] \{\Delta X\})/ dX  \f$ over \par elem,
-         *   and returns the matrix in \par vec .
+         *   calculates \f$ d ([J] \{\Delta X\})/ dX  \f$ over \p elem,
+         *   and returns the matrix in \p vec .
          */
         virtual void
         elem_second_derivative_dot_solution_assembly(RealMatrixX& mat);

--- a/src/heat_conduction/heat_conduction_system_initialization.cpp
+++ b/src/heat_conduction/heat_conduction_system_initialization.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/heat_conduction/heat_conduction_system_initialization.h
+++ b/src/heat_conduction/heat_conduction_system_initialization.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/heat_conduction/heat_conduction_transient_assembly.cpp
+++ b/src/heat_conduction/heat_conduction_transient_assembly.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/heat_conduction/heat_conduction_transient_assembly.h
+++ b/src/heat_conduction/heat_conduction_transient_assembly.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -45,9 +45,9 @@ namespace MAST {
         virtual ~HeatConductionTransientAssemblyElemOperations();
         
         /*!
-         *   performs the element calculations over \par elem, and returns
-         *   the element vector and matrix quantities in \par mat and
-         *   \par vec, respectively. \par if_jac tells the method to also
+         *   performs the element calculations over \p elem, and returns
+         *   the element vector and matrix quantities in \p mat and
+         *   \p vec, respectively. \p if_jac tells the method to also
          *   assemble the Jacobian, in addition to the residual vector.
          */
         virtual void elem_calculations(bool if_jac,
@@ -84,9 +84,9 @@ namespace MAST {
         linearized_jacobian_solution_product(RealVectorX& f);
         
         /*!
-         *   performs the element sensitivity calculations over \par elem,
+         *   performs the element sensitivity calculations over \p elem,
          *   and returns the component of  element residual sensitivity in
-         *   \par f_m and \par f_x.
+         *   \p f_m and \p f_x.
          */
         virtual void elem_sensitivity_calculations(const MAST::FunctionBase& f,
                                                    RealVectorX& f_m,
@@ -94,8 +94,8 @@ namespace MAST {
         
         
         /*!
-         *   calculates \f$ d ([J] \{\Delta X\})/ dX  \f$ over \par elem,
-         *   and returns the matrix in \par vec .
+         *   calculates \f$ d ([J] \{\Delta X\})/ dX  \f$ over \p elem,
+         *   and returns the matrix in \p vec .
          */
         virtual void
         elem_second_derivative_dot_solution_assembly(RealMatrixX& mat);

--- a/src/level_set/indicator_function_constrain_dofs.cpp
+++ b/src/level_set/indicator_function_constrain_dofs.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/level_set/indicator_function_constrain_dofs.h
+++ b/src/level_set/indicator_function_constrain_dofs.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/level_set/interface_dof_handler.cpp
+++ b/src/level_set/interface_dof_handler.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/level_set/interface_dof_handler.h
+++ b/src/level_set/interface_dof_handler.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/level_set/level_set_boundary_velocity.cpp
+++ b/src/level_set/level_set_boundary_velocity.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/level_set/level_set_boundary_velocity.h
+++ b/src/level_set/level_set_boundary_velocity.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/level_set/level_set_constrain_dofs.cpp
+++ b/src/level_set/level_set_constrain_dofs.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/level_set/level_set_constrain_dofs.h
+++ b/src/level_set/level_set_constrain_dofs.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/level_set/level_set_discipline.cpp
+++ b/src/level_set/level_set_discipline.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/level_set/level_set_discipline.h
+++ b/src/level_set/level_set_discipline.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/level_set/level_set_eigenproblem_assembly.cpp
+++ b/src/level_set/level_set_eigenproblem_assembly.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/level_set/level_set_eigenproblem_assembly.h
+++ b/src/level_set/level_set_eigenproblem_assembly.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -90,7 +90,7 @@ namespace MAST {
         /**
          * Assembly function.  This function will be called
          * to assemble the sensitivity of eigenproblem matrices.
-         * The method provides dA/dp and dB/dp for \par f parameter.
+         * The method provides dA/dp and dB/dp for \p f parameter.
          *
          * If the routine is not able to provide sensitivity for this parameter,
          * then it should return false, and the system will attempt to use

--- a/src/level_set/level_set_elem_base.cpp
+++ b/src/level_set/level_set_elem_base.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/level_set/level_set_elem_base.h
+++ b/src/level_set/level_set_elem_base.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/level_set/level_set_intersection.cpp
+++ b/src/level_set/level_set_intersection.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/level_set/level_set_intersection.h
+++ b/src/level_set/level_set_intersection.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/level_set/level_set_nonlinear_implicit_assembly.cpp
+++ b/src/level_set/level_set_nonlinear_implicit_assembly.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/level_set/level_set_nonlinear_implicit_assembly.h
+++ b/src/level_set/level_set_nonlinear_implicit_assembly.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -136,12 +136,12 @@ namespace MAST {
         
         /*!
          *   evaluates the sensitivity of the outputs in the attached
-         *   discipline with respect to the parametrs in \par params.
-         *   The base solution should be provided in \par X. If total sensitivity
-         *   is desired, then \par dXdp should contain the sensitivity of
-         *   solution wrt the parameter \par p. If this \par dXdp is zero,
+         *   discipline with respect to the parametrs in \p params.
+         *   The base solution should be provided in \p X. If total sensitivity
+         *   is desired, then \p dXdp should contain the sensitivity of
+         *   solution wrt the parameter \p p. If this \p dXdp is zero,
          *   the calculated sensitivity will be the partial derivarive of
-         *   \par output wrt \par p.
+         *   \p output wrt \p p.
          */
         virtual void
         calculate_output_direct_sensitivity(const libMesh::NumericVector<Real>& X,
@@ -151,9 +151,9 @@ namespace MAST {
         
         
         /*!
-         *   Evaluates the total sensitivity of \par output wrt \par p using
-         *   the adjoint solution provided in \par dq_dX for a linearization
-         *   about solution \par X.
+         *   Evaluates the total sensitivity of \p output wrt \p p using
+         *   the adjoint solution provided in \p dq_dX for a linearization
+         *   about solution \p X.
          */
         /*virtual Real
         calculate_output_adjoint_sensitivity(const libMesh::NumericVector<Real>& X,

--- a/src/level_set/level_set_reinitialization_transient_assembly.cpp
+++ b/src/level_set/level_set_reinitialization_transient_assembly.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/level_set/level_set_reinitialization_transient_assembly.h
+++ b/src/level_set/level_set_reinitialization_transient_assembly.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/level_set/level_set_system_initialization.cpp
+++ b/src/level_set/level_set_system_initialization.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/level_set/level_set_system_initialization.h
+++ b/src/level_set/level_set_system_initialization.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/level_set/level_set_transient_assembly.cpp
+++ b/src/level_set/level_set_transient_assembly.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/level_set/level_set_transient_assembly.h
+++ b/src/level_set/level_set_transient_assembly.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -51,9 +51,9 @@ namespace MAST {
         void set_elem_reference_solution(const RealVectorX& sol);
         
         /*!
-         *   performs the element calculations over \par elem, and returns
-         *   the element vector and matrix quantities in \par mat and
-         *   \par vec, respectively. \par if_jac tells the method to also
+         *   performs the element calculations over \p elem, and returns
+         *   the element vector and matrix quantities in \p mat and
+         *   \p vec, respectively. \p if_jac tells the method to also
          *   assemble the Jacobian, in addition to the residual vector.
          */
         virtual void elem_calculations(bool if_jac,
@@ -90,16 +90,16 @@ namespace MAST {
         linearized_jacobian_solution_product(RealVectorX& f);
         
         /*!
-         *   performs the element sensitivity calculations over \par elem,
-         *   and returns the element residual sensitivity in \par vec .
+         *   performs the element sensitivity calculations over \p elem,
+         *   and returns the element residual sensitivity in \p vec .
          */
         virtual void elem_sensitivity_calculations(const MAST::FunctionBase& f,
                                                    RealVectorX& vec);
         
         
         /*!
-         *   calculates \f$ d ([J] \{\Delta X\})/ dX  \f$ over \par elem,
-         *   and returns the matrix in \par vec .
+         *   calculates \f$ d ([J] \{\Delta X\})/ dX  \f$ over \p elem,
+         *   and returns the matrix in \p vec .
          */
         virtual void
         elem_second_derivative_dot_solution_assembly(RealMatrixX& mat);

--- a/src/level_set/level_set_void_solution.cpp
+++ b/src/level_set/level_set_void_solution.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/level_set/level_set_void_solution.h
+++ b/src/level_set/level_set_void_solution.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/level_set/level_set_volume_output.cpp
+++ b/src/level_set/level_set_volume_output.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/level_set/level_set_volume_output.h
+++ b/src/level_set/level_set_volume_output.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -99,7 +99,7 @@ namespace MAST {
 
         /*!
          *   returns the output quantity derivative with respect to
-         *   state vector in \par dq_dX.
+         *   state vector in \p dq_dX.
          *   This method calculates the quantity
          *    \f[ \frac{\partial q(X, p)}{\partial X} \f] for this
          *    output function. This is returned for the element for which

--- a/src/level_set/material_patch.cpp
+++ b/src/level_set/material_patch.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/level_set/material_patch.h
+++ b/src/level_set/material_patch.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/level_set/sub_cell_fe.cpp
+++ b/src/level_set/sub_cell_fe.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/level_set/sub_cell_fe.h
+++ b/src/level_set/sub_cell_fe.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/fe_base.cpp
+++ b/src/mesh/fe_base.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/fe_base.h
+++ b/src/mesh/fe_base.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/local_1d_elem.cpp
+++ b/src/mesh/local_1d_elem.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/local_1d_elem.h
+++ b/src/mesh/local_1d_elem.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -48,7 +48,7 @@ namespace MAST {
         
         /*!
          *   Calculates the surface normal of the element at the given point
-         *   \par p, where the finite element provided surface normal is
+         *   \p p, where the finite element provided surface normal is
          *   \p n_local. The calculated surface normal in the global
          *   coordinate system is \p n_global. For 1D or 2D elements, the flux
          *   loads can be defined over the entire domain of the element. This,

--- a/src/mesh/local_2d_elem.cpp
+++ b/src/mesh/local_2d_elem.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/local_2d_elem.h
+++ b/src/mesh/local_2d_elem.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -41,7 +41,7 @@ namespace MAST {
         
         /*!
          *   Calculates the surface normal of the element at the given point
-         *   \par p, where the finite element provided surface normal is
+         *   \p p, where the finite element provided surface normal is
          *   \p n_local. The calculated surface normal in the global
          *   coordinate system is \p n_global. For 1D or 2D elements, the flux
          *   loads can be defined over the entire domain of the element. This,

--- a/src/mesh/local_3d_elem.cpp
+++ b/src/mesh/local_3d_elem.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/local_3d_elem.h
+++ b/src/mesh/local_3d_elem.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -44,7 +44,7 @@ namespace MAST {
         
         /*!
          *   Calculates the surface normal of the element at the given point
-         *   \par p, where the finite element provided surface normal is
+         *   \p p, where the finite element provided surface normal is
          *   \p n_local. The calculated surface normal in the global
          *   coordinate system is \p n_global. For 1D or 2D elements, the flux
          *   loads can be defined over the entire domain of the element. This,

--- a/src/mesh/local_elem_base.cpp
+++ b/src/mesh/local_elem_base.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/local_elem_base.h
+++ b/src/mesh/local_elem_base.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -90,7 +90,7 @@ namespace MAST {
         
         /*!
          *   Calculates the side surface normal of the element at the given
-         *   point \par p, where the finite element provided surface normal is
+         *   point \p p, where the finite element provided surface normal is
          *   \p n_local. The calculated surface normal in the global
          *   coordinate system is \p n_global.
          *
@@ -105,7 +105,7 @@ namespace MAST {
 
         /*!
          *   Calculates the surface normal of the element at the given point
-         *   \par p, where the finite element provided surface normal is
+         *   \p p, where the finite element provided surface normal is
          *   \p n_local. The calculated surface normal in the global
          *   coordinate system is \p n_global. For 1D or 2D elements, the flux
          *   loads can be defined over the entire domain of the element. This,

--- a/src/numerics/basis_matrix.cpp
+++ b/src/numerics/basis_matrix.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/basis_matrix.h
+++ b/src/numerics/basis_matrix.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/fem_operator_matrix.cpp
+++ b/src/numerics/fem_operator_matrix.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/fem_operator_matrix.h
+++ b/src/numerics/fem_operator_matrix.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -65,10 +65,10 @@ namespace MAST {
         
         /*!
          *   sets the shape function values for the block corresponding to
-         *   \par interpolated_var and \par discrete_var. This means that the row
-         *   \par interpolated_var, the value in columns
-         *   \par discrete_vars*n_discrete_dofs_per_var - (discrete_vars+1)*n_discrete_dofs_per_var-1)
-         *    will be set equal to \par shape_func .
+         *   \p interpolated_var and \p discrete_var. This means that the row
+         *   \p interpolated_var, the value in columns
+         *   \p discrete_vars*n_discrete_dofs_per_var - (discrete_vars+1)*n_discrete_dofs_per_var-1)
+         *    will be set equal to \p shape_func .
          */
         void set_shape_function(unsigned int interpolated_var,
                                 unsigned int discrete_var,

--- a/src/numerics/lapack_dgeev_interface.cpp
+++ b/src/numerics/lapack_dgeev_interface.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/lapack_dgeev_interface.h
+++ b/src/numerics/lapack_dgeev_interface.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -156,7 +156,7 @@ namespace MAST {
         { }
         
         /*!
-         *    computes the eigensolution for A x = \lambda I x. A & B will be
+         *    computes the eigensolution for \f$ A x = \lambda I x\f$. A & B will be
          *    overwritten
          */
         void compute(const RealMatrixX& A,

--- a/src/numerics/lapack_dggev_interface.cpp
+++ b/src/numerics/lapack_dggev_interface.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/lapack_dggev_interface.h
+++ b/src/numerics/lapack_dggev_interface.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -186,7 +186,7 @@ namespace MAST {
         { }
         
         /*!
-         *    computes the eigensolution for A x = \lambda B x. A & B will be
+         *    computes the eigensolution for \f$ A x = \lambda B x\f$. A & B will be
          *    overwritten
          */
         void compute(const RealMatrixX& A,

--- a/src/numerics/lapack_zggev_base.h
+++ b/src/numerics/lapack_zggev_base.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -38,7 +38,7 @@ namespace MAST {
         { }
         
         /*!
-         *    computes the eigensolution for A x = \lambda B x. A & B will be
+         *    computes the eigensolution for \f$A x = \lambda B x\f$. A & B will be
          *    overwritten
          */
         virtual void compute(const ComplexMatrixX& A,

--- a/src/numerics/lapack_zggev_interface.cpp
+++ b/src/numerics/lapack_zggev_interface.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/lapack_zggev_interface.h
+++ b/src/numerics/lapack_zggev_interface.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -177,7 +177,7 @@ namespace MAST {
         { }
         
         /*!
-         *    computes the eigensolution for A x = \lambda B x. A & B will be
+         *    computes the eigensolution for \f$A x = \lambda B x\f$. A & B will be
          *    overwritten
          */
         virtual void compute(const ComplexMatrixX& A,

--- a/src/numerics/lapack_zggevx_interface.cpp
+++ b/src/numerics/lapack_zggevx_interface.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/lapack_zggevx_interface.h
+++ b/src/numerics/lapack_zggevx_interface.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -298,7 +298,7 @@ namespace MAST {
         { }
         
         /*!
-         *    computes the eigensolution for A x = \lambda B x. A & B will be
+         *    computes the eigensolution for \f$A x = \lambda B x\f$. A & B will be
          *    overwritten
          */
         virtual void compute(const ComplexMatrixX& A,

--- a/src/numerics/utility.h
+++ b/src/numerics/utility.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/optimization/dot_optimization_interface.cpp
+++ b/src/optimization/dot_optimization_interface.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/optimization/dot_optimization_interface.h
+++ b/src/optimization/dot_optimization_interface.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/optimization/function_evaluation.cpp
+++ b/src/optimization/function_evaluation.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/optimization/function_evaluation.h
+++ b/src/optimization/function_evaluation.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -99,7 +99,7 @@ namespace MAST {
                                std::vector<Real>& xmax) = 0;
         
         /*!
-         *   \par grads(k): Derivative of f_i(x) with respect
+         *   \p grads(k): Derivative of f_i(x) with respect
          *   to x_j, where k = (j-1)*M + i.
          */
         virtual void evaluate(const std::vector<Real>& dvars,
@@ -146,8 +146,8 @@ namespace MAST {
          *   optimization history output file. This will verify that the
          *   optimization setup (number of DVs, constraints, etc.) are the
          *   same as the initialized data for this object and then
-         *   read the dv values from \par iter iteration into
-         *   \par x. 
+         *   read the dv values from \p iter iteration into
+         *   \p x. 
          */
         void initialize_dv_from_output_file(const std::string& nm,
                                             const unsigned int iter,

--- a/src/optimization/gcmma_optimization_interface.cpp
+++ b/src/optimization/gcmma_optimization_interface.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/optimization/gcmma_optimization_interface.h
+++ b/src/optimization/gcmma_optimization_interface.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/optimization/npsol_optimization_interface.cpp
+++ b/src/optimization/npsol_optimization_interface.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/optimization/npsol_optimization_interface.h
+++ b/src/optimization/npsol_optimization_interface.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/optimization/optimization_interface.cpp
+++ b/src/optimization/optimization_interface.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/optimization/optimization_interface.h
+++ b/src/optimization/optimization_interface.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/property_cards/element_property_card_1D.cpp
+++ b/src/property_cards/element_property_card_1D.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/property_cards/element_property_card_1D.h
+++ b/src/property_cards/element_property_card_1D.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -80,8 +80,8 @@ namespace MAST
         
         
 //        /*!
-//         *   returns value of the property \par val. The string values for 
-//         *   \par val are IYY, IZZ, IYZ
+//         *   returns value of the property \p val. The string values for 
+//         *   \p val are IYY, IZZ, IYZ
 //         */
 //        virtual Real value(const std::string& val) const = 0;
         

--- a/src/property_cards/element_property_card_2D.cpp
+++ b/src/property_cards/element_property_card_2D.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/property_cards/element_property_card_2D.h
+++ b/src/property_cards/element_property_card_2D.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/property_cards/element_property_card_base.h
+++ b/src/property_cards/element_property_card_base.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/property_cards/isotropic_element_property_card_3D.cpp
+++ b/src/property_cards/isotropic_element_property_card_3D.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/property_cards/isotropic_element_property_card_3D.h
+++ b/src/property_cards/isotropic_element_property_card_3D.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/property_cards/isotropic_material_property_card.cpp
+++ b/src/property_cards/isotropic_material_property_card.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/property_cards/isotropic_material_property_card.h
+++ b/src/property_cards/isotropic_material_property_card.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/property_cards/material_property_card_base.h
+++ b/src/property_cards/material_property_card_base.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/property_cards/multilayer_1d_section_element_property_card.cpp
+++ b/src/property_cards/multilayer_1d_section_element_property_card.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/property_cards/multilayer_1d_section_element_property_card.h
+++ b/src/property_cards/multilayer_1d_section_element_property_card.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/property_cards/multilayer_2d_section_element_property_card.cpp
+++ b/src/property_cards/multilayer_2d_section_element_property_card.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/property_cards/multilayer_2d_section_element_property_card.h
+++ b/src/property_cards/multilayer_2d_section_element_property_card.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/property_cards/orthotropic_element_property_card_3D.cpp
+++ b/src/property_cards/orthotropic_element_property_card_3D.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/property_cards/orthotropic_element_property_card_3D.h
+++ b/src/property_cards/orthotropic_element_property_card_3D.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/property_cards/orthotropic_material_property_card.cpp
+++ b/src/property_cards/orthotropic_material_property_card.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/property_cards/orthotropic_material_property_card.h
+++ b/src/property_cards/orthotropic_material_property_card.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/property_cards/solid_1d_section_element_property_card.cpp
+++ b/src/property_cards/solid_1d_section_element_property_card.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/property_cards/solid_1d_section_element_property_card.h
+++ b/src/property_cards/solid_1d_section_element_property_card.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/property_cards/solid_2d_section_element_property_card.cpp
+++ b/src/property_cards/solid_2d_section_element_property_card.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/property_cards/solid_2d_section_element_property_card.h
+++ b/src/property_cards/solid_2d_section_element_property_card.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/solver/complex_solver_base.cpp
+++ b/src/solver/complex_solver_base.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/solver/complex_solver_base.h
+++ b/src/solver/complex_solver_base.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -75,7 +75,7 @@ namespace MAST {
         
         /*!
          *  solves the complex system of equations using block matrices. If 
-         *  no argument is specified for \par p, then the system is solved. 
+         *  no argument is specified for \p p, then the system is solved. 
          *  Otherwise, the sensitivity of the system is solved with respect
          *  to the parameter p
          */
@@ -84,7 +84,7 @@ namespace MAST {
         
         /*!
          *  @returns a reference to the real part of the solution. If 
-         *  \par if_sens is true, the the sensitivity vector is returned. Note,
+         *  \p if_sens is true, the the sensitivity vector is returned. Note,
          *  that the sensitivity can be requested only after a sensitivity 
          *  solve.
          */
@@ -93,7 +93,7 @@ namespace MAST {
         
         /*!
          *  @returns a constant reference to the real part of the solution. If
-         *  \par if_sens is true, the the sensitivity vector is returned. Note,
+         *  \p if_sens is true, the the sensitivity vector is returned. Note,
          *  that the sensitivity can be requested only after a sensitivity
          *  solve.
          */
@@ -102,7 +102,7 @@ namespace MAST {
         
         /*!
          *  @returns a reference to the imaginary part of the solution. If
-         *  \par if_sens is true, the the sensitivity vector is returned. Note,
+         *  \p if_sens is true, the the sensitivity vector is returned. Note,
          *  that the sensitivity can be requested only after a sensitivity
          *  solve.
          */
@@ -111,7 +111,7 @@ namespace MAST {
         
         /*!
          *  @returns a constant reference to the imaginary part of the solution.
-         *  If \par if_sens is true, the the sensitivity vector is returned.
+         *  If \p if_sens is true, the the sensitivity vector is returned.
          *  Note, that the sensitivity can be requested only after a sensitivity
          *  solve.
          */

--- a/src/solver/first_order_newmark_transient_solver.cpp
+++ b/src/solver/first_order_newmark_transient_solver.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/solver/first_order_newmark_transient_solver.h
+++ b/src/solver/first_order_newmark_transient_solver.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -35,15 +35,15 @@ namespace MAST {
      *    \f[ r = beta*dt(f_m + f_x )= 0 \f]
      *    where, (for example)
      *    \f{eqnarray*}{
-     *      f_m & = &  int_Omega phi u_dot   \mbox{ [typical mass vector in conduction, for example]}\\
-     *      f_x & = &  int_Omega phi_i u_i - int_Gamma phi q_n \mbox{ [typical conductance and heat flux combination, for example]}
+     *      f_m & = &  \int_\Omega \phi \dot{u}   \mbox{ [typical mass vector in conduction, for example]}\\
+     *      f_x & = &  \int_\Omega \phi_i u_i - \int_\Gamma \phi q_n \mbox{ [typical conductance and heat flux combination, for example]}
      *    \f}
      *
      *    This method assumes
      *    \f{eqnarray*}{
-     *     x     &=& x0 + (1-beta) dt x0_dot + beta dt x_dot \\
-     *    \mbox{or, } x_dot &=& (x-x0)/beta/dt - (1-beta)/beta x0_dot
-     *    }
+     *     x     &=& x_0 + (1-\beta) dt \dot{x_0} + \beta dt \dot{x} \\
+     *    \mbox{or, } \dot{x} &=& (x-x_0)/\beta/dt - (1-\beta)/\beta \dot{x_0}
+     *    \f}
      *    Note that the residual expression multiplies the expression by beta*dt
      *    for convenience in the following expressions
      *
@@ -51,10 +51,10 @@ namespace MAST {
      *    Jacobian is
      *    \f{eqnarray*}{
      *    dr/dx &=& [df_m/dx + df_x/dx +\\
-     *       &&          df_m/dx_dot dx_dot/dx + df_x/dx_dot dx_dot/dx]\\
+     *       &&          df_m/d\dot{x} d\dot{x}/dx + df_x/d\dot{x} d\dot{x}/dx]\\
      *       &=& [(df_m/dx + df_x/dx) +\\
-     *       &&           (df_m/dx_dot + df_x/dx_dot) (1/beta/dt)]
-     *    }
+     *       &&           (df_m/d\dot{x} + df_x/d\dot{x}) (1/\beta/dt)]
+     *    \f}
      *   Note that this form of equations makes it a good candidate for
      *   use as implicit solver, ie, for a nonzero beta.
      */
@@ -130,9 +130,9 @@ namespace MAST {
         
         
         /*!
-         *   performs the element calculations over \par elem, and returns
-         *   the element vector and matrix quantities in \par mat and
-         *   \par vec, respectively. \par if_jac tells the method to also
+         *   performs the element calculations over \p elem, and returns
+         *   the element vector and matrix quantities in \p mat and
+         *   \p vec, respectively. \p if_jac tells the method to also
          *   assemble the Jacobian, in addition to the residual vector.
          */
         virtual void
@@ -141,9 +141,9 @@ namespace MAST {
                           RealMatrixX& mat);
         
         /*!
-         *   performs the element calculations over \par elem, and returns
-         *   the element vector quantity in \par vec. The vector quantity only
-         *   include the \f$ [J] \{dX\} f$ components, so the inherited classes
+         *   performs the element calculations over \p elem, and returns
+         *   the element vector quantity in \p vec. The vector quantity only
+         *   include the \f$ [J] \{dX\} \f$ components, so the inherited classes
          *   must ensure that no component of constant forces (traction/body
          *   forces/etc.) are added to this vector.
          */
@@ -151,24 +151,24 @@ namespace MAST {
         elem_linearized_jacobian_solution_product(RealVectorX& vec);
         
         /*!
-         *   performs the element sensitivity calculations over \par elem,
-         *   and returns the element residual sensitivity in \par vec .
+         *   performs the element sensitivity calculations over \p elem,
+         *   and returns the element residual sensitivity in \p vec .
          */
         virtual void
         elem_sensitivity_calculations(const MAST::FunctionBase& f,
                                       RealVectorX& vec);
 
         /*!
-         *   performs the element shape sensitivity calculations over \par elem,
-         *   and returns the element residual sensitivity in \par vec .
+         *   performs the element shape sensitivity calculations over \p elem,
+         *   and returns the element residual sensitivity in \p vec .
          */
         virtual void
         elem_shape_sensitivity_calculations(const MAST::FunctionBase& f,
                                             RealVectorX& vec);
         
         /*!
-         *   performs the element topology sensitivity calculations over \par elem,
-         *   and returns the element residual sensitivity in \par vec .
+         *   performs the element topology sensitivity calculations over \p elem,
+         *   and returns the element residual sensitivity in \p vec .
          */
         virtual void
         elem_topology_sensitivity_calculations(const MAST::FunctionBase& f,
@@ -177,8 +177,8 @@ namespace MAST {
                                                RealVectorX& vec);
 
         /*!
-         *   calculates \f$ d ([J] \{\Delta X\})/ dX  \f$ over \par elem,
-         *   and returns the matrix in \par vec .
+         *   calculates \f$ d ([J] \{\Delta X\})/ dX  \f$ over \p elem,
+         *   and returns the matrix in \p vec .
          */
         virtual void
         elem_second_derivative_dot_solution_assembly(RealMatrixX& mat) {

--- a/src/solver/multiphysics_nonlinear_solver.cpp
+++ b/src/solver/multiphysics_nonlinear_solver.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/solver/multiphysics_nonlinear_solver.h
+++ b/src/solver/multiphysics_nonlinear_solver.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/solver/second_order_newmark_transient_solver.cpp
+++ b/src/solver/second_order_newmark_transient_solver.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/solver/second_order_newmark_transient_solver.h
+++ b/src/solver/second_order_newmark_transient_solver.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -103,9 +103,9 @@ namespace MAST {
         
         
         /*!
-         *   performs the element calculations over \par elem, and returns
-         *   the element vector and matrix quantities in \par mat and
-         *   \par vec, respectively. \par if_jac tells the method to also
+         *   performs the element calculations over \p elem, and returns
+         *   the element vector and matrix quantities in \p mat and
+         *   \p vec, respectively. \p if_jac tells the method to also
          *   assemble the Jacobian, in addition to the residual vector.
          */
         virtual void
@@ -114,9 +114,9 @@ namespace MAST {
                           RealMatrixX& mat);
         
         /*!
-         *   performs the element calculations over \par elem, and returns
-         *   the element vector quantity in \par vec. The vector quantity only
-         *   include the \f$ [J] \{dX\} f$ components, so the inherited classes
+         *   performs the element calculations over \p elem, and returns
+         *   the element vector quantity in \p vec. The vector quantity only
+         *   include the \f$ [J] \{dX\} \f$ components, so the inherited classes
          *   must ensure that no component of constant forces (traction/body
          *   forces/etc.) are added to this vector.
          */
@@ -124,24 +124,24 @@ namespace MAST {
         elem_linearized_jacobian_solution_product(RealVectorX& vec);
         
         /*!
-         *   performs the element sensitivity calculations over \par elem,
-         *   and returns the element residual sensitivity in \par vec .
+         *   performs the element sensitivity calculations over \p elem,
+         *   and returns the element residual sensitivity in \p vec .
          */
         virtual void
         elem_sensitivity_calculations(const MAST::FunctionBase& f,
                                       RealVectorX& vec);
         
         /*!
-         *   performs the element shape sensitivity calculations over \par elem,
-         *   and returns the element residual sensitivity in \par vec .
+         *   performs the element shape sensitivity calculations over \p elem,
+         *   and returns the element residual sensitivity in \p vec .
          */
         virtual void
         elem_shape_sensitivity_calculations(const MAST::FunctionBase& f,
                                             RealVectorX& vec);
         
         /*!
-         *   performs the element topology sensitivity calculations over \par elem,
-         *   and returns the element residual sensitivity in \par vec .
+         *   performs the element topology sensitivity calculations over \p elem,
+         *   and returns the element residual sensitivity in \p vec .
          */
         virtual void
         elem_topology_sensitivity_calculations(const MAST::FunctionBase& f,
@@ -150,8 +150,8 @@ namespace MAST {
                                                RealVectorX& vec);
 
         /*!
-         *   calculates \f$ d ([J] \{\Delta X\})/ dX  \f$ over \par elem,
-         *   and returns the matrix in \par vec .
+         *   calculates \f$ d ([J] \{\Delta X\})/ dX  \f$ over \p elem,
+         *   and returns the matrix in \p vec .
          */
         virtual void
         elem_second_derivative_dot_solution_assembly(RealMatrixX& mat) {

--- a/src/solver/slepc_eigen_solver.cpp
+++ b/src/solver/slepc_eigen_solver.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/solver/slepc_eigen_solver.h
+++ b/src/solver/slepc_eigen_solver.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/solver/transient_solver_base.cpp
+++ b/src/solver/transient_solver_base.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/solver/transient_solver_base.h
+++ b/src/solver/transient_solver_base.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -79,8 +79,8 @@ namespace MAST {
         
         /*!
          *    @returns a reference to the localized solution from
-         *    iteration number = current - prev_iter. So, \par prev_iter = 0
-         *    gives the current solution estimate. Note that \par prev_iter
+         *    iteration number = current - prev_iter. So, \p prev_iter = 0
+         *    gives the current solution estimate. Note that \p prev_iter
          *    cannot be greater than the total number of iterations that this
          *    solver stores solutions for.
          */
@@ -96,8 +96,8 @@ namespace MAST {
 
         /*!
          *    @returns a reference to the localized velocity from
-         *    iteration number = current - prev_iter. So, \par prev_iter = 0
-         *    gives the current velocity estimate. Note that \par prev_iter
+         *    iteration number = current - prev_iter. So, \p prev_iter = 0
+         *    gives the current velocity estimate. Note that \p prev_iter
          *    cannot be greater than the total number of iterations that this
          *    solver stores solutions for.
          */
@@ -115,8 +115,8 @@ namespace MAST {
         
         /*!
          *    @returns a reference to the localized acceleration from
-         *    iteration number = current - prev_iter. So, \par prev_iter = 0
-         *    gives the current acceleration estimate. Note that \par prev_iter
+         *    iteration number = current - prev_iter. So, \p prev_iter = 0
+         *    gives the current acceleration estimate. Note that \p prev_iter
          *    cannot be greater than the total number of iterations that this
          *    solver stores solutions for.
          */
@@ -219,7 +219,7 @@ namespace MAST {
          *    \param current_sol  the perturbation in current displacement 
          *    \f$ \Delta X \f$
          *    \param qtys upon returning, this vector is populated such that the
-         *    ith element of the vector is \f$ (d (d^iX/dt^i)/ dX) dX \Delta X$
+         *    ith element of the vector is \f$ (d (d^iX/dt^i)/ dX) dX \Delta X \f$
          */
         virtual void
         build_perturbed_local_quantities

--- a/src/utility/plot.cpp
+++ b/src/utility/plot.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/utility/plot.h
+++ b/src/utility/plot.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/base/check_sensitivity.h
+++ b/tests/base/check_sensitivity.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/base/test_comparisons.h
+++ b/tests/base/test_comparisons.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/base/test_main.cpp
+++ b/tests/base/test_main.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/fluid/build_conservative_fluid_elem.cpp
+++ b/tests/fluid/build_conservative_fluid_elem.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/fluid/build_conservative_fluid_elem.h
+++ b/tests/fluid/build_conservative_fluid_elem.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/fluid/check_frequency_domain_jacobian.cpp
+++ b/tests/fluid/check_frequency_domain_jacobian.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/fluid/eigenvector_derivative.cpp
+++ b/tests/fluid/eigenvector_derivative.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/fluid/fluid_elem_initialization.h
+++ b/tests/fluid/fluid_elem_initialization.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/fluid/jacobian_second_derivative.cpp
+++ b/tests/fluid/jacobian_second_derivative.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/fluid/panel_2d_small_disturbance_frequency_domain.cpp
+++ b/tests/fluid/panel_2d_small_disturbance_frequency_domain.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/fsi/beam_flutter_sensitivity.cpp
+++ b/tests/fsi/beam_flutter_sensitivity.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/numerics/fem_operator_matrix.cpp
+++ b/tests/numerics/fem_operator_matrix.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/structural/bar_extension_evaluation.cpp
+++ b/tests/structural/bar_extension_evaluation.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/structural/beam_bending_evaluation.cpp
+++ b/tests/structural/beam_bending_evaluation.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/structural/beam_bending_evaluation_with_offset.cpp
+++ b/tests/structural/beam_bending_evaluation_with_offset.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/structural/beam_bending_thermal_stress_evaluation.cpp
+++ b/tests/structural/beam_bending_thermal_stress_evaluation.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/structural/beam_buckling_analysis.cpp
+++ b/tests/structural/beam_buckling_analysis.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/structural/beam_modal_analysis.cpp
+++ b/tests/structural/beam_modal_analysis.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/structural/beam_piston_theory_flutter.cpp
+++ b/tests/structural/beam_piston_theory_flutter.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/structural/build_structural_elem_1D.cpp
+++ b/tests/structural/build_structural_elem_1D.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/structural/build_structural_elem_1D.h
+++ b/tests/structural/build_structural_elem_1D.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/structural/build_structural_elem_2D.cpp
+++ b/tests/structural/build_structural_elem_2D.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/structural/build_structural_elem_2D.h
+++ b/tests/structural/build_structural_elem_2D.h
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/structural/internal_residual_sensitivity.cpp
+++ b/tests/structural/internal_residual_sensitivity.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/structural/jacobian_1D_and_2D.cpp
+++ b/tests/structural/jacobian_1D_and_2D.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/structural/jacobian_dot_sensitivity.cpp
+++ b/tests/structural/jacobian_dot_sensitivity.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/structural/membrane_extension_evaluation.cpp
+++ b/tests/structural/membrane_extension_evaluation.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/structural/piston_theory_1D_and_2D.cpp
+++ b/tests/structural/piston_theory_1D_and_2D.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/structural/plate_bending_evaluation.cpp
+++ b/tests/structural/plate_bending_evaluation.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/structural/plate_bending_evaluation_section_offset.cpp
+++ b/tests/structural/plate_bending_evaluation_section_offset.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/structural/plate_bending_evaluation_thermal_stress.cpp
+++ b/tests/structural/plate_bending_evaluation_thermal_stress.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/structural/plate_modal_analysis.cpp
+++ b/tests/structural/plate_modal_analysis.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/structural/plate_piston_theory_flutter.cpp
+++ b/tests/structural/plate_piston_theory_flutter.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/structural/plate_thermally_stressed_modal_analysis.cpp
+++ b/tests/structural/plate_thermally_stressed_modal_analysis.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/structural/plate_thermally_stressed_piston_theory_flutter.cpp
+++ b/tests/structural/plate_thermally_stressed_piston_theory_flutter.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/structural/solid_1D_section_property.cpp
+++ b/tests/structural/solid_1D_section_property.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/structural/stress_evaluations.cpp
+++ b/tests/structural/stress_evaluations.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/tests/structural/thermal_residual_sensitivity.cpp
+++ b/tests/structural/thermal_residual_sensitivity.cpp
@@ -1,6 +1,6 @@
 /*
  * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
- * Copyright (C) 2013-2018  Manav Bhatia
+ * Copyright (C) 2013-2019  Manav Bhatia
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public


### PR DESCRIPTION
- Updated documentation, installation instructions
- Modified doxygen configuration to create a navigation tree.

Currently, the installation instructions include installation on Mac OS using MacPorts to install dependencies, followed by installation from source of petsc, slepc, libmesh, mast. A second approach details installation of dependencies till libmesh using Spack and then installation of MAST from source. 

Longer term, I think we want to lean more heavily towards Spack, and I am not sure if we want to retain MacPorts page (although I don't think it hurts to have it here since I am using the MacPorts route on my laptop). 
