### PR TITLE
CI system runs examples with CTest if tests are defined in examples CMakeList.txt.

### DIFF
--- a/ci/build_dependencies.sh
+++ b/ci/build_dependencies.sh
@@ -5,7 +5,7 @@ if [ "${TRAVIS_OS_NAME}" = linux ]; then # Ubuntu Linux
   if [ "${TRAVIS_DIST}" = xenial ]; then # Ubuntu 16.04 Xenial Xerus
     cd ${HOME} || exit
 
-    # Python 3.6 apt repository (since its not neatly included in Ubuntu 16.04)
+    # Python 3.7 apt repository (since its not neatly included in Ubuntu 16.04)
     sudo add-apt-repository -y ppa:deadsnakes/ppa
 
     # Regular libMesh/MAST dependencies.
@@ -21,7 +21,7 @@ if [ "${TRAVIS_OS_NAME}" = linux ]; then # Ubuntu Linux
     sudo apt-get -qq install -y texlive-latex-base dvi2ps ghostscript
     sudo apt-get -qq install -y python3.7 python3.7-dev libpython3.7
 
-    # Get pip working with external Python 3.6.
+    # Get pip working with external Python 3.7.
     wget https://bootstrap.pypa.io/get-pip.py || exit
     sudo python3.7 get-pip.py || exit
 

--- a/ci/build_dependencies.sh
+++ b/ci/build_dependencies.sh
@@ -14,18 +14,19 @@ if [ "${TRAVIS_OS_NAME}" = linux ]; then # Ubuntu Linux
     sudo apt-get -qq install -y openmpi-bin libopenmpi-dev
     sudo apt-get -qq install -y libpetsc3.6 libpetsc3.6.2-dev
     sudo apt-get -qq install -y libslepc3.6 libslepc3.6.1-dev libparpack2-dev
+    sudo apt-get -qq install -y libnetcdf11 libnetcdf-dev
     sudo apt-get -qq install -y libboost-all-dev
     sudo apt-get -qq install -y libeigen3-dev
     sudo apt-get -qq install -y doxygen graphviz rsync
     sudo apt-get -qq install -y texlive-latex-base dvi2ps ghostscript
-    sudo apt-get -qq install -y python3.6 python3.6-dev libpython3.6
+    sudo apt-get -qq install -y python3.7 python3.7-dev libpython3.7
 
     # Get pip working with external Python 3.6.
     wget https://bootstrap.pypa.io/get-pip.py || exit
-    sudo python3.6 get-pip.py || exit
+    sudo python3.7 get-pip.py || exit
 
-    sudo python3.6 -m pip install numpy scipy docopt colorama pandas h5py matplotlib cpylog pyNastran
-    sudo python3.6 -m pip install Cython --install-option="--no-cython-compile"
+    sudo python3.7 -m pip install numpy scipy docopt colorama pandas h5py matplotlib cpylog pyNastran
+    sudo python3.7 -m pip install Cython --install-option="--no-cython-compile"
 
     # Update to later CMake release.
     wget https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5-Linux-x86_64.sh || exit

--- a/ci/build_mast.sh
+++ b/ci/build_mast.sh
@@ -50,8 +50,12 @@ if [ "${TRAVIS_OS_NAME}" = linux ]; then # Ubuntu Linux
         echo "No CI documentation for a Debug build."
       else
         make -j 2 || exit
+        echo "RUNNING UNIT TESTS" || exit
         cd "${DBG_BUILD_DIR}/tests" || exit
         ctest --force-new-ctest-process --output-on-failure --timeout 10
+        echo "RUNNING SHORT EXAMPLES" || exit
+        cd "${DBG_BUILD_DIR}/examples"  || exit
+        ctest --force-new-ctest-process --output-on-failure -L "SHORT"
       fi
 
     fi # No Debug build for libMesh < 1.5.0
@@ -85,8 +89,12 @@ if [ "${TRAVIS_OS_NAME}" = linux ]; then # Ubuntu Linux
     else
       make -j 2 || exit
       make install || exit
