### PR TITLE
changing boost version check in testsuite 

### DIFF
--- a/tests/fluid/jacobians/check_fluid_eigenvectors.cpp
+++ b/tests/fluid/jacobians/check_fluid_eigenvectors.cpp
@@ -57,7 +57,7 @@ struct GlobalTestFixture {
 };
 
 
-#if BOOST_VERSION > 105800
+#if BOOST_VERSION > 106100
 BOOST_TEST_GLOBAL_FIXTURE( GlobalTestFixture );
 #else
 BOOST_GLOBAL_FIXTURE( GlobalTestFixture );

--- a/tests/fluid/jacobians/check_fluid_jacobian.cpp
+++ b/tests/fluid/jacobians/check_fluid_jacobian.cpp
@@ -57,7 +57,7 @@ struct GlobalTestFixture {
 };
 
 
-#if BOOST_VERSION > 105800
+#if BOOST_VERSION > 106100
 BOOST_TEST_GLOBAL_FIXTURE( GlobalTestFixture );
 #else
 BOOST_GLOBAL_FIXTURE( GlobalTestFixture );


### PR DESCRIPTION
Changing boost version check in testsuite to 1.61 for setting up the fixture.

This should address #28 .