### PR TITLE
Fixed minor build issues and improved robustness of CMake Find files.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,9 @@ option(BUILD_DOC      "Build documentation"         OFF)
 set(MAST_ROOT_DIR ${CMAKE_CURRENT_LIST_DIR})
 set(libMesh_DIR "libMesh_DIR" CACHE PATH "Directory containing libMesh include/ and lib/")
 set(PETSc_DIR   "PETSc_DIR"   CACHE PATH "Directory containing PETSc include/ and lib/")
+set(PETSc_ARCH  "PETSc_ARCH"  CACHE STRING "Configuration/build of PETSc that should be used.")
 set(SLEPc_DIR   "SLEPc_DIR"   CACHE PATH "Directory containing SLEPc include/ and lib/")
+set(SLEPc_ARCH  "SLEPc_ARCH"  CACHE STRING "Configuration/build of SLEPc that should be used.")
 set(EIGEN3_ROOT "Eigen_DIR"   CACHE PATH "Directory containing eigen header files")
 set(DOT_DIR "DOT_DIR"   CACHE PATH "Directory containing DOT lib/")
 set(SNOPT_DIR "SNOpt_DIR"   CACHE PATH "Directory containing SNOPT lib/")
@@ -37,6 +39,8 @@ set(NLOPT_DIR "NLOpt_DIR"   CACHE PATH "Directory containing NLOpt include/ and 
 # FIND DEPENDENCIES
 find_package(MPI REQUIRED)
 find_package(LAPACK REQUIRED)
+message("-- Found BLAS libs: ${BLAS_LIBRARIES}")
+message("-- Found LAPACK libs: ${LAPACK_LIBRARIES}")
 find_package(PETSc REQUIRED)
 find_package(SLEPc REQUIRED)
 find_package(HDF5 REQUIRED)
@@ -48,6 +52,8 @@ find_package(Eigen3 REQUIRED)
 #       Boost CMake configuration in the FindBoost module for now.
 set(Boost_NO_BOOST_CMAKE ON) 
 find_package(Boost COMPONENTS iostreams system filesystem unit_test_framework REQUIRED)
+message("-- Found Boost include: ${Boost_INCLUDE_DIRS}") # To ensure the found Boost is what user expected
+message("-- Found Boost libs:    ${Boost_LIBRARY_DIRS}") # To ensure the found Boost is what user expected
 
 # Find optional packages.
 if (ENABLE_GCMMA)

--- a/cmake/FindEigen3.cmake
+++ b/cmake/FindEigen3.cmake
@@ -82,6 +82,7 @@ else (EIGEN3_INCLUDE_DIR)
         HINTS
         ENV EIGEN3_ROOT 
         ENV EIGEN3_ROOT_DIR
+        ${EIGEN3_ROOT}/include
         PATHS
         ${CMAKE_INSTALL_PREFIX}/include
         ${KDE4_INCLUDE_DIR}

--- a/cmake/FindPETSc.cmake
+++ b/cmake/FindPETSc.cmake
@@ -1,17 +1,26 @@
-# This module relies on PETSc_DIR being set.
+# This module relies on PETSc_DIR and PETSc_ARCH being set in CMake or
+# PETSC_DIR and PETSC_ARCH being set in the environment
 #
 # PETSc_FOUND - system has PETSc.
 # PETSc_INCLUDE_DIRS - PETSc include directories.
 # PETSc_LIBRARIES - PETSc libraries.
 
 # Find the headers.
+# Search CMake variable paths first (PETSc_DIR) and then environment variable paths next (PETSC_DIR)
 find_path(PETSc_INCLUDE_DIR petsc.h
-          HINTS ${PETSc_DIR}/include)
+          HINTS "${PETSc_DIR}/include"
+                "${PETSc_DIR}/${PETSc_ARCH}/include" 
+                "$ENV{PETSC_DIR}/include"
+                "$ENV{PETSC_DIR}/$ENV{PETSC_ARCH}/include")
 
-# Find the libraries.
+# Find the libraries. 
+# Search CMake variable paths first (PETSc_DIR) and then environment variable paths next (PETSC_DIR)
 find_library(PETSc_LIBRARY
              NAMES petsc
-             HINTS ${PETSc_DIR}/lib)
+             HINTS "${PETSc_DIR}/lib"
+                   "${PETSc_DIR}/${PETSc_ARCH}/lib"
+                   "$ENV{PETSC_DIR}/lib"
+                   "$ENV{PETSC_DIR}/$ENV{PETSC_ARCH}/lib")
 
 # Find PETSc version.
 if(PETSc_INCLUDE_DIR)