+      echo "RUNNING UNIT TESTS" || exit
       cd "${REL_BUILD_DIR}/tests" || exit
       ctest --force-new-ctest-process --output-on-failure --timeout 10
+      echo "RUNNING SHORT EXAMPLES" || exit
+      cd "${REL_BUILD_DIR}/examples"  || exit
+      ctest --force-new-ctest-process --output-on-failure -L "SHORT"
     fi
 
   # elif [ "${TRAVIS_DIST}" = bionic ]; then # Ubuntu 18.04 Bionic Beaver
@@ -141,8 +149,12 @@ elif [ "${TRAVIS_OS_NAME}" = osx ]; then # macOS 10.14, XCode 10.2
     -DENABLE_CYTHON=ON || exit
 
   make -j 2 || exit
+  echo "RUNNING UNIT TESTS" || exit
   cd "${DBG_BUILD_DIR}/tests" || exit
   ctest --force-new-ctest-process --output-on-failure --timeout 10
+  echo "RUNNING SHORT EXAMPLES" || exit
+  cd "${DBG_BUILD_DIR}/examples" || exit
+  ctest --force-new-ctest-process --output-on-failure -L "SHORT"
 
   # Now build/install a Release (optimized) version of MAST (-DCMAKE_BUILD_TYPE=Release).
   echo "TEST RELEASE/OPTIMIZED BUILD..."
@@ -175,8 +187,12 @@ elif [ "${TRAVIS_OS_NAME}" = osx ]; then # macOS 10.14, XCode 10.2
   make -j 2 || exit
   make install || exit
 
+  echo "RUNNING UNIT TESTS" || exit
   cd "${REL_BUILD_DIR}/tests" || exit
   ctest --force-new-ctest-process --output-on-failure --timeout 10
+  echo "RUNNING SHORT EXAMPLES" || exit
+  cd "${REL_BUILD_DIR}/examples" || exit
+  ctest --force-new-ctest-process --output-on-failure -L "SHORT"
 
 else
   echo "INVALID OS: ${TRAVIS_OS_NAME}"

--- a/ci/build_mast.sh
+++ b/ci/build_mast.sh
@@ -55,7 +55,7 @@ if [ "${TRAVIS_OS_NAME}" = linux ]; then # Ubuntu Linux
         ctest --force-new-ctest-process --output-on-failure --timeout 10
         echo "RUNNING SHORT EXAMPLES" || exit
         cd "${DBG_BUILD_DIR}/examples"  || exit
-        ctest --force-new-ctest-process --output-on-failure -L "SHORT"
+        ctest --force-new-ctest-process --output-on-failure -L "SHORT" --timeout 60
       fi
 
     fi # No Debug build for libMesh < 1.5.0
@@ -94,7 +94,7 @@ if [ "${TRAVIS_OS_NAME}" = linux ]; then # Ubuntu Linux
       ctest --force-new-ctest-process --output-on-failure --timeout 10
       echo "RUNNING SHORT EXAMPLES" || exit
       cd "${REL_BUILD_DIR}/examples"  || exit
-      ctest --force-new-ctest-process --output-on-failure -L "SHORT"
+      ctest --force-new-ctest-process --output-on-failure -L "SHORT" --timeout 60
     fi
 
   # elif [ "${TRAVIS_DIST}" = bionic ]; then # Ubuntu 18.04 Bionic Beaver
@@ -154,7 +154,7 @@ elif [ "${TRAVIS_OS_NAME}" = osx ]; then # macOS 10.14, XCode 10.2
   ctest --force-new-ctest-process --output-on-failure --timeout 10
   echo "RUNNING SHORT EXAMPLES" || exit
   cd "${DBG_BUILD_DIR}/examples" || exit
-  ctest --force-new-ctest-process --output-on-failure -L "SHORT"
+  ctest --force-new-ctest-process --output-on-failure -L "SHORT" --timeout 60
 
   # Now build/install a Release (optimized) version of MAST (-DCMAKE_BUILD_TYPE=Release).
   echo "TEST RELEASE/OPTIMIZED BUILD..."
@@ -192,7 +192,7 @@ elif [ "${TRAVIS_OS_NAME}" = osx ]; then # macOS 10.14, XCode 10.2
   ctest --force-new-ctest-process --output-on-failure --timeout 10
   echo "RUNNING SHORT EXAMPLES" || exit
   cd "${REL_BUILD_DIR}/examples" || exit
-  ctest --force-new-ctest-process --output-on-failure -L "SHORT"
+  ctest --force-new-ctest-process --output-on-failure -L "SHORT" --timeout 60
 
 else
   echo "INVALID OS: ${TRAVIS_OS_NAME}"

--- a/examples/structural/example_1/CMakeLists.txt
+++ b/examples/structural/example_1/CMakeLists.txt
@@ -13,7 +13,7 @@ set_tests_properties(structural_example_1
     PROPERTIES
         LABELS "SHORT;SEQ")
 
-# Test multiple processors, parallel direct solver using external MUMPS package.
+# Test multiple processors, parallel direct linear solver using external MUMPS package.
 add_test(NAME structural_example_1_mpi
     COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:structural_example_1>
             -ksp_type preonly -pc_type lu -pc_factor_mat_solver_package mumps -options_view)

--- a/examples/structural/example_1/CMakeLists.txt
+++ b/examples/structural/example_1/CMakeLists.txt
@@ -1,7 +1,22 @@
 add_executable(structural_example_1
-               example_1.cpp)
+    example_1.cpp)
 
 target_link_libraries(structural_example_1 mast)
 
 install(TARGETS structural_example_1
-        RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/examples)
+    RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/examples)
+
+# Test on single processor, PETSc built-in LU direct linear solver (sequential).
+add_test(NAME structural_example_1
+    COMMAND $<TARGET_FILE:structural_example_1> -ksp_type preonly -pc_type lu -options_view)
+set_tests_properties(structural_example_1
+    PROPERTIES
+        LABELS "SHORT;SEQ")
+
+# Test multiple processors, parallel direct solver using external MUMPS package.
+add_test(NAME structural_example_1_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:structural_example_1>
+            -ksp_type preonly -pc_type lu -pc_factor_mat_solver_package mumps -options_view)
+set_tests_properties(structural_example_1_mpi
+    PROPERTIES
+        LABELS "SHORT;MPI")

--- a/examples/structural/example_2/CMakeLists.txt
+++ b/examples/structural/example_2/CMakeLists.txt
@@ -1,12 +1,26 @@
 add_executable(structural_example_2
-               example_2.cpp)
-
-target_include_directories(structural_example_2 PRIVATE
-                            ${CMAKE_CURRENT_LIST_DIR}
-                            ${PROJECT_SOURCE_DIR}
-                            ${PROJECT_SOURCE_DIR}/src)
+    example_2.cpp)
 
 target_link_libraries(structural_example_2 mast)
 
+target_include_directories(structural_example_2
+        PRIVATE
+        ${CMAKE_SOURCE_DIR})
+
 install(TARGETS structural_example_2
-RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/examples)
+    RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/examples)
+
+# Test on single processor, PETSc built-in LU direct linear solver (sequential).
+add_test(NAME structural_example_2
+    COMMAND $<TARGET_FILE:structural_example_2> -ksp_type preonly -pc_type lu -options_view)
+set_tests_properties(structural_example_2
+    PROPERTIES
+        LABELS "SHORT;SEQ")
+
+# Test multiple processors, parallel direct solver using external MUMPS package.
+add_test(NAME structural_example_2_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:structural_example_2>
+            -ksp_type preonly -pc_type lu -pc_factor_mat_solver_package mumps -options_view)
+set_tests_properties(structural_example_2_mpi
+    PROPERTIES
+        LABELS "SHORT;MPI")

--- a/examples/structural/example_3/CMakeLists.txt
+++ b/examples/structural/example_3/CMakeLists.txt
@@ -1,13 +1,27 @@
 add_executable(structural_example_3
-                example_3.cpp
-                ${MAST_ROOT_DIR}/examples/structural/base/thermal_stress_jacobian_scaling_function.cpp)
-
-target_include_directories(structural_example_3 PRIVATE
-                            ${CMAKE_CURRENT_LIST_DIR}
-                            ${PROJECT_SOURCE_DIR}
-                            ${PROJECT_SOURCE_DIR}/src)
+    example_3.cpp
+    ${CMAKE_SOURCE_DIR}/examples/structural/base/thermal_stress_jacobian_scaling_function.cpp)
 
 target_link_libraries(structural_example_3 mast)
 
+target_include_directories(structural_example_3
+    PRIVATE
+        ${CMAKE_SOURCE_DIR})
+
 install(TARGETS structural_example_3
-        RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/examples)
+    RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/examples)
+
+# Test on single processor, PETSc built-in LU direct linear solver (sequential).
+add_test(NAME structural_example_3
+        COMMAND $<TARGET_FILE:structural_example_3> -ksp_type preonly -pc_type lu -options_view)
+set_tests_properties(structural_example_3
+        PROPERTIES
+        LABELS "SEQ")
+
+# Test multiple processors, parallel direct solver using external MUMPS package.
+add_test(NAME structural_example_3_mpi
+        COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:structural_example_3>
+        -ksp_type preonly -pc_type lu -pc_factor_mat_solver_package mumps -options_view)
+set_tests_properties(structural_example_3_mpi
+        PROPERTIES
+        LABELS "MPI")

--- a/examples/structural/example_4/CMakeLists.txt
+++ b/examples/structural/example_4/CMakeLists.txt
@@ -4,4 +4,19 @@ add_executable(structural_example_4
 target_link_libraries(structural_example_4 mast)
 
 install(TARGETS structural_example_4
-        RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/examples)
+    RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/examples)
+
+# Test on single processor, PETSc built-in LU direct linear solver (sequential).
+add_test(NAME structural_example_4
+        COMMAND $<TARGET_FILE:structural_example_4> -ksp_type preonly -pc_type lu -options_view)
+set_tests_properties(structural_example_4
+        PROPERTIES
+        LABELS "SHORT;SEQ")
+
+# Test multiple processors, parallel direct solver using external MUMPS package.
+add_test(NAME structural_example_4_mpi
+        COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:structural_example_4>
+        -ksp_type preonly -pc_type lu -pc_factor_mat_solver_package mumps -options_view)
+set_tests_properties(structural_example_4_mpi
+        PROPERTIES
+        LABELS "SHORT;MPI")

--- a/examples/structural/example_7/CMakeLists.txt
+++ b/examples/structural/example_7/CMakeLists.txt
@@ -5,12 +5,16 @@ if(ENABLE_NASTRANIO)
 
     target_link_libraries(structural_example_7 mast)
 
-    install(TARGETS structural_example_7
-            RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/examples)
+# Move BDF to binary directory for convenient testing.
+configure_file(${CMAKE_CURRENT_LIST_DIR}/example_7_acoss_mesh.bdf ${CMAKE_CURRENT_BINARY_DIR} COPYONLY)
 
-    configure_file(${CMAKE_CURRENT_LIST_DIR}/example_7_acoss_mesh.bdf ${CMAKE_CURRENT_BINARY_DIR} COPYONLY)
-
-    add_test(NAME structural_example_7_mpi
-        COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:structural_example_7> -ksp_type "preonly" -pc_type "lu")
+## Test on single processor, default options.
+#add_test(NAME structural_example_7
+#        COMMAND $<TARGET_FILE:structural_example_7>)
+#
+## Test multiple processors, parallel direct solver using external MUMPS package.
+#add_test(NAME structural_example_7_mpi
+#    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:structural_example_7>
+#            -st_ksp_type gmres -st_pc_type bjacobi -st_ksp_rtol 1e-9)
 
 endif()

--- a/examples/structural/example_7/CMakeLists.txt
+++ b/examples/structural/example_7/CMakeLists.txt
@@ -1,20 +1,29 @@
 if(ENABLE_NASTRANIO)
 
     add_executable(structural_example_7
-            example_7.cpp)
+        example_7.cpp)
 
     target_link_libraries(structural_example_7 mast)
 
-# Move BDF to binary directory for convenient testing.
-configure_file(${CMAKE_CURRENT_LIST_DIR}/example_7_acoss_mesh.bdf ${CMAKE_CURRENT_BINARY_DIR} COPYONLY)
+    # Move BDF to binary directory for convenient testing.
+    configure_file(${CMAKE_CURRENT_LIST_DIR}/example_7_acoss_mesh.bdf ${CMAKE_CURRENT_BINARY_DIR} COPYONLY)
 
-## Test on single processor, default options.
-#add_test(NAME structural_example_7
-#        COMMAND $<TARGET_FILE:structural_example_7>)
-#
-## Test multiple processors, parallel direct solver using external MUMPS package.
-#add_test(NAME structural_example_7_mpi
-#    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:structural_example_7>
-#            -st_ksp_type gmres -st_pc_type bjacobi -st_ksp_rtol 1e-9)
+    install(TARGETS structural_example_7
+        RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/examples)
+
+    # Test on single processor, PETSc built-in LU direct linear solver (sequential).
+    add_test(NAME structural_example_7
+        COMMAND $<TARGET_FILE:structural_example_7> -ksp_type preonly -pc_type lu -options_view)
+    set_tests_properties(structural_example_7
+        PROPERTIES
+            LABELS "SHORT;SEQ")
+
+    # Test multiple processors, parallel direct solver using external MUMPS package.
+    add_test(NAME structural_example_7_mpi
+        COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:structural_example_7>
+                -ksp_type preonly -pc_type lu -pc_factor_mat_solver_package mumps -options_view)
+    set_tests_properties(structural_example_7_mpi
+        PROPERTIES
+            LABELS "SHORT;MPI")
 
 endif()


### PR DESCRIPTION
Previously, the Travis-CI system only checked that all of the separate example executables successfully compile, but did not execute them. Here we implement a solution that lets the Travis-CI system automatically test the execution of the examples if appropriate CTest "tests" are defined for them and they are identified to be quick executing.

We use CTest to handle the execution of examples on Travis-CI. As a result, running an example requires `add_test()` statements for its CMake target. In addition, since many of the examples have long runtime and we currently only want to test execution of fast ones on Travis-CI, we need to apply a `"SHORT"` label to the test target. The following code shows what to add to an example's `CMakeLists.txt` to enable both a serial and parallel MPI execution on Travis-CI. Currently, structural examples 1, 4, and 7 provide good references for "short" examples. Structural example 3 defines tests that are NOT labeled as `"SHORT"`. They can be executed by CTest locally, but will not run on Travis-CI since it this example currently has longer runtime.

```cmake
# Test on single processor.
add_test(NAME example_name
    COMMAND $<TARGET_FILE:example_target_name> -petsc_solver_options -other_command_line_options)
set_tests_properties(test_name
    PROPERTIES
        LABELS "SHORT;SEQ")

# Test multiple processors.
add_test(NAME example_name_mpi
    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:example_target_name>
            -petsc_solver_options -other_command_line_options)
set_tests_properties(example_name
    PROPERTIES
        LABELS "SHORT;MPI")
```

Note that Travis CI workers only have 2 processors so we should only use -np 2 when running there and I have currently hard-coded this in.

Future enhancements in new pull requests will:
- check the results of all `"SHORT"` labeled examples against known verification data.
- incorporate a wrapper to start execution of long examples, but then kill them once the solvers start. This will detect potential linking errors in build and ensure that basic problem setup is correct.
