### PR TITLE
Bug-fixes for 1D and 2D structural examples.

### DIFF
--- a/doc/tutorials.dox
+++ b/doc/tutorials.dox
@@ -8,6 +8,7 @@
 
   - \subpage structural_example_1
   - \subpage structural_example_2
+  - \subpage structural_example_3
   - \subpage structural_example_5
   - \subpage fluid_example_1
   - \subpage fsi_example_1

--- a/examples/structural/CMakeLists.txt
+++ b/examples/structural/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(example_1) # bar extension
 add_subdirectory(example_2) # plate bending
+add_subdirectory(example_3) # tie constraints
 add_subdirectory(example_5) # 2D topology optimization
 

--- a/examples/structural/example_3/CMakeLists.txt
+++ b/examples/structural/example_3/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_executable(structural_example_3
+                example_3.cpp)
+
+target_link_libraries(structural_example_3 mast)
+
+install(TARGETS structural_example_3
+        RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/examples)

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -13,6 +13,8 @@ target_sources(mast
         ${CMAKE_CURRENT_LIST_DIR}/complex_mesh_field_function.h
         ${CMAKE_CURRENT_LIST_DIR}/constant_field_function.cpp
         ${CMAKE_CURRENT_LIST_DIR}/constant_field_function.h
+        ${CMAKE_CURRENT_LIST_DIR}/dof_coupling_base.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/dof_coupling_base.h
         ${CMAKE_CURRENT_LIST_DIR}/eigenproblem_assembly.cpp
         ${CMAKE_CURRENT_LIST_DIR}/eigenproblem_assembly.h
         ${CMAKE_CURRENT_LIST_DIR}/eigenproblem_assembly_elem_operations.cpp
@@ -24,7 +26,6 @@ target_sources(mast
         ${CMAKE_CURRENT_LIST_DIR}/function_base.h
         ${CMAKE_CURRENT_LIST_DIR}/function_set_base.cpp
         ${CMAKE_CURRENT_LIST_DIR}/function_set_base.h
-#        ${CMAKE_CURRENT_LIST_DIR}/mast_config.h.in
         ${CMAKE_CURRENT_LIST_DIR}/mast_data_types.h
         ${CMAKE_CURRENT_LIST_DIR}/mesh_field_function.cpp
         ${CMAKE_CURRENT_LIST_DIR}/mesh_field_function.h

--- a/src/base/assembly_base.cpp
+++ b/src/base/assembly_base.cpp
@@ -277,7 +277,7 @@ MAST::AssemblyBase::calculate_output(const libMesh::NumericVector<Real>& X,
         //    physics_elem->attach_active_solution_function(*_sol_function);
         
         MAST::GeomElem geom_elem;
-        output.set_elem_data(elem->dim(), geom_elem);
+        output.set_elem_data(elem->dim(), *elem, geom_elem);
         geom_elem.init(*elem, *_system);
         
         output.init(geom_elem);
@@ -356,7 +356,7 @@ calculate_output_derivative(const libMesh::NumericVector<Real>& X,
 //            physics_elem->attach_active_solution_function(*_sol_function);
         
         MAST::GeomElem geom_elem;
-        output.set_elem_data(elem->dim(), geom_elem);
+        output.set_elem_data(elem->dim(), *elem, geom_elem);
         geom_elem.init(*elem, *_system);
         
         output.init(geom_elem);
@@ -447,7 +447,7 @@ calculate_output_direct_sensitivity(const libMesh::NumericVector<Real>& X,
         //            physics_elem->attach_active_solution_function(*_sol_function);
         
         MAST::GeomElem geom_elem;
-        output.set_elem_data(elem->dim(), geom_elem);
+        output.set_elem_data(elem->dim(), *elem, geom_elem);
         geom_elem.init(*elem, *_system);
         
         output.init(geom_elem);

--- a/src/base/assembly_elem_operation.h
+++ b/src/base/assembly_elem_operation.h
@@ -92,6 +92,7 @@ namespace MAST {
          */
         virtual void
         set_elem_data(unsigned int dim,
+                      const libMesh::Elem& ref_elem,
                       MAST::GeomElem& elem) const = 0;
         
         /*!

--- a/src/base/complex_assembly_base.cpp
+++ b/src/base/complex_assembly_base.cpp
@@ -165,7 +165,7 @@ MAST::ComplexAssemblyBase::residual_l2_norm(const libMesh::NumericVector<Real>& 
         dof_map.dof_indices (elem, dof_indices);
         
         MAST::GeomElem geom_elem;
-        ops.set_elem_data(elem->dim(), geom_elem);
+        ops.set_elem_data(elem->dim(), *elem, geom_elem);
         geom_elem.init(*elem, *_system);
         
         ops.init(geom_elem);
@@ -312,7 +312,7 @@ residual_and_jacobian_field_split (const libMesh::NumericVector<Real>& X_R,
         dof_map.dof_indices (elem, dof_indices);
         
         MAST::GeomElem geom_elem;
-        ops.set_elem_data(elem->dim(), geom_elem);
+        ops.set_elem_data(elem->dim(), *elem, geom_elem);
         geom_elem.init(*elem, *_system);
         
         ops.init(geom_elem);
@@ -495,7 +495,7 @@ residual_and_jacobian_blocked (const libMesh::NumericVector<Real>& X,
         dof_map.dof_indices (elem, dof_indices);
         
         MAST::GeomElem geom_elem;
-        ops.set_elem_data(elem->dim(), geom_elem);
+        ops.set_elem_data(elem->dim(), *elem, geom_elem);
         geom_elem.init(*elem, *_system);
         
         ops.init(geom_elem);

--- a/src/base/dof_coupling_base.cpp
+++ b/src/base/dof_coupling_base.cpp
@@ -1,0 +1,33 @@
+/*
+ * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
+ * Copyright (C) 2013-2019  Manav Bhatia
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+// MAST includes
+#include "base/dof_coupling_base.h"
+
+
+MAST::DoFCouplingBase::DoFCouplingBase(MAST::SystemInitialization& sys_init):
+_system_init    (sys_init) {
+    
+}
+
+
+
+MAST::DoFCouplingBase::~DoFCouplingBase() {
+    
+}

--- a/src/base/dof_coupling_base.h
+++ b/src/base/dof_coupling_base.h
@@ -1,0 +1,69 @@
+/*
+ * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
+ * Copyright (C) 2013-2019  Manav Bhatia
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef __mast__dof_coupling_base_h__
+#define __mast__dof_coupling_base_h__
+
+// MAST includes
+#include "base/mast_data_types.h"
+
+// libMesh includes
+#include "libmesh/dof_map.h"
+
+
+namespace MAST {
+    
+    // Forward declerations
+    class SystemInitialization;
+    
+    /*!
+     *  This provides a base class to couple degrees-of-freedom within a single
+     *  system. This makes use of libMesh::DofConstraintRow as provided in
+     *  libMesh::DofMap. For the \f$ k^{th}\f$ dof , \f$ u_k \f$, the
+     *  libMesh::DofConstraintRow is defined as a linear equation
+     *  \f[ u_k + \sum_{i=0, i\neq k}^{n-1} a_{u_i} u_i = b_k, \f]
+     *  where, \f$ n \f$ is the number of degrees-of-freedom in the system.
+     *  Note that a DofConstraintRow only requires non-zero \f$ a_{u_i} \f$ to
+     *  be specified in the constraint.
+     */
+    
+    class DoFCouplingBase {
+
+    public:
+        
+        DoFCouplingBase(MAST::SystemInitialization& sys_init);
+        
+        virtual ~DoFCouplingBase();
+        
+        /*!.
+         * Provides the vector of constraints and right-hand-side value pairs
+         * to be added to the system.
+         */
+        virtual void
+        get_constraint_rows(std::vector<std::tuple<libMesh::dof_id_type, libMesh::DofConstraintRow, Real>>& constrs) = 0;
+        
+    protected:
+        
+        MAST::SystemInitialization& _system_init;
+    };
+    
+    
+}
+
+#endif // __mast__dof_coupling_base_h__

--- a/src/base/eigenproblem_assembly.cpp
+++ b/src/base/eigenproblem_assembly.cpp
@@ -137,7 +137,7 @@ eigenproblem_assemble(libMesh::SparseMatrix<Real>* A,
         dof_map.dof_indices (elem, dof_indices);
         
         MAST::GeomElem geom_elem;
-        ops.set_elem_data(elem->dim(), geom_elem);
+        ops.set_elem_data(elem->dim(), *elem, geom_elem);
         geom_elem.init(*elem, *_system);
         
         ops.init(geom_elem);
@@ -239,7 +239,7 @@ eigenproblem_sensitivity_assemble(const MAST::FunctionBase& f,
         dof_map.dof_indices (elem, dof_indices);
         
         MAST::GeomElem geom_elem;
-        ops.set_elem_data(elem->dim(), geom_elem);
+        ops.set_elem_data(elem->dim(), *elem, geom_elem);
         geom_elem.init(*elem, *_system);
         
         ops.init(geom_elem);

--- a/src/base/nonlinear_implicit_assembly.cpp
+++ b/src/base/nonlinear_implicit_assembly.cpp
@@ -114,7 +114,7 @@ residual_and_jacobian (const libMesh::NumericVector<Real>& X,
         dof_map.dof_indices (elem, dof_indices);
         
         MAST::GeomElem geom_elem;
-        ops.set_elem_data(elem->dim(), geom_elem);
+        ops.set_elem_data(elem->dim(), *elem, geom_elem);
         geom_elem.init(*elem, *_system);
         
         ops.init(geom_elem);
@@ -248,7 +248,7 @@ linearized_jacobian_solution_product (const libMesh::NumericVector<Real>& X,
         dof_map.dof_indices (elem, dof_indices);
         
         MAST::GeomElem geom_elem;
-        ops.set_elem_data(elem->dim(), geom_elem);
+        ops.set_elem_data(elem->dim(), *elem, geom_elem);
         geom_elem.init(*elem, *_system);
         
         ops.init(geom_elem);
@@ -361,7 +361,7 @@ second_derivative_dot_solution_assembly (const libMesh::NumericVector<Real>& X,
         dof_map.dof_indices (elem, dof_indices);
         
         MAST::GeomElem geom_elem;
-        ops.set_elem_data(elem->dim(), geom_elem);
+        ops.set_elem_data(elem->dim(), *elem, geom_elem);
         geom_elem.init(*elem, *_system);
         
         ops.init(geom_elem);
@@ -457,7 +457,7 @@ sensitivity_assemble (const MAST::FunctionBase& f,
         dof_map.dof_indices (elem, dof_indices);
         
         MAST::GeomElem geom_elem;
-        ops.set_elem_data(elem->dim(), geom_elem);
+        ops.set_elem_data(elem->dim(), *elem, geom_elem);
         geom_elem.init(*elem, *_system);
         
         ops.init(geom_elem);

--- a/src/base/physics_discipline_base.cpp
+++ b/src/base/physics_discipline_base.cpp
@@ -158,6 +158,17 @@ MAST::PhysicsDisciplineBase::get_property_card(const unsigned int sid) const {
 
 
 const MAST::ElementPropertyCardBase&
+MAST::PhysicsDisciplineBase::get_property_card(const libMesh::Elem& elem) const {
+    
+    MAST::PropertyCardMapType::const_iterator
+    elem_p_it = _element_property.find(elem.subdomain_id());
+    libmesh_assert(elem_p_it != _element_property.end());
+    
+    return *elem_p_it->second;
+}
+
+
+const MAST::ElementPropertyCardBase&
 MAST::PhysicsDisciplineBase::get_property_card(const MAST::GeomElem& elem) const {
     
     MAST::PropertyCardMapType::const_iterator

--- a/src/base/physics_discipline_base.h
+++ b/src/base/physics_discipline_base.h
@@ -196,6 +196,11 @@ namespace MAST {
         /*!
          *    get property card for the specified element
          */
+        const MAST::ElementPropertyCardBase& get_property_card(const libMesh::Elem& elem) const;
+
+        /*!
+         *    get property card for the specified element
+         */
         const MAST::ElementPropertyCardBase& get_property_card(const MAST::GeomElem& elem) const;
         
         /*!

--- a/src/base/transient_assembly.cpp
+++ b/src/base/transient_assembly.cpp
@@ -109,7 +109,7 @@ residual_and_jacobian (const libMesh::NumericVector<Real>& X,
         dof_map.dof_indices (elem, dof_indices);
         
         MAST::GeomElem geom_elem;
-        solver.set_elem_data(elem->dim(), geom_elem);
+        solver.set_elem_data(elem->dim(), *elem, geom_elem);
         geom_elem.init(*elem, *_system);
         
         solver.init(geom_elem);
@@ -222,7 +222,7 @@ linearized_jacobian_solution_product (const libMesh::NumericVector<Real>& X,
         dof_map.dof_indices (elem, dof_indices);
 
         MAST::GeomElem geom_elem;
-        _elem_ops->set_elem_data(elem->dim(), geom_elem);
+        _elem_ops->set_elem_data(elem->dim(), *elem, geom_elem);
         geom_elem.init(*elem, *_system);
         
         _elem_ops->init(geom_elem);
@@ -319,7 +319,7 @@ sensitivity_assemble (const MAST::FunctionBase& f,
         dof_map.dof_indices (elem, dof_indices);
         
         MAST::GeomElem geom_elem;
-        _elem_ops->set_elem_data(elem->dim(), geom_elem);
+        _elem_ops->set_elem_data(elem->dim(), *elem, geom_elem);
         geom_elem.init(*elem, *_system);
         
         _elem_ops->init(geom_elem);

--- a/src/elasticity/CMakeLists.txt
+++ b/src/elasticity/CMakeLists.txt
@@ -12,6 +12,10 @@ target_sources(mast
         ${CMAKE_CURRENT_LIST_DIR}/fluid_structure_assembly_elem_operations.h
         ${CMAKE_CURRENT_LIST_DIR}/fsi_generalized_aero_force_assembly.cpp
         ${CMAKE_CURRENT_LIST_DIR}/fsi_generalized_aero_force_assembly.h
+        ${CMAKE_CURRENT_LIST_DIR}/kinematic_coupling_constraint.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/kinematic_coupling_constraint.h
+        ${CMAKE_CURRENT_LIST_DIR}/kinematic_coupling.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/kinematic_coupling.h
         ${CMAKE_CURRENT_LIST_DIR}/level_set_stress_assembly.cpp
         ${CMAKE_CURRENT_LIST_DIR}/level_set_stress_assembly.h
         ${CMAKE_CURRENT_LIST_DIR}/mindlin_bending_operator.cpp

--- a/src/elasticity/fluid_structure_assembly_elem_operations.cpp
+++ b/src/elasticity/fluid_structure_assembly_elem_operations.cpp
@@ -45,6 +45,7 @@ MAST::FluidStructureAssemblyElemOperations::~FluidStructureAssemblyElemOperation
 void
 MAST::FluidStructureAssemblyElemOperations::
 set_elem_data(unsigned int dim,
+              const libMesh::Elem& ref_elem,
               MAST::GeomElem& elem) const {
     
     libmesh_assert(!_physics_elem);
@@ -52,7 +53,7 @@ set_elem_data(unsigned int dim,
     if (dim == 1) {
         
         const MAST::ElementPropertyCard1D& p =
-        dynamic_cast<const MAST::ElementPropertyCard1D&>(_discipline->get_property_card(elem));
+        dynamic_cast<const MAST::ElementPropertyCard1D&>(_discipline->get_property_card(ref_elem));
         
         elem.set_local_y_vector(p.y_vector());
     }

--- a/src/elasticity/fluid_structure_assembly_elem_operations.h
+++ b/src/elasticity/fluid_structure_assembly_elem_operations.h
@@ -44,6 +44,7 @@ namespace MAST {
          */
         virtual void
         set_elem_data(unsigned int dim,
+                      const libMesh::Elem& ref_elem,
                       MAST::GeomElem& elem) const;
 
         /*!

--- a/src/elasticity/fsi_generalized_aero_force_assembly.cpp
+++ b/src/elasticity/fsi_generalized_aero_force_assembly.cpp
@@ -205,7 +205,7 @@ assemble_generalized_aerodynamic_force_matrix
             dof_map.dof_indices (elem, dof_indices);
             
             MAST::GeomElem geom_elem;
-            ops.set_elem_data(elem->dim(), geom_elem);
+            ops.set_elem_data(elem->dim(), *elem, geom_elem);
             geom_elem.init(*elem, *_system);
             
             ops.init(geom_elem);

--- a/src/elasticity/kinematic_coupling.cpp
+++ b/src/elasticity/kinematic_coupling.cpp
@@ -1,0 +1,121 @@
+/*
+ * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
+ * Copyright (C) 2013-2019  Manav Bhatia
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+//MAST includes
+#include "elasticity/kinematic_coupling.h"
+#include "elasticity/kinematic_coupling_constraint.h"
+#include "base/system_initialization.h"
+#include "base/nonlinear_system.h"
+#include "mesh/mesh_coupling_base.h"
+
+// libMesh includes
+#include "libmesh/dof_map.h"
+
+
+MAST::KinematicCoupling::KinematicCoupling(MAST::SystemInitialization& sys_init):
+MAST::DoFCouplingBase(sys_init),
+_initialized   (false) {
+    
+}
+
+
+MAST::KinematicCoupling::~KinematicCoupling() {
+    
+    std::map<const libMesh::Node*, const MAST::KinematicCouplingConstraint*>::const_iterator
+    it   = _slave_node_constraints.begin(),
+    end  = _slave_node_constraints.end();
+
+    for ( ; it != end; it++)
+        delete it->second;
+}
+
+
+
+void
+MAST::KinematicCoupling::
+add_master_and_slave
+(std::vector<std::pair<const libMesh::Node*, std::set<const libMesh::Node*>>>& couplings,
+ bool constrain_rotations) {
+    
+    for (unsigned int i=0; i<couplings.size(); i++)
+        this->add_master_and_slave(couplings[i].second,
+                                   *couplings[i].first,
+                                   constrain_rotations);
+}
+
+
+void
+MAST::KinematicCoupling::
+add_master_and_slave(std::set<const libMesh::Node*>& master,
+                     const libMesh::Node&            slave,
+                     bool                            constrain_rotations) {
+    
+    libmesh_assert(!_initialized);
+    libmesh_assert(!_slave_node_constraints.count(&slave));
+    
+    MAST::KinematicCouplingConstraint
+    *constr = new MAST::KinematicCouplingConstraint(_system_init,
+                                                    slave,
+                                                    master,
+                                                    constrain_rotations);
+    
+    _slave_node_constraints[&slave] = constr;
+}
+
+
+
+void
+MAST::KinematicCoupling::
+get_constraint_rows
+(std::vector<std::tuple<libMesh::dof_id_type, libMesh::DofConstraintRow, Real>>& constrs) {
+
+    // iterate over all the nodes in the map and initialize their constraints
+    constrs.clear();
+
+    std::map<const libMesh::Node*, const MAST::KinematicCouplingConstraint*>::const_iterator
+    it   = _slave_node_constraints.begin(),
+    end  = _slave_node_constraints.end();
+    
+    unsigned int
+    idx  = 0;
+    
+    for ( ; it != end; it++)
+        idx += it->second->n_constrain_nodes();
+
+    constrs.resize(idx);
+
+    it   = _slave_node_constraints.begin();
+    
+    for ( ; it != end; it++) {
+        
+        std::vector<std::tuple<libMesh::dof_id_type, libMesh::DofConstraintRow, Real>>
+        constraints;
+        
+        it->second->get_dof_constraint_row(constraints);
+        
+        for (unsigned int i=0; i<constrs.size(); i++)
+            constrs.push_back(constraints[i]);
+    }
+
+    libmesh_assert_equal_to(constrs.size(), idx);
+    
+    // set the flag so that new slave-master sets cannot be added
+    _initialized = true;
+}
+

--- a/src/elasticity/kinematic_coupling.h
+++ b/src/elasticity/kinematic_coupling.h
@@ -1,0 +1,92 @@
+/*
+ * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
+ * Copyright (C) 2013-2019  Manav Bhatia
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef __mast__kinematic_coupling_h__
+#define __mast__kinematic_coupling_h__
+
+
+// C++ includes
+#include <set>
+#include <map>
+
+// MAST includes
+#include "base/dof_coupling_base.h"
+
+// libMesh includes
+#include "libmesh/node.h"
+
+namespace MAST {
+    
+    // Forward declerations
+    class KinematicCouplingConstraint;
+    class MeshCouplingBase;
+    
+    /*!
+     *  This constrains the slave nodes to be kinematically constrained
+     *  to the master node. 
+     */
+     
+    class KinematicCoupling:
+    public MAST::DoFCouplingBase {
+
+    public:
+        
+        KinematicCoupling(MAST::SystemInitialization& sys_init);
+        
+        virtual ~KinematicCoupling();
+
+        /*!
+         *   Constrain the slave node to the specified set of master nodes.
+         *   A geometric relation is used to compute the weights for each
+         *   master dof. If \p constrain_rotations is \p true then the
+         *   rotations of the slave nodes are constrained to those of the master
+         *   nodes. Otherwise, the constraint acts as a pinned connection.
+         */
+        void
+        add_master_and_slave(std::set<const libMesh::Node*>& master,
+                             const libMesh::Node&            slave,
+                             bool                            constrain_rotations);
+        
+
+        /*!
+         *   provides a vector of the pair of slave and set of master nodes.
+         */
+        void
+        add_master_and_slave
+        (std::vector<std::pair<const libMesh::Node*, std::set<const libMesh::Node*>>>& couplings,
+         bool constrain_rotations);
+        
+        
+        /*!
+         * Provides the vector of constraints and right-hand-side value pairs
+         * to be added to the system.
+         */
+        virtual void
+        get_constraint_rows(std::vector<std::tuple<libMesh::dof_id_type, libMesh::DofConstraintRow, Real>>& constrs);
+
+        
+    protected:
+        
+        bool _initialized;
+        
+        std::map<const libMesh::Node*, const MAST::KinematicCouplingConstraint*> _slave_node_constraints;
+    };
+}
+
+#endif // __mast__kinematic_coupling_h__

--- a/src/elasticity/kinematic_coupling_constraint.cpp
+++ b/src/elasticity/kinematic_coupling_constraint.cpp
@@ -1,0 +1,180 @@
+/*
+ * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
+ * Copyright (C) 2013-2019  Manav Bhatia
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+// MAST includes
+#include "elasticity/kinematic_coupling_constraint.h"
+#include "base/system_initialization.h"
+#include "base/nonlinear_system.h"
+
+
+MAST::KinematicCouplingConstraint::
+KinematicCouplingConstraint(MAST::SystemInitialization& sys_init,
+                            const libMesh::Node& slave_node,
+                            std::set<const libMesh::Node*>& master_nodes,
+                            bool constrain_rotations):
+_sys_init              (sys_init),
+_slave                 (&slave_node),
+_masters               (master_nodes),
+_constrain_rotations   (constrain_rotations) {
+    
+}
+
+
+MAST::KinematicCouplingConstraint::~KinematicCouplingConstraint() {
+    
+}
+
+
+void
+MAST::KinematicCouplingConstraint::
+get_dof_constraint_row(std::vector<std::tuple
+                       <libMesh::dof_id_type, libMesh::DofConstraintRow,Real>>& constraints) const {
+    
+    
+    constraints.clear();
+    
+    libMesh::DofMap& dof_map = _sys_init.system().get_dof_map();
+
+    std::vector<libMesh::dof_id_type>
+    slave_dofs;
+
+    // master nodes, their dofs and weights
+    std::map<const libMesh::Node*, std::pair<std::vector<libMesh::dof_id_type>, Real>>
+    master_node_data; // master dofs of all nodes
+
+    
+    // get dofs for all the nodes
+    dof_map.dof_indices(_slave, slave_dofs);
+
+    std::set<const libMesh::Node*>::const_iterator
+    n_it   = _masters.begin(),
+    n_end  = _masters.end();
+    
+    libMesh::Point dx;
+    
+    std::map<const libMesh::Node*, Real> weights;
+    
+    Real
+    sum = 0.,
+    val = 0.;
+    
+    // compute the position vectors for nodal weight
+    for ( ; n_it != n_end; n_it++ ) {
+
+        const libMesh::Node* nd = *n_it;
+
+        dx   = *_slave - *nd;
+        
+        // exponential function, so that closer nodes are more influential
+        // than distant nodes.
+        val  = exp(-dx.norm());
+        sum += val;
+        
+        weights[nd] = val;
+    }
+    
+    // now compute the constraint data
+    n_it   = _masters.begin();
+    
+    for ( ; n_it != n_end; n_it++ ) {
+        
+        const libMesh::Node* nd = *n_it;
+
+        std::pair<std::vector<libMesh::dof_id_type>, Real> dofs_wt_pair;
+        dof_map.dof_indices(nd, dofs_wt_pair.first);
+        // divide by sum so that all weights sum to a value of 1.
+        dofs_wt_pair.second = weights[nd]/sum;
+        
+        master_node_data[nd] = dofs_wt_pair;
+    }
+
+    // now initialize the vector with constraint data. This assumes that dof_ids
+    // for all nodes have the same sequence: ux, uy, uz, tx, ty, tz
+    unsigned int
+    dofs_to_constrain = _constrain_rotations?6:3,
+    idx               = 0;
+
+    constraints.resize(dofs_to_constrain);
+    
+    // the translation and rotation dofs both share a common code, except
+    // translation constraints require a contribution from the rotational dofs
+    for (unsigned int i=0; i<dofs_to_constrain; i++) {
+        
+        // dof id of ith variable for slave node
+        std::get<0>(constraints[i]) = slave_dofs[i];
+        
+        // rhs of the constraint is zero
+        std::get<2>(constraints[i]) = 0.;
+        
+        libMesh::DofConstraintRow&
+        c_row = std::get<1>(constraints[i]);
+        
+        std::map<const libMesh::Node*,
+        std::pair<std::vector<libMesh::dof_id_type>, Real>>::const_iterator
+        master_nd_it   = master_node_data.begin(),
+        master_nd_end  = master_node_data.end();
+        
+        for ( ; master_nd_it != master_nd_end; master_nd_it++) {
+            
+            dx = *_slave - *master_nd_it->first;
+            
+            const std::vector<libMesh::dof_id_type>
+            &master_dofs = master_nd_it->second.first;
+            
+            // dof id of the i^th var on the master node
+            idx = master_dofs[i];
+            val = master_nd_it->second.second; // weight for this node
+            
+            // add constraints with rotational dofs of all nodes
+            // -1 is used since the constraint reads
+            //     slave dof = avg of master dofs
+            // or, slave dof - avg of master dofs = 0
+            c_row[idx] = -val;
+            
+            // for translation dofs a contribution is needed from the
+            // rotation of the master nodes
+            if (i<3) {
+                
+                switch (i) {
+                    case 0: {
+                        // index of the rotational dof of the master node
+                        c_row[master_dofs[4]]  = -dx(2) * val; //  theta_y * dz
+                        c_row[master_dofs[5]]  =  dx(1) * val; // -theta_z * dy
+                    }
+                        break;
+                        
+                    case 1: {
+                        // index of the rotational dof of the master node
+                        c_row[master_dofs[3]]  = -dx(2) * val; //  theta_x * dz
+                        c_row[master_dofs[5]]  =  dx(0) * val; // -theta_z * dx
+                    }
+                        break;
+
+                    case 2: {
+                        // index of the rotational dof of the master node
+                        c_row[master_dofs[3]]  = -dx(1) * val; //  theta_x * dy
+                        c_row[master_dofs[4]]  =  dx(0) * val; // -theta_y * dx
+                    }
+                        break;
+                }
+            }
+        }
+    }
+}
+

--- a/src/elasticity/kinematic_coupling_constraint.h
+++ b/src/elasticity/kinematic_coupling_constraint.h
@@ -1,0 +1,110 @@
+/*
+ * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
+ * Copyright (C) 2013-2019  Manav Bhatia
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef __mast__kinematic_coupling_constraint_h__
+#define __mast__kinematic_coupling_constraint_h__
+
+// MAST includes
+#include "base/mast_data_types.h"
+
+// libMesh includes
+#include "libmesh/node.h"
+#include "libmesh/dof_map.h"
+
+
+namespace MAST {
+
+    // Forward declerations
+    class SystemInitialization;
+
+    /*!
+     *  This object stores the information about the coupling of nodes.
+     *  A slave node can be constrained to one or more nodes and the rotations
+     *  of the slave can be constrained (set equal to) the rotation of
+     *  the master node. In case more than one master nodes are specified, then
+     *  the coefficients in the constraint equation are weighted based on
+     *  inverse relationship with the geometric distance and partition-of-unity.
+     *
+     *  The constraints are defined such that the displacement of the slave nodes
+     *  is identified as
+     *  \f[  u_s = u_m + \theta \times (X_s - X_m),   \f]
+     *  where, \f$ \theta \f$ is the rotation vector
+     *  \f$(\theta_x, \theta_y, \theta_z)\f$,
+     *  \f$ u_s \f$ and \f$ X_s \f$ are the translation and location
+     *  of the slave nodes, respectively, and likewise for the master node
+     *  with subscript \f$ (\cdot)_m \f$. Note, that the rotations of the
+     *  slave node are not constrained to those of the master node. The
+     *  cross product is written as
+     *  \f{eqnarray*}{ \theta \times dX
+     *  & = & \left| \begin{array}{ccc}
+     *           \hat{i} & \hat{j} & \hat{k} \\
+     *           \theta_x & \theta_y & \theta_z \\
+     *           dx & dy & dz
+     *        \end{array} \right| \\
+     *  & = &    \hat{i} (\theta_y dz - \theta_z dy)
+     *         - \hat{j} (\theta_x dz - \theta_z dx)
+     *         + \hat{k} (\theta_x dy - \theta_y dx)
+     *  \f}
+     *   Therefore, the constraint for displacement along the x-axis is
+     *  \f[ u_{xs} = u_{xm} + (\theta_y dz - \theta_z dy),  \f]
+     *   for displacement along the y-axis,
+     *  \f[ u_{ys} = u_{ym} + (\theta_x dz - \theta_z dx),  \f]
+     *   and for displacement along the z-axis,
+     *  \f[ u_{zs} = u_{zm} + (\theta_x dy - \theta_y dx).  \f]
+     */
+    class KinematicCouplingConstraint {
+      
+    public:
+        
+        KinematicCouplingConstraint(MAST::SystemInitialization& sys_init,
+                                    const libMesh::Node& slave_node,
+                                    std::set<const libMesh::Node*>& master_nodes,
+                                    bool constrain_rotations);
+        
+        virtual ~KinematicCouplingConstraint();
+
+        /*!
+         *  @return the number of constraints that will be added from this object
+         */
+        unsigned int
+        n_constrain_nodes() const {
+            
+            return _constrain_rotations?6:3;
+        }
+
+        /*!
+         *   initializes the vector of \p libMesh::DofConstraintRow objects
+         *   and rhs values for this node
+         */
+        void
+        get_dof_constraint_row(std::vector<std::tuple
+                               <libMesh::dof_id_type,
+                               libMesh::DofConstraintRow,
+                               Real>>& constraints) const;
+        
+    protected:
+        
+        MAST::SystemInitialization&    _sys_init;
+        const libMesh::Node*           _slave;
+        std::set<const libMesh::Node*> _masters;
+        bool                           _constrain_rotations;
+    };
+}
+
+#endif // __mast__kinematic_coupling_constraint_h__

--- a/src/elasticity/level_set_stress_assembly.cpp
+++ b/src/elasticity/level_set_stress_assembly.cpp
@@ -176,7 +176,7 @@ update_stress_strain_data(MAST::StressStrainOutputBase&       ops,
                 
                 const libMesh::Elem* sub_elem = *hi_sub_elem_it;
                 MAST::LevelSetIntersectedElem geom_elem;
-                ops.set_elem_data(elem->dim(), geom_elem);
+                ops.set_elem_data(elem->dim(), *elem, geom_elem);
                 geom_elem.init(*sub_elem, *_system, *_intersection);
                 
                 // clear before calculating the data

--- a/src/elasticity/stress_assembly.cpp
+++ b/src/elasticity/stress_assembly.cpp
@@ -162,7 +162,7 @@ update_stress_strain_data(MAST::StressStrainOutputBase&       ops,
         // clear before calculating the data
         ops.clear();
         MAST::GeomElem geom_elem;
-        ops.set_elem_data(elem->dim(), geom_elem);
+        ops.set_elem_data(elem->dim(), *elem, geom_elem);
         geom_elem.init(*elem, *_system);
         
         ops.init(geom_elem);
@@ -298,7 +298,7 @@ update_stress_strain_sensitivity_data(MAST::StressStrainOutputBase&       ops,
         // presence of stress data, which is cleared after each element.
         ops.clear();
         MAST::GeomElem geom_elem;
-        ops.set_elem_data(elem->dim(), geom_elem);
+        ops.set_elem_data(elem->dim(), *elem, geom_elem);
         geom_elem.init(*elem, *_system);
         
         ops.init(geom_elem);

--- a/src/elasticity/stress_output_base.cpp
+++ b/src/elasticity/stress_output_base.cpp
@@ -439,6 +439,7 @@ MAST::StressStrainOutputBase::output_derivative_for_elem(RealVectorX& dq_dX) {
 void
 MAST::StressStrainOutputBase::
 set_elem_data(unsigned int dim,
+              const libMesh::Elem& ref_elem,
               MAST::GeomElem& elem) const {
     
     libmesh_assert(!_physics_elem);
@@ -446,7 +447,7 @@ set_elem_data(unsigned int dim,
     if (dim == 1) {
         
         const MAST::ElementPropertyCard1D& p =
-        dynamic_cast<const MAST::ElementPropertyCard1D&>(_discipline->get_property_card(elem));
+        dynamic_cast<const MAST::ElementPropertyCard1D&>(_discipline->get_property_card(ref_elem));
         
         elem.set_local_y_vector(p.y_vector());
     }

--- a/src/elasticity/stress_output_base.h
+++ b/src/elasticity/stress_output_base.h
@@ -267,6 +267,7 @@ namespace MAST {
          */
         virtual void
         set_elem_data(unsigned int dim,
+                      const libMesh::Elem& ref_elem,
                       MAST::GeomElem& elem) const;
 
         /*!

--- a/src/elasticity/structural_assembly.cpp
+++ b/src/elasticity/structural_assembly.cpp
@@ -218,7 +218,7 @@ MAST::StructuralAssembly::update_incompatible_solution(libMesh::NumericVector<Re
         MAST::AssemblyElemOperations& ops = _assembly->get_elem_ops();
         
         MAST::GeomElem geom_elem;
-        ops.set_elem_data(elem->dim(), geom_elem);
+        ops.set_elem_data(elem->dim(), *elem, geom_elem);
         geom_elem.init(*elem, _assembly->system_init());
         
         ops.init(geom_elem);

--- a/src/elasticity/structural_buckling_eigenproblem_assembly.cpp
+++ b/src/elasticity/structural_buckling_eigenproblem_assembly.cpp
@@ -157,7 +157,7 @@ eigenproblem_assemble(libMesh::SparseMatrix<Real> *A,
             sol(i) = (*localized_solution1)(dof_indices[i]);
     
         MAST::GeomElem geom_elem;
-        ops.set_elem_data(elem->dim(), geom_elem);
+        ops.set_elem_data(elem->dim(), *elem, geom_elem);
         geom_elem.init(*elem, *_system);
         
         ops.init(geom_elem);

--- a/src/elasticity/structural_buckling_eigenproblem_elem_operations.cpp
+++ b/src/elasticity/structural_buckling_eigenproblem_elem_operations.cpp
@@ -44,6 +44,7 @@ MAST::StructuralBucklingEigenproblemElemOperations::
 void
 MAST::StructuralBucklingEigenproblemElemOperations::
 set_elem_data(unsigned int dim,
+              const libMesh::Elem& ref_elem,
               MAST::GeomElem& elem) const {
     
     libmesh_assert(!_physics_elem);
@@ -51,7 +52,7 @@ set_elem_data(unsigned int dim,
     if (dim == 1) {
         
         const MAST::ElementPropertyCard1D& p =
-        dynamic_cast<const MAST::ElementPropertyCard1D&>(_discipline->get_property_card(elem));
+        dynamic_cast<const MAST::ElementPropertyCard1D&>(_discipline->get_property_card(ref_elem));
         
         elem.set_local_y_vector(p.y_vector());
     }

--- a/src/elasticity/structural_buckling_eigenproblem_elem_operations.h
+++ b/src/elasticity/structural_buckling_eigenproblem_elem_operations.h
@@ -42,6 +42,7 @@ namespace MAST {
          */
         virtual void
         set_elem_data(unsigned int dim,
+                      const libMesh::Elem& ref_elem,
                       MAST::GeomElem& elem) const;
 
         /*!

--- a/src/elasticity/structural_element_base.cpp
+++ b/src/elasticity/structural_element_base.cpp
@@ -1539,7 +1539,8 @@ transform_matrix_to_global_system(const ValType& local_mat,
     
     if (_elem.use_local_elem()) {
         
-        const unsigned int n_dofs = local_mat.rows();
+        // assuming same shape function for all 6 dofs.
+        const unsigned int n_dofs = local_mat.rows()/6;
         
         ValType mat(6*n_dofs, 6*n_dofs);
         
@@ -1576,7 +1577,8 @@ transform_vector_to_local_system(const ValType& global_vec,
     
     if (_elem.use_local_elem()) {
 
-        const unsigned int n_dofs = global_vec.size();
+        // assuming same shape function for all 6 dofs.
+        const unsigned int n_dofs = global_vec.size()/6;
         RealMatrixX mat  = RealMatrixX::Zero(6*n_dofs, 6*n_dofs);
         
         local_vec.setZero();
@@ -1611,7 +1613,8 @@ transform_vector_to_global_system(const ValType& local_vec,
     
     if (_elem.use_local_elem()) {
         
-        const unsigned int n_dofs = local_vec.size();
+        // assuming same shape function for all 6 dofs.
+        const unsigned int n_dofs = local_vec.size()/6;
         
         RealMatrixX mat  = RealMatrixX::Zero(6*n_dofs, 6*n_dofs);
         

--- a/src/elasticity/structural_fluid_interaction_assembly.cpp
+++ b/src/elasticity/structural_fluid_interaction_assembly.cpp
@@ -184,7 +184,7 @@ assemble_reduced_order_quantity
         //            physics_elem->attach_active_solution_function(*_sol_function);
         
         MAST::GeomElem geom_elem;
-        _elem_ops->set_elem_data(elem->dim(), geom_elem);
+        _elem_ops->set_elem_data(elem->dim(), *elem, geom_elem);
         geom_elem.init(*elem, *_system);
         
         _elem_ops->init(geom_elem);
@@ -320,7 +320,7 @@ assemble_reduced_order_quantity_sensitivity
         basis_mat.setZero(ndofs, n_basis);
         
         MAST::GeomElem geom_elem;
-        _elem_ops->set_elem_data(elem->dim(), geom_elem);
+        _elem_ops->set_elem_data(elem->dim(), *elem, geom_elem);
         geom_elem.init(*elem, *_system);
         _elem_ops->init(geom_elem);
         

--- a/src/elasticity/structural_modal_eigenproblem_assembly.cpp
+++ b/src/elasticity/structural_modal_eigenproblem_assembly.cpp
@@ -214,6 +214,7 @@ elem_topology_sensitivity_calculations(const MAST::FunctionBase& f,
 void
 MAST::StructuralModalEigenproblemAssemblyElemOperations::
 set_elem_data(unsigned int dim,
+              const libMesh::Elem& ref_elem,
               MAST::GeomElem& elem) const {
     
     libmesh_assert(!_physics_elem);
@@ -221,7 +222,7 @@ set_elem_data(unsigned int dim,
     if (dim == 1) {
         
         const MAST::ElementPropertyCard1D& p =
-        dynamic_cast<const MAST::ElementPropertyCard1D&>(_discipline->get_property_card(elem));
+        dynamic_cast<const MAST::ElementPropertyCard1D&>(_discipline->get_property_card(ref_elem));
         
         elem.set_local_y_vector(p.y_vector());
     }

--- a/src/elasticity/structural_modal_eigenproblem_assembly.h
+++ b/src/elasticity/structural_modal_eigenproblem_assembly.h
@@ -102,7 +102,9 @@ namespace MAST {
          *   sets the structural element y-vector if 1D element is used.
          */
         virtual void
-        set_elem_data(unsigned int dim, MAST::GeomElem& elem) const;
+        set_elem_data(unsigned int dim,
+                      const libMesh::Elem& ref_elem,
+                      MAST::GeomElem& elem) const;
 
         /*!
          *   initializes the object for the geometric element \p elem. This

--- a/src/elasticity/structural_nonlinear_assembly.cpp
+++ b/src/elasticity/structural_nonlinear_assembly.cpp
@@ -74,6 +74,7 @@ MAST::StructuralNonlinearAssemblyElemOperations::set_elem_solution(const RealVec
 void
 MAST::StructuralNonlinearAssemblyElemOperations::
 set_elem_data(unsigned int dim,
+              const libMesh::Elem& ref_elem,
               MAST::GeomElem& elem) const {
     
     libmesh_assert(!_physics_elem);
@@ -81,7 +82,7 @@ set_elem_data(unsigned int dim,
     if (dim == 1) {
         
         const MAST::ElementPropertyCard1D& p =
-        dynamic_cast<const MAST::ElementPropertyCard1D&>(_discipline->get_property_card(elem));
+        dynamic_cast<const MAST::ElementPropertyCard1D&>(_discipline->get_property_card(ref_elem));
         
         elem.set_local_y_vector(p.y_vector());
     }

--- a/src/elasticity/structural_nonlinear_assembly.h
+++ b/src/elasticity/structural_nonlinear_assembly.h
@@ -126,6 +126,7 @@ namespace MAST {
          */
         virtual void
         set_elem_data(unsigned int dim,
+                      const libMesh::Elem& ref_elem,
                       MAST::GeomElem& elem) const;
 
         /*!

--- a/src/elasticity/structural_transient_assembly.cpp
+++ b/src/elasticity/structural_transient_assembly.cpp
@@ -216,6 +216,7 @@ elem_second_derivative_dot_solution_assembly(RealMatrixX& m) {
 void
 MAST::StructuralTransientAssemblyElemOperations::
 set_elem_data(unsigned int dim,
+              const libMesh::Elem& ref_elem,
               MAST::GeomElem& elem) const {
     
     libmesh_assert(!_physics_elem);
@@ -223,7 +224,7 @@ set_elem_data(unsigned int dim,
     if (dim == 1) {
         
         const MAST::ElementPropertyCard1D& p =
-        dynamic_cast<const MAST::ElementPropertyCard1D&>(_discipline->get_property_card(elem));
+        dynamic_cast<const MAST::ElementPropertyCard1D&>(_discipline->get_property_card(ref_elem));
         
         elem.set_local_y_vector(p.y_vector());
     }

--- a/src/elasticity/structural_transient_assembly.h
+++ b/src/elasticity/structural_transient_assembly.h
@@ -110,6 +110,7 @@ namespace MAST {
          */
         virtual void
         set_elem_data(unsigned int dim,
+                      const libMesh::Elem& ref_elem,
                       MAST::GeomElem& elem) const;
 
 

--- a/src/fluid/conservative_fluid_transient_assembly.h
+++ b/src/fluid/conservative_fluid_transient_assembly.h
@@ -114,6 +114,7 @@ namespace MAST {
          */
         virtual void
         set_elem_data(unsigned int dim,
+                      const libMesh::Elem& ref_elem,
                       MAST::GeomElem& elem) const { }
 
         /*!

--- a/src/fluid/frequency_domain_linearized_complex_assembly.h
+++ b/src/fluid/frequency_domain_linearized_complex_assembly.h
@@ -83,6 +83,7 @@ namespace MAST {
          */
         virtual void
         set_elem_data(unsigned int dim,
+                      const libMesh::Elem& ref_elem,
                       MAST::GeomElem& elem) const { }
 
         /*!

--- a/src/fluid/integrated_force_output.h
+++ b/src/fluid/integrated_force_output.h
@@ -40,6 +40,7 @@ namespace MAST {
          */
         virtual void
         set_elem_data(unsigned int dim,
+                      const libMesh::Elem& ref_elem,
                       MAST::GeomElem& elem) const {}
 
         /*!

--- a/src/heat_conduction/heat_conduction_nonlinear_assembly.cpp
+++ b/src/heat_conduction/heat_conduction_nonlinear_assembly.cpp
@@ -44,6 +44,7 @@ MAST::HeatConductionNonlinearAssemblyElemOperations::
 void
 MAST::HeatConductionNonlinearAssemblyElemOperations::
 set_elem_data(unsigned int dim,
+              const libMesh::Elem& ref_elem,
               MAST::GeomElem& elem) const {
     
     libmesh_assert(!_physics_elem);
@@ -51,7 +52,7 @@ set_elem_data(unsigned int dim,
     if (dim == 1) {
         
         const MAST::ElementPropertyCard1D& p =
-        dynamic_cast<const MAST::ElementPropertyCard1D&>(_discipline->get_property_card(elem));
+        dynamic_cast<const MAST::ElementPropertyCard1D&>(_discipline->get_property_card(ref_elem));
         
         elem.set_local_y_vector(p.y_vector());
     }

--- a/src/heat_conduction/heat_conduction_nonlinear_assembly.h
+++ b/src/heat_conduction/heat_conduction_nonlinear_assembly.h
@@ -101,6 +101,7 @@ namespace MAST {
          */
         virtual void
         set_elem_data(unsigned int dim,
+                      const libMesh::Elem& ref_elem,
                       MAST::GeomElem& elem) const;
 
         /*!

--- a/src/heat_conduction/heat_conduction_transient_assembly.cpp
+++ b/src/heat_conduction/heat_conduction_transient_assembly.cpp
@@ -105,6 +105,7 @@ elem_second_derivative_dot_solution_assembly(RealMatrixX& m) {
 void
 MAST::HeatConductionTransientAssemblyElemOperations::
 set_elem_data(unsigned int dim,
+              const libMesh::Elem& ref_elem,
               MAST::GeomElem& elem) const {
     
     libmesh_assert(!_physics_elem);
@@ -112,7 +113,7 @@ set_elem_data(unsigned int dim,
     if (dim == 1) {
         
         const MAST::ElementPropertyCard1D& p =
-        dynamic_cast<const MAST::ElementPropertyCard1D&>(_discipline->get_property_card(elem));
+        dynamic_cast<const MAST::ElementPropertyCard1D&>(_discipline->get_property_card(ref_elem));
         
         elem.set_local_y_vector(p.y_vector());
     }

--- a/src/heat_conduction/heat_conduction_transient_assembly.h
+++ b/src/heat_conduction/heat_conduction_transient_assembly.h
@@ -105,6 +105,7 @@ namespace MAST {
          */
         virtual void
         set_elem_data(unsigned int dim,
+                      const libMesh::Elem& ref_elem,
                       MAST::GeomElem& elem) const;
 
         /*!

--- a/src/level_set/level_set_eigenproblem_assembly.cpp
+++ b/src/level_set/level_set_eigenproblem_assembly.cpp
@@ -197,7 +197,7 @@ eigenproblem_assemble(libMesh::SparseMatrix<Real>* A,
                 //const libMesh::Elem* sub_elem = *hi_sub_elem_it;
                 
                 MAST::GeomElem geom_elem;
-                ops.set_elem_data(elem->dim(), geom_elem);
+                ops.set_elem_data(elem->dim(), *elem, geom_elem);
                 geom_elem.init(*elem, *_system);
                 
                 ops.init(geom_elem);
@@ -328,7 +328,7 @@ eigenproblem_sensitivity_assemble(const MAST::FunctionBase& f,
                 const libMesh::Elem* sub_elem = *hi_sub_elem_it;
                 
                 MAST::LevelSetIntersectedElem geom_elem;
-                ops.set_elem_data(elem->dim(), geom_elem);
+                ops.set_elem_data(elem->dim(), *elem, geom_elem);
                 geom_elem.init(*sub_elem, *_system, *_intersection);
                 
                 ops.init(geom_elem);

--- a/src/level_set/level_set_nonlinear_implicit_assembly.cpp
+++ b/src/level_set/level_set_nonlinear_implicit_assembly.cpp
@@ -435,7 +435,7 @@ residual_and_jacobian (const libMesh::NumericVector<Real>& X,
                 // the Jacobian is based on the homogenizaton method to maintain
                 // a well conditioned global Jacobian.
                 MAST::GeomElem geom_elem;
-                ops.set_elem_data(elem->dim(), geom_elem);
+                ops.set_elem_data(elem->dim(), *elem, geom_elem);
                 geom_elem.init(*elem, *_system);
                 
                 ops.init(geom_elem);
@@ -487,7 +487,7 @@ residual_and_jacobian (const libMesh::NumericVector<Real>& X,
                     const libMesh::Elem* sub_elem = *hi_sub_elem_it;
                     
                     MAST::LevelSetIntersectedElem geom_elem;
-                    ops.set_elem_data(elem->dim(), geom_elem);
+                    ops.set_elem_data(elem->dim(), *elem, geom_elem);
                     geom_elem.init(*sub_elem, *_system, *_intersection);
                     
                     ops.init(geom_elem);
@@ -646,7 +646,7 @@ sensitivity_assemble (const MAST::FunctionBase& f,
                 const libMesh::Elem* sub_elem = *hi_sub_elem_it;
                 
                 MAST::LevelSetIntersectedElem geom_elem;
-                ops.set_elem_data(elem->dim(), geom_elem);
+                ops.set_elem_data(elem->dim(), *elem, geom_elem);
                 geom_elem.init(*sub_elem, *_system, *_intersection);
                 
                 ops.init(geom_elem);
@@ -679,7 +679,7 @@ sensitivity_assemble (const MAST::FunctionBase& f,
                     mat.setZero(ndofs, ndofs);
                     
                     MAST::GeomElem geom_elem;
-                    ops.set_elem_data(elem->dim(), geom_elem);
+                    ops.set_elem_data(elem->dim(), *elem, geom_elem);
                     geom_elem.init(*elem, *_system);
                     
                     ops.init(geom_elem);
@@ -827,7 +827,7 @@ calculate_output(const libMesh::NumericVector<Real>& X,
                 //                if (_sol_function)
                 //                    physics_elem->attach_active_solution_function(*_sol_function);
                 MAST::LevelSetIntersectedElem geom_elem;
-                output.set_elem_data(elem->dim(), geom_elem);
+                output.set_elem_data(elem->dim(), *elem, geom_elem);
                 geom_elem.init(*sub_elem, *_system, *_intersection);
                 
                 output.init(geom_elem);
@@ -869,7 +869,7 @@ calculate_output(const libMesh::NumericVector<Real>& X,
                 //                if (_sol_function)
                 //                    physics_elem->attach_active_solution_function(*_sol_function);
                 MAST::LevelSetIntersectedElem geom_elem;
-                output.set_elem_data(elem->dim(), geom_elem);
+                output.set_elem_data(elem->dim(), *elem, geom_elem);
                 geom_elem.init(*sub_elem, *_system, *_intersection);
                 
                 output.init(geom_elem);
@@ -1001,7 +1001,7 @@ calculate_output_derivative(const libMesh::NumericVector<Real>& X,
                 //        if (_sol_function)
                 //            physics_elem->attach_active_solution_function(*_sol_function);
                 MAST::LevelSetIntersectedElem geom_sub_elem;
-                output.set_elem_data(elem->dim(), geom_sub_elem);
+                output.set_elem_data(elem->dim(), *elem, geom_sub_elem);
                 geom_sub_elem.init(*sub_elem, *_system, *_intersection);
                 
                 output.init(geom_sub_elem);
@@ -1054,7 +1054,7 @@ calculate_output_derivative(const libMesh::NumericVector<Real>& X,
                 //        if (_sol_function)
                 //            physics_elem->attach_active_solution_function(*_sol_function);
                 MAST::LevelSetIntersectedElem geom_sub_elem;
-                output.set_elem_data(elem->dim(), geom_sub_elem);
+                output.set_elem_data(elem->dim(), *elem, geom_sub_elem);
                 geom_sub_elem.init(*sub_elem, *_system, *_intersection);
                 
                 output.init(geom_sub_elem);
@@ -1068,7 +1068,7 @@ calculate_output_derivative(const libMesh::NumericVector<Real>& X,
                     mat.setZero(ndofs, ndofs);
                     
                     MAST::GeomElem geom_elem;
-                    ops.set_elem_data(elem->dim(), geom_elem);
+                    ops.set_elem_data(elem->dim(), *elem, geom_elem);
                     geom_elem.init(*elem, *_system);
                     
                     ops.init(geom_elem);
@@ -1221,7 +1221,7 @@ calculate_output_direct_sensitivity(const libMesh::NumericVector<Real>& X,
                 // if (_sol_function)
                 //   physics_elem->attach_active_solution_function(*_sol_function);
                 MAST::LevelSetIntersectedElem geom_elem;
-                output.set_elem_data(elem->dim(), geom_elem);
+                output.set_elem_data(elem->dim(), *elem, geom_elem);
                 geom_elem.init(*sub_elem, *_system, *_intersection);
                 
                 output.init(geom_elem);
@@ -1272,7 +1272,7 @@ calculate_output_direct_sensitivity(const libMesh::NumericVector<Real>& X,
                 // if (_sol_function)
                 //   physics_elem->attach_active_solution_function(*_sol_function);
                 MAST::LevelSetIntersectedElem geom_elem;
-                output.set_elem_data(elem->dim(), geom_elem);
+                output.set_elem_data(elem->dim(), *elem, geom_elem);
                 geom_elem.init(*sub_elem, *_system, *_intersection);
                 
                 output.init(geom_elem);

--- a/src/level_set/level_set_perimeter_output.h
+++ b/src/level_set/level_set_perimeter_output.h
@@ -51,6 +51,7 @@ namespace MAST {
          */
         virtual void
         set_elem_data(unsigned int dim,
+                      const libMesh::Elem& ref_elem,
                       MAST::GeomElem& elem) const { }
         
         /*!

--- a/src/level_set/level_set_reinitialization_transient_assembly.cpp
+++ b/src/level_set/level_set_reinitialization_transient_assembly.cpp
@@ -128,7 +128,7 @@ residual_and_jacobian (const libMesh::NumericVector<Real>& X,
         dof_map.dof_indices (elem, dof_indices);
         
         MAST::GeomElem geom_elem;
-        solver.set_elem_data(elem->dim(), geom_elem);
+        solver.set_elem_data(elem->dim(), *elem, geom_elem);
         geom_elem.init(*elem, *_system);
         solver.init(geom_elem);
         

--- a/src/level_set/level_set_transient_assembly.h
+++ b/src/level_set/level_set_transient_assembly.h
@@ -114,6 +114,7 @@ namespace MAST {
          */
         virtual void
         set_elem_data(unsigned int dim,
+                      const libMesh::Elem& ref_elem,
                       MAST::GeomElem& elem) const { }
 
         

--- a/src/level_set/level_set_void_solution.cpp
+++ b/src/level_set/level_set_void_solution.cpp
@@ -250,7 +250,7 @@ update_void_solution(libMesh::NumericVector<Real>& X,
 
             // the Jacobian is based on the homogenization method
             MAST::GeomElem geom_elem;
-            elem_ops.set_elem_data(elem->dim(), geom_elem);
+            elem_ops.set_elem_data(elem->dim(), *elem, geom_elem);
             geom_elem.init(*elem, _assembly->system_init());
             
             elem_ops.init(geom_elem);
@@ -274,7 +274,7 @@ update_void_solution(libMesh::NumericVector<Real>& X,
                 const libMesh::Elem* sub_elem = *hi_sub_elem_it;
                 
                 MAST::LevelSetIntersectedElem geom_elem;
-                ops.set_elem_data(elem->dim(), geom_elem);
+                ops.set_elem_data(elem->dim(), *elem, geom_elem);
                 geom_elem.init(*sub_elem, *_intersection);
              
                 ops.init(geom_elem);

--- a/src/level_set/level_set_volume_output.h
+++ b/src/level_set/level_set_volume_output.h
@@ -44,6 +44,7 @@ namespace MAST {
          */
         virtual void
         set_elem_data(unsigned int dim,
+                      const libMesh::Elem& ref_elem,
                       MAST::GeomElem& elem) const { }
 
         /*!

--- a/src/mesh/CMakeLists.txt
+++ b/src/mesh/CMakeLists.txt
@@ -3,7 +3,9 @@ target_sources(mast
         ${CMAKE_CURRENT_LIST_DIR}/fe_base.cpp
         ${CMAKE_CURRENT_LIST_DIR}/fe_base.h
         ${CMAKE_CURRENT_LIST_DIR}/geom_elem.cpp
-        ${CMAKE_CURRENT_LIST_DIR}/geom_elem.h)
+        ${CMAKE_CURRENT_LIST_DIR}/geom_elem.h
+        ${CMAKE_CURRENT_LIST_DIR}/mesh_coupling_base.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/mesh_coupling_base.h)
 
 # Install MAST headers for this directory.
 install(DIRECTORY ./ DESTINATION include/mesh

--- a/src/mesh/geom_elem.cpp
+++ b/src/mesh/geom_elem.cpp
@@ -445,6 +445,7 @@ MAST::GeomElem::_init_local_elem_2d() {
     v2 = v3.cross(v1); v2 /= v2.norm();      // local y
     
     // copy the surface normal
+    _domain_surface_normal = RealVectorX::Zero(3);
     for (unsigned int i=0; i<3; i++)
         _domain_surface_normal(i) = v3(i);
     

--- a/src/mesh/mesh_coupling_base.cpp
+++ b/src/mesh/mesh_coupling_base.cpp
@@ -1,0 +1,176 @@
+/*
+ * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
+ * Copyright (C) 2013-2019  Manav Bhatia
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+
+// MAST includes
+#include "mesh/mesh_coupling_base.h"
+#include "base/system_initialization.h"
+#include "base/nonlinear_system.h"
+
+// libMesh includes
+#include "libmesh/mesh_base.h"
+#include "libmesh/boundary_info.h"
+#include "libmesh/point_locator_tree.h"
+
+
+
+MAST::MeshCouplingBase::MeshCouplingBase(MAST::SystemInitialization& sys_init):
+_sys_init(sys_init) {
+    
+    
+}
+
+
+MAST::MeshCouplingBase::~MeshCouplingBase() {
+    
+    
+}
+
+
+
+
+void
+MAST::MeshCouplingBase::
+add_master_and_slave_boundary_coupling(unsigned int master_b_id,
+                                       unsigned int slave_b_id,
+                                       Real tol) {
+    
+    // iterate on all nodes and check with boundary info about
+    // current ids on it.
+    libMesh::MeshBase& mesh = _sys_init.system().get_mesh();
+    
+    std::unique_ptr<libMesh::PointLocatorBase>
+    pt_locator(mesh.sub_point_locator());
+    
+    libMesh::PointLocatorTree
+    &locator_tree = dynamic_cast<libMesh::PointLocatorTree&>(*pt_locator);
+    
+    libMesh::MeshBase::const_element_iterator
+    e_it   =  mesh.local_elements_begin(),
+    e_end  =  mesh.local_elements_end();
+    
+    std::set<const libMesh::Node*> slave_nodes;
+    
+    for ( ; e_it != e_end; e_it++) {
+        
+        // iterate on sides and check if it is on specified boundary id
+        for (unsigned int slave_side=0;
+             slave_side < (*e_it)->n_sides();
+             slave_side++) {
+            
+            // check if the side is on the specified boundary
+            if (_check_if_side_on_boundary(mesh, **e_it, slave_side, slave_b_id)) {
+                
+                std::unique_ptr<const libMesh::Elem>
+                slave_side_ptr((*e_it)->side_ptr(slave_side));
+                
+                // check for coupling of nodes on this side
+                for (unsigned int slave_n_id=0;
+                     slave_n_id < slave_side_ptr->n_nodes();
+                     slave_n_id++) {
+                    
+                    const libMesh::Node*
+                    slave_node = slave_side_ptr->node_ptr(slave_n_id);
+                    
+                    // if the node has not already been constrained, then
+                    // identify the constraint on it
+                    if (!slave_nodes.count(slave_node)) {
+                        
+                        std::set<const libMesh::Node*> master_nodes;
+                        
+                        std::set<const libMesh::Elem*>
+                        elems = locator_tree.perform_fuzzy_linear_search(*slave_node, nullptr, tol);
+                        
+                        // make sure some elements were found for this node
+                        libmesh_assert(elems.size());
+                        
+                        // now check which of these elements have sides on
+                        // the boundary.
+                        std::set<const libMesh::Elem*>::const_iterator
+                        master_e_it   = elems.begin(),
+                        master_e_end  = elems.end();
+                        
+                        for (; master_e_it!=master_e_end; master_e_it++) {
+                            
+                            
+                            for (unsigned int master_side=0;
+                                 master_side < (*master_e_it)->n_sides();
+                                 master_side++) {
+                                
+                                if (_check_if_side_on_boundary(mesh,
+                                                               **master_e_it,
+                                                               master_side,
+                                                               master_b_id)) {
+                                    
+                                    std::unique_ptr<const libMesh::Elem>
+                                    master_side_ptr((*master_e_it)->side_ptr(master_side));
+                                    
+                                    // check for coupling of nodes on this side
+                                    for (unsigned int master_n_id=0;
+                                         master_n_id < master_side_ptr->n_nodes();
+                                         master_n_id++)
+                                        master_nodes.insert(master_side_ptr->node_ptr(master_n_id));
+                                }
+                            }
+                        }
+                            
+                        // add this slave/master information to the data
+                        _node_couplings.push_back
+                        (std::pair<const libMesh::Node*, std::set<const libMesh::Node*>>
+                         (slave_node, master_nodes));
+                        
+                        // register this slave node as having been processed
+                        slave_nodes.insert(slave_node);
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+void
+MAST::MeshCouplingBase::
+add_slave_boundary_and_master_subdomain_coupling(unsigned int master_b_id,
+                                                 unsigned int slave_b_id,
+                                                 Real tol) {
+    
+    libmesh_assert(false); // to be implemented
+}
+
+
+
+bool
+MAST::MeshCouplingBase::
+_check_if_side_on_boundary(libMesh::MeshBase& mesh,
+                           const libMesh::Elem& elem,
+                           unsigned int side,
+                           unsigned int b_id) {
+    
+    std::vector<libMesh::boundary_id_type> bc_ids;
+    mesh.boundary_info->boundary_ids(&elem, side, bc_ids);
+    
+    bool
+    on_side = false;
+    for (unsigned int i=0; i<bc_ids.size(); i++)
+        if (bc_ids[i] == b_id)
+            on_side = true;
+    
+    return on_side;
+}

--- a/src/mesh/mesh_coupling_base.h
+++ b/src/mesh/mesh_coupling_base.h
@@ -1,0 +1,91 @@
+/*
+ * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
+ * Copyright (C) 2013-2019  Manav Bhatia
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef __mast__mesh_couplings__
+#define __mast__mesh_couplings__
+
+// C++ includes
+#include <set>
+
+// MAST includes
+#include "base/mast_data_types.h"
+
+// libMesh includes
+#include "libmesh/elem.h"
+#include "libmesh/node.h"
+
+
+namespace MAST {
+  
+    // Forward declerations
+    class SystemInitialization;
+
+    
+    class MeshCouplingBase {
+ 
+    public:
+    
+        MeshCouplingBase(MAST::SystemInitialization& sys_init);
+        
+        
+        virtual ~MeshCouplingBase();
+        
+        
+        void
+        add_master_and_slave_boundary_coupling(unsigned int master_b_id,
+                                               unsigned int slave_b_id,
+                                               Real tol);
+
+        
+        void
+        add_slave_boundary_and_master_subdomain_coupling(unsigned int master_b_id,
+                                                         unsigned int slave_b_id,
+                                                         Real tol);
+        
+        /*!
+         *  \returns a const reference to a vector of pairs where each pair
+         *  identifies the slave and the set of master nodes to which the
+         *  slave is connected.
+         */
+        const std::vector<std::pair<const libMesh::Node*, std::set<const libMesh::Node*>>>&
+        get_node_couplings() const {
+            
+            return _node_couplings;
+        }
+        
+        
+    protected:
+
+        bool
+        _check_if_side_on_boundary(libMesh::MeshBase& mesh,
+                                   const libMesh::Elem& elem,
+                                   unsigned int side,
+                                   unsigned int b_id);
+        
+        
+        MAST::SystemInitialization &_sys_init;
+        
+        std::vector<std::pair<const libMesh::Node*, std::set<const libMesh::Node*>>> _node_couplings;
+        
+    };
+    
+}
+
+
+#endif // __mast__mesh_couplings__

--- a/src/solver/continuation_solver_base.cpp
+++ b/src/solver/continuation_solver_base.cpp
@@ -246,7 +246,6 @@ _solve_schur_factorization(const libMesh::NumericVector<Real>  &X,
     //         STEP 3:  a   = dg/dp + dg/dX dXdp
     //////////////////////////////////////////////////////////
     a   = dgdp + dgdX.dot(dXdp);
-    libmesh_assert_greater(a, 0.);
     
     //////////////////////////////////////////////////////////
     //         STEP 4:  a  dp     = -g + dg/dX r1

--- a/src/solver/transient_solver_base.cpp
+++ b/src/solver/transient_solver_base.cpp
@@ -827,10 +827,11 @@ MAST::TransientSolverBase::advance_time_step_with_sensitivity() {
 
 void
 MAST::TransientSolverBase::set_elem_data(unsigned int dim,
+                                         const libMesh::Elem& ref_elem,
                                          MAST::GeomElem &elem) const {
     
     libmesh_assert(_assembly_ops);
-    _assembly_ops->set_elem_data(dim, elem);
+    _assembly_ops->set_elem_data(dim, ref_elem, elem);
 }
 
 

--- a/src/solver/transient_solver_base.h
+++ b/src/solver/transient_solver_base.h
@@ -291,6 +291,7 @@ namespace MAST {
          */
         virtual void
         set_elem_data(unsigned int dim,
+                      const libMesh::Elem& ref_elem,
                       MAST::GeomElem& elem) const;
 
         /*!


### PR DESCRIPTION
-- Bug-fix for initialization of 1D/2D geometric element for structural analysis
-- Fixes to path continuation example in structures 
-- Added some capability to couple disjoint mesh regions using implicitly defined constraints. More examples to be added. 