@@ -19,9 +28,12 @@ if(PETSc_INCLUDE_DIR)
     file(STRINGS "${HEADER}" major REGEX "define +PETSC_VERSION_MAJOR")
     file(STRINGS "${HEADER}" minor REGEX "define +PETSC_VERSION_MINOR")
     file(STRINGS "${HEADER}" patch REGEX "define +PETSC_VERSION_SUBMINOR")
-    string(REGEX REPLACE ".+([0-9]+)" "\\1" major ${major})
-    string(REGEX REPLACE ".+([0-9]+)" "\\1" minor ${minor})
-    string(REGEX REPLACE ".+([0-9]+)" "\\1" patch ${patch})
+    string(REGEX MATCH "#define PETSC_VERSION_MAJOR *([0-9]*)" _ ${major})
+    set(major ${CMAKE_MATCH_1})
+    string(REGEX MATCH "#define PETSC_VERSION_MINOR *([0-9]*)" _ ${minor})
+    set(minor ${CMAKE_MATCH_1})
+    string(REGEX MATCH "#define PETSC_VERSION_SUBMINOR *([0-9]*)" _ ${patch})
+    set(patch ${CMAKE_MATCH_1})
     string(STRIP "${major}" major)
     string(STRIP "${minor}" minor)
     string(STRIP "${patch}" patch)

--- a/cmake/FindSLEPc.cmake
+++ b/cmake/FindSLEPc.cmake
@@ -5,23 +5,44 @@
 # SLEPc_LIBRARIES - SLEPc libraries.
 
 # Find the headers.
-find_path(SLEPc_INCLUDE_DIR slepc.h
-          HINTS ${SLEPc_DIR}/include)
+# Search CMake variable paths first (SLEPc_DIR) and then environment variable paths next (SLEPC_DIR)
+find_path(SLEPc_INCLUDE_DIR1 slepc.h
+          HINTS "${SLEPc_DIR}/include"
+                "${SLEPc_DIR}/${SLEPc_ARCH}/include" 
+                "$ENV{SLEPC_DIR}/include"
+                "$ENV{SLEPC_DIR}/$ENV{SLEPC_ARCH}/include")
 
-# Find the libraries.
+# Search for slepcconf.h, which could be in a different location than slepc.h if an ARCH was specified
+find_path(SLEPc_INCLUDE_DIR2 slepcconf.h
+          HINTS "${SLEPc_DIR}/include"
+                "${SLEPc_DIR}/${SLEPc_ARCH}/include" 
+                "$ENV{SLEPC_DIR}/include"
+                "$ENV{SLEPC_DIR}/$ENV{SLEPC_ARCH}/include")
+
+# Use both SLEPc include directories found above
+set(SLEPc_INCLUDE_DIR "${SLEPc_INCLUDE_DIR1};${SLEPc_INCLUDE_DIR2}")
+
+# Find the libraries. 
+# Search CMake variable paths first (SLEPc_DIR) and then environment variable paths next (SLEPC_DIR)
 find_library(SLEPc_LIBRARY
              NAMES slepc
-             HINTS ${SLEPc_DIR}/lib)
+             HINTS "${SLEPc_DIR}/lib"
+                   "${SLEPc_DIR}/${SLEPc_ARCH}/lib"
+                   "$ENV{SLEPC_DIR}/lib"
+                   "$ENV{SLEPC_DIR}/$ENV{SLEPC_ARCH}/lib")
 
 # Find SLEPc version.
 if(SLEPc_INCLUDE_DIR)
-    set(HEADER "${SLEPc_INCLUDE_DIR}/slepcversion.h")
+    set(HEADER "${SLEPc_INCLUDE_DIR1}/slepcversion.h")
     file(STRINGS "${HEADER}" major REGEX "define +SLEPC_VERSION_MAJOR")
     file(STRINGS "${HEADER}" minor REGEX "define +SLEPC_VERSION_MINOR")
     file(STRINGS "${HEADER}" patch REGEX "define +SLEPC_VERSION_SUBMINOR")
