### PR TITLE
Fix documentation deployment error due to Travis-CI cache.

### DIFF
--- a/ci/deploy_docs.sh
+++ b/ci/deploy_docs.sh
@@ -3,15 +3,16 @@
 # Deploy organized HTML documentation to Github for hosting.
 #
 #    This script deploys organized HTML documentation produced by `prepare_docs.sh` to a repository in the MAST Team
-#    GitHub repository for hosting. It is meant to be called during the Travis-CI `deploy` stage and requires the
-#    GH_TOKEN environment variable be set in the Travis-CI job from an account that can push
-#    to https://github.com/MASTmultiphysics/MASTmultiphysics.github.io
+#    GitHub repository for hosting using a simple git push. It is meant to be called during the Travis-CI
+#    `deploy` stage and requires the GH_TOKEN environment variable be set in the Travis-CI job from
+#    an account that can push to https://github.com/MASTmultiphysics/MASTmultiphysics.github.io. The GH_TOKEN variable
+#    is specified in the Travis-CI web interface as a secret variable so it is not displayed publically.
 #
 #    Contents of this script (and `prepare_docs.sh`) were inspired in part
 #    by https://gist.github.com/willprice/e07efd73fb7f13f917ea.
 
 # Set git remote URL. Force push to GitHub website repository.
 # Update git remote URL to include ${GH_TOKEN} key. Push files back to GitHub website repository.
-git remote add origin https://${GH_TOKEN}@github.com/MASTmultiphysics/MASTmultiphysics.github.io.git || exit
+cd ${TRAVIS_BUILD_DIR}/website || exit
 git push --force origin master || exit
 

--- a/ci/prepare_docs.sh
+++ b/ci/prepare_docs.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# Prepare/organized Doxygen generated HTML documentation to Github for hosting by `deploy_docs.sh`.
+# Prepare/organize Doxygen generated HTML documentation to be hosted on Github.
 #
-#    This script organizes the Doxygen generated HTML documentation and commits it to local .git repository.
-#    Doxygen generated HTML documentation to the MAST Github repository for hosting. This script should be called
-#    during the Travis-CI 'script' phase after documentation is built so that if an error occurs we can catch it
-#    on a non-master build (the 'deploy' stage only runs for commits on the `master` branch). We currently call it
-#    inside of `ci/build_mast.sh` on the worker that satisfies ${CI_BUILD_DOCS}=true.
+#    This script organizes the Doxygen generated HTML documentation and commits it to a local .git repository.
+#    This script should be called during the Travis-CI 'script' phase after documentation is built so that
+#    if an error occurs we can catch it on a non-master build (the 'deploy' stage only runs for commits on the
+#    `master` branch). We currently call it inside of `ci/build_mast.sh` on the worker that satisfies
+#    the condition ${CI_BUILD_DOCS}=true. To actually deploy the documentation (after running this script)
+#    call `ci/deploy_docs.sh`.
 #
 #    Contents of this script (and `deploy_docs.sh`) were inspired in part by
 #    https://gist.github.com/willprice/e07efd73fb7f13f917ea.
@@ -15,8 +16,10 @@
 git config --global user.email "travis@travis-ci.org" || exit
 git config --global user.name "Travis CI" || exit
 
-# Organize website content. First delete all current contents (except .git directory) and then copy generated
-# HTML and other desired files.
+# Organize website content. First make sure we delete any existing website contents (these may exist from
+# a previous Travis-CI cache) and then copy generated HTML and other desired files.
+rm -rf ${TRAVIS_BUILD_DIR}/website # Don't `|| exit` here. Its not a failure if this directory doesn't exist when
+                                   # we try to delete it.
 mkdir ${TRAVIS_BUILD_DIR}/website || exit
 cd ${TRAVIS_BUILD_DIR}/website || exit
 rsync -r ${TRAVIS_BUILD_DIR}/build_rel/doc/doxygen/html/ . || exit
@@ -25,3 +28,7 @@ rsync -r ${TRAVIS_BUILD_DIR}/build_rel/doc/doxygen/html/ . || exit
 git init || exit
 git add . || exit
 git commit --quiet --message "Travis build ${TRAVIS_BUILD_NUMBER}, mast-multiphysics commit ${TRAVIS_COMMIT}" || exit
+
+# Add remote where we will push website to on actual deployment. GH_TOKEN environment variable is set automatically
+# in the Travis-CI, but must from an account that can push to https://github.com/MASTmultiphysics/MASTmultiphysics.github.io
+git remote add origin https://${GH_TOKEN}@github.com/MASTmultiphysics/MASTmultiphysics.github.io.git || exit


### PR DESCRIPTION
Refactoring done in commit 65ecace2b9a02a2153c1d75371b0471905048d6b seems to have introduced an error due to to the caching step that Travis-CI does. Reorganized code here eliminates the issue and actually makes documentation testing a bit more robust.