### PR TITLE
Bug-fix for restart of continuation solver

### DIFF
--- a/src/solver/continuation_solver_base.cpp
+++ b/src/solver/continuation_solver_base.cpp
@@ -103,15 +103,16 @@ MAST::ContinuationSolverBase::solve()  {
     _p0     = (*_p)();
     _X0.reset(X.clone().release());
     
+
+    // save data for possible reuse if the iterations are restarted.
+    _save_iteration_data();
+
     Real
     norm0   = _res_norm(X, *_p),
     norm    = norm0;
     
     bool
     cont    = true;
-
-    // save data for possible reuse if the iterations are restarted.
-    _save_iteration_data();
     
     while (cont) {
         


### PR DESCRIPTION
The initial data of the continuation solver is stored before competing the initial residual, which may update the search direction.