-    string(REGEX REPLACE ".+([0-9]+)" "\\1" major ${major})
-    string(REGEX REPLACE ".+([0-9]+)" "\\1" minor ${minor})
-    string(REGEX REPLACE ".+([0-9]+)" "\\1" patch ${patch})
+    string(REGEX MATCH "#define SLEPC_VERSION_MAJOR *([0-9]*)" _ ${major})
+    set(major ${CMAKE_MATCH_1})
+    string(REGEX MATCH "#define SLEPC_VERSION_MINOR *([0-9]*)" _ ${minor})
+    set(minor ${CMAKE_MATCH_1})
+    string(REGEX MATCH "#define SLEPC_VERSION_SUBMINOR *([0-9]*)" _ ${patch})
+    set(patch ${CMAKE_MATCH_1})
     string(STRIP "${major}" major)
     string(STRIP "${minor}" minor)
     string(STRIP "${patch}" patch)

--- a/cmake/FindlibMesh.cmake
+++ b/cmake/FindlibMesh.cmake
@@ -21,7 +21,7 @@ find_library(libMesh_dbg_LIBRARY
 
 # If debug library is not available then set it to the optimized library
 if(NOT libMesh_dbg_LIBRARY)
-   message("Did not fine libmesh_dbg using libmesh_opt for debug version.")
+   message("-- WARN: Did not find libmesh_dbg using libmesh_opt for debug version.")
     find_library(libMesh_dbg_LIBRARY
                  NAMES mesh_opt
                  HINTS ${libMesh_DIR}/lib)
@@ -34,9 +34,15 @@ if(libMesh_INCLUDE_DIR)
     file(STRINGS "${HEADER}" major REGEX "define +LIBMESH_MAJOR_VERSION")
     file(STRINGS "${HEADER}" minor REGEX "define +LIBMESH_MINOR_VERSION")
     file(STRINGS "${HEADER}" patch REGEX "define +LIBMESH_MICRO_VERSION")
-    string(REGEX REPLACE ".+([0-9]+)" "\\1" major ${major})
-    string(REGEX REPLACE ".+([0-9]+)" "\\1" minor ${minor})
-    string(REGEX REPLACE ".+([0-9]+)" "\\1" patch ${patch})
+    string(REGEX MATCH "#define LIBMESH_MAJOR_VERSION *([0-9]*)" _ ${major})
+    set(major ${CMAKE_MATCH_1})
+    string(REGEX MATCH "#define LIBMESH_MINOR_VERSION *([0-9]*)" _ ${minor})
+    set(minor ${CMAKE_MATCH_1})
+    string(REGEX MATCH "#define LIBMESH_MICRO_VERSION *([0-9]*)" _ ${patch})
+    set(patch ${CMAKE_MATCH_1})
+    #string(REGEX REPLACE ".+([0-9]+)" "\\1" major ${major})
+    #string(REGEX REPLACE ".+([0-9]+)" "\\1" minor ${minor})
+    #string(REGEX REPLACE ".+([0-9]+)" "\\1" patch ${patch})
     string(STRIP "${major}" major)
     string(STRIP "${minor}" minor)
     string(STRIP "${patch}" patch)

--- a/src/base/nonlinear_system.cpp
+++ b/src/base/nonlinear_system.cpp
@@ -999,7 +999,7 @@ project_vector_without_dirichlet (libMesh::NumericVector<Real> & new_vector,
     libMesh::WrappedFunctor<Real>     f_fem(f);
     libMesh::FEMFunctionWrapper<Real> fw(f_fem);
     
-#if (LIBMESH_MAJOR_VERSION == 1 && LIBMESH_MINOR_VERSION < 4)
+#if (LIBMESH_MAJOR_VERSION == 1 && LIBMESH_MINOR_VERSION < 5)
     libMesh::Threads::parallel_for
     (active_local_range,
      FEMProjector(*this, fw, nullptr, setter, vars));


### PR DESCRIPTION
Added support for PETSC_ARCH and SLEPC_ARCH variables.
Fixed wrong PETSc (SLEPc, libMesh) version reported error (3.11.2 was reported as 3.1.2).
Minor change to libmesh_opt not found warning message foramt.
Added ${EIGEN3_ROOT}/include to HINTS for FindEigen3.cmake.
In base/nonlinear_system.cpp changed libMesh minimum version detection from 1.4 to 1.5 to solve build error encountered when building with libMesh v1.4.1 (Release).