### PR TITLE
Updates to CMake build to work with MAST Spack package.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ build2
 
 # Visual Studio Code settings.
 .vscode/
+
+# Spack files.
+spconfig.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,25 +39,34 @@ find_package(MPI REQUIRED)
 find_package(LAPACK REQUIRED)
 find_package(PETSc REQUIRED)
 find_package(SLEPc REQUIRED)
+find_package(HDF5 REQUIRED)
 find_package(libMesh REQUIRED)
 find_package(Eigen3 REQUIRED)
+# Note: for some reason, letting CMake find a package configuration file for Boost from
+#       a CMake/Spack-based installation of Boost causes trouble. Some of the include 
+#       directories seem to be missing in this case. We disable the search for a 
+#       Boost CMake configuration in the FindBoost module for now.
+set(Boost_NO_BOOST_CMAKE ON) 
 find_package(Boost COMPONENTS iostreams system filesystem unit_test_framework REQUIRED)
 
 # Find optional packages.
 if (ENABLE_GCMMA)
     find_package(GCMMA REQUIRED)
+    find_package(GFortranLibs REQUIRED)
 else()
     set (MAST_ENABLE_GCMMA 0)
 endif()
 
 if (ENABLE_DOT)
     find_package(DOT REQUIRED)
+    find_package(GFortranLibs REQUIRED)
 else()
     set (MAST_ENABLE_DOT 0)
 endif()
 
 if (ENABLE_SNOPT)
     find_package(SNOPT REQUIRED)
+    find_package(GFortranLibs REQUIRED)
 else()
     set (MAST_ENABLE_SNOPT 0)
 endif()
@@ -66,12 +75,6 @@ if (ENABLE_NLOPT)
    find_package(NLOpt REQUIRED)
 else()
     set (MAST_ENABLE_NLOPT 0)
-endif()
-
-# gfortran lib is required if GCMMA/DOT are used, since these are written
-# in fortran
-if (ENABLE_GCMMA OR ENABLE_DOT OR ENABLE_SNOPT)
-find_package(GFortranLibs REQUIRED)
 endif()
 
 # MAIN TARGETS

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,7 @@ target_include_directories(mast
             ${MPI_CXX_INCLUDE_PATH}
             ${PETSc_INCLUDE_DIRS}
             ${SLEPc_INCLUDE_DIRS}
+            ${HDF5_INCLUDE_DIRS}
             ${libMesh_INCLUDE_DIRS}
             ${EIGEN3_INCLUDE_DIR}
             ${NLOPT_INCLUDE_DIR}
@@ -30,6 +31,7 @@ target_link_libraries(mast
             ${LAPACK_LIBRARIES}
             ${PETSc_LIBRARIES}
             ${SLEPc_LIBRARIES}
+            ${HDF5_LIBRARIES}
             ${Boost_IOSTREAMS_LIBRARY}
             ${Boost_FILESYSTEM_LIBRARY}
             ${Boost_SYSTEM_LIBRARY}


### PR DESCRIPTION
We needed a few modifications to the CMake build to accommodate installation of MAST completely via a Spack package (I plan to push my mast/package.py to the main Spack GitHub repo soon). 

First, we were neglecting a requirement for HDF5 for libmast.a since it was. The compiler needing something during the linking of PETSc. I think we were getting lucky before since we both generally consolidate/install a lot of dependency files into a single include/ directory.

Second, it seems when Spack is used to build Boost, it does so using a CMake-type build and creates a CMake module for it in the files installed by Spack. Our MAST FindBoost() in src/CMakeLists.txt was finding this and trying to use it (more advanced feature I don't full grasp yet). The MAST build was having trouble finding some headers from Boost functionality we use. I disabled the use of this feature (by simply setting a CMake variable) in FindBoost and it seems to work as expected.