### PR TITLE
Additional Catch2 tests of existing functionality.

### DIFF
--- a/src/property_cards/isotropic_element_property_card_3D.cpp
+++ b/src/property_cards/isotropic_element_property_card_3D.cpp
@@ -431,6 +431,17 @@ stiffness_A_matrix(const MAST::ElementBase& e) const {
 }
 
 
+std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+MAST::IsotropicElementPropertyCard3D::
+stiffness_A_matrix() const {
+    
+    MAST::FieldFunction<RealMatrixX>* rval =
+    new MAST::IsotropicElementProperty3D::StiffnessMatrix
+    (_material->stiffness_matrix(3));
+    
+    return std::unique_ptr<MAST::FieldFunction<RealMatrixX> >(rval);
+}
+
 
 std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
 MAST::IsotropicElementPropertyCard3D::
@@ -442,6 +453,14 @@ stiffness_B_matrix(const MAST::ElementBase& e) const {
 }
 
 
+std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+MAST::IsotropicElementPropertyCard3D::
+stiffness_B_matrix() const {
+    
+    libmesh_assert(false);
+    
+    return std::unique_ptr<MAST::FieldFunction<RealMatrixX> >(nullptr);
+}
 
 
 std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
@@ -453,6 +472,15 @@ stiffness_D_matrix(const MAST::ElementBase& e) const {
     return std::unique_ptr<MAST::FieldFunction<RealMatrixX> >(nullptr);
 }
 
+
+std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+MAST::IsotropicElementPropertyCard3D::
+stiffness_D_matrix() const {
+    
+    libmesh_assert(false);
+    
+    return std::unique_ptr<MAST::FieldFunction<RealMatrixX> >(nullptr);
+}
 
 
 std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
@@ -477,10 +505,34 @@ inertia_matrix(const MAST::ElementBase& e) const {
 }
 
 
+std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+MAST::IsotropicElementPropertyCard3D::
+inertia_matrix() const {
+    
+    MAST::FieldFunction<RealMatrixX>* rval =
+    new MAST::IsotropicElementProperty3D::InertiaMatrix
+    (_material->inertia_matrix(3));
+    
+    return std::unique_ptr<MAST::FieldFunction<RealMatrixX> >(rval);
+}
+
 
 std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
 MAST::IsotropicElementPropertyCard3D::
 thermal_expansion_A_matrix(const MAST::ElementBase& e) const {
+    
+    MAST::FieldFunction<RealMatrixX>* rval =
+    new MAST::IsotropicElementProperty3D::ThermalExpansionMatrix
+    (_material->stiffness_matrix(3),
+     _material->thermal_expansion_matrix(3));
+    
+    return std::unique_ptr<MAST::FieldFunction<RealMatrixX> >(rval);
+}
+
+
+std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+MAST::IsotropicElementPropertyCard3D::
+thermal_expansion_A_matrix() const {
     
     MAST::FieldFunction<RealMatrixX>* rval =
     new MAST::IsotropicElementProperty3D::ThermalExpansionMatrix
@@ -499,6 +551,14 @@ thermal_expansion_B_matrix(const MAST::ElementBase& e) const {
     return this->thermal_expansion_A_matrix(e);
 }
 
+
+std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+MAST::IsotropicElementPropertyCard3D::
+thermal_expansion_B_matrix() const {
+    
+    // for 3D elements, there is no difference between the A and B matrices
+    return this->thermal_expansion_A_matrix();
+}
 
 
 std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
@@ -545,6 +605,18 @@ thermal_conductance_matrix(const MAST::ElementBase& e) const {
 
 std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
 MAST::IsotropicElementPropertyCard3D::
+thermal_conductance_matrix() const {
+    
+    MAST::FieldFunction<RealMatrixX>* rval =
+    new MAST::IsotropicElementProperty3D::ThermalConductanceMatrix
+    (_material->conductance_matrix(3));
+    
+    return std::unique_ptr<MAST::FieldFunction<RealMatrixX> >(rval);
+}
+
+
+std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+MAST::IsotropicElementPropertyCard3D::
 thermal_capacitance_matrix(const MAST::ElementBase& e) const {
     
     MAST::FieldFunction<RealMatrixX>* rval =
@@ -554,4 +626,15 @@ thermal_capacitance_matrix(const MAST::ElementBase& e) const {
     return std::unique_ptr<MAST::FieldFunction<RealMatrixX> >(rval);
 }
 
+
+std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+MAST::IsotropicElementPropertyCard3D::
+thermal_capacitance_matrix() const {
+    
+    MAST::FieldFunction<RealMatrixX>* rval =
+    new MAST::IsotropicElementProperty3D::ThermalCapacitanceMatrix
+    (_material->capacitance_matrix(3));
+    
+    return std::unique_ptr<MAST::FieldFunction<RealMatrixX> >(rval);
+}
 

--- a/src/property_cards/isotropic_element_property_card_3D.h
+++ b/src/property_cards/isotropic_element_property_card_3D.h
@@ -104,10 +104,19 @@ namespace MAST
         stiffness_A_matrix(const MAST::ElementBase& e) const;
         
         virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+        stiffness_A_matrix() const;
+        
+        virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
         stiffness_B_matrix(const MAST::ElementBase& e) const;
         
         virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+        stiffness_B_matrix() const;
+        
+        virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
         stiffness_D_matrix(const MAST::ElementBase& e) const;
+        
+        virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+        stiffness_D_matrix() const;
         
         virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
         damping_matrix(const MAST::ElementBase& e) const;
@@ -116,10 +125,19 @@ namespace MAST
         inertia_matrix(const MAST::ElementBase& e) const;
         
         virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+        inertia_matrix() const;
+        
+        virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
         thermal_expansion_A_matrix(const MAST::ElementBase& e) const;
         
         virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+        thermal_expansion_A_matrix() const;
+        
+        virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
         thermal_expansion_B_matrix(const MAST::ElementBase& e) const;
+        
+        virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+        thermal_expansion_B_matrix() const;
         
         virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
         transverse_shear_stiffness_matrix(const MAST::ElementBase& e) const;
@@ -134,7 +152,13 @@ namespace MAST
         thermal_conductance_matrix(const MAST::ElementBase& e) const;
         
         virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+        thermal_conductance_matrix() const;
+        
+        virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
         thermal_capacitance_matrix(const MAST::ElementBase& e) const;
+        
+        virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+        thermal_capacitance_matrix() const;
         
         virtual const MAST::FieldFunction<Real>&
         section(const MAST::ElementBase& e) const {

--- a/src/property_cards/solid_1d_section_element_property_card.cpp
+++ b/src/property_cards/solid_1d_section_element_property_card.cpp
@@ -1619,9 +1619,7 @@ MAST::Solid1DSectionElementPropertyCard::Gam() {
 
 void
 MAST::Solid1DSectionElementPropertyCard::clear() {
-    
-    libmesh_assert(!_initialized);
-    
+
     _A.reset();
     _Ay.reset();
     _Az.reset();

--- a/src/property_cards/solid_1d_section_element_property_card.cpp
+++ b/src/property_cards/solid_1d_section_element_property_card.cpp
@@ -1926,7 +1926,7 @@ transverse_shear_stiffness_matrix() const {
     MAST::FieldFunction<RealMatrixX>* rval =
     new MAST::Solid1DSectionProperty::TransverseStiffnessMatrix
     (_material->transverse_shear_stiffness_matrix(),
-     *_A);
+     *_A, *_Kappa);
     
     return std::unique_ptr<MAST::FieldFunction<RealMatrixX> > (rval);
 }

--- a/src/property_cards/solid_1d_section_element_property_card.cpp
+++ b/src/property_cards/solid_1d_section_element_property_card.cpp
@@ -1693,7 +1693,37 @@ stiffness_A_matrix(const MAST::ElementBase& e) const {
 
 std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
 MAST::Solid1DSectionElementPropertyCard::
+stiffness_A_matrix() const {
+    
+    // make sure that the init method has been called on the card
+    libmesh_assert(_initialized);
+    
+    MAST::FieldFunction<RealMatrixX>* rval =
+    new MAST::Solid1DSectionProperty::ExtensionStiffnessMatrix
+    (_material->stiffness_matrix(1), *_A, *_J);
+    
+    return std::unique_ptr<MAST::FieldFunction<RealMatrixX> > (rval);
+}
+
+
+std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+MAST::Solid1DSectionElementPropertyCard::
 stiffness_B_matrix(const MAST::ElementBase& e) const {
+    
+    // make sure that the init method has been called on the card
+    libmesh_assert(_initialized);
+
+    MAST::FieldFunction<RealMatrixX>* rval =
+    new MAST::Solid1DSectionProperty::ExtensionBendingStiffnessMatrix
+    (_material->stiffness_matrix(1), *_Ay, *_Az);
+    
+    return std::unique_ptr<MAST::FieldFunction<RealMatrixX> > (rval);
+}
+
+
+std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+MAST::Solid1DSectionElementPropertyCard::
+stiffness_B_matrix() const {
     
     // make sure that the init method has been called on the card
     libmesh_assert(_initialized);
@@ -1723,6 +1753,21 @@ stiffness_D_matrix(const MAST::ElementBase& e) const {
 
 std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
 MAST::Solid1DSectionElementPropertyCard::
+stiffness_D_matrix() const {
+    
+    // make sure that the init method has been called on the card
+    libmesh_assert(_initialized);
+    
+    MAST::FieldFunction<RealMatrixX>* rval =
+    new MAST::Solid1DSectionProperty::BendingStiffnessMatrix
+    (_material->stiffness_matrix(1), *_AI);
+    
+    return std::unique_ptr<MAST::FieldFunction<RealMatrixX> > (rval);
+}
+
+
+std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+MAST::Solid1DSectionElementPropertyCard::
 damping_matrix(const MAST::ElementBase& e) const {
     
     libmesh_error();
@@ -1730,6 +1775,15 @@ damping_matrix(const MAST::ElementBase& e) const {
     return std::unique_ptr<MAST::FieldFunction<RealMatrixX> > (nullptr);
 }
 
+
+std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+MAST::Solid1DSectionElementPropertyCard::
+damping_matrix() const {
+    
+    libmesh_error();
+    
+    return std::unique_ptr<MAST::FieldFunction<RealMatrixX> > (nullptr);
+}
 
 
 std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
@@ -1752,6 +1806,25 @@ inertia_matrix(const MAST::ElementBase& e) const {
 }
 
 
+std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+MAST::Solid1DSectionElementPropertyCard::
+inertia_matrix() const {
+    
+    // make sure that the init method has been called on the card
+    libmesh_assert(_initialized);
+    
+    MAST::FieldFunction<RealMatrixX>* rval =
+    new MAST::Solid1DSectionProperty::InertiaMatrix
+    (_material->get<FieldFunction<Real> >("rho"),
+     *_A,
+     *_Ay,
+     *_Az,
+     *_Ip,
+     *_AI);
+    
+    return std::unique_ptr<MAST::FieldFunction<RealMatrixX> > (rval);
+}
+
 
 std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
 MAST::Solid1DSectionElementPropertyCard::
@@ -1770,10 +1843,45 @@ thermal_expansion_A_matrix(const MAST::ElementBase& e) const {
 }
 
 
+std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+MAST::Solid1DSectionElementPropertyCard::
+thermal_expansion_A_matrix() const {
+    
+    // make sure that the init method has been called on the card
+    libmesh_assert(_initialized);
+
+    MAST::FieldFunction<RealMatrixX>* rval =
+    new MAST::Solid1DSectionProperty::ThermalExpansionAMatrix
+    (_material->stiffness_matrix(1),
+     _material->thermal_expansion_matrix(1),
+     *_A);
+    
+    return std::unique_ptr<MAST::FieldFunction<RealMatrixX> > (rval);
+}
+
 
 std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
 MAST::Solid1DSectionElementPropertyCard::
 thermal_expansion_B_matrix(const MAST::ElementBase& e) const {
+    
+    
+    // make sure that the init method has been called on the card
+    libmesh_assert(_initialized);
+
+    MAST::FieldFunction<RealMatrixX>* rval =
+    new MAST::Solid1DSectionProperty::ThermalExpansionBMatrix
+    (_material->stiffness_matrix(1),
+     _material->thermal_expansion_matrix(1),
+     *_Ay,
+     *_Az);
+    
+    return std::unique_ptr<MAST::FieldFunction<RealMatrixX> > (rval);
+}
+
+
+std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+MAST::Solid1DSectionElementPropertyCard::
+thermal_expansion_B_matrix() const {
     
     
     // make sure that the init method has been called on the card
@@ -1809,7 +1917,43 @@ transverse_shear_stiffness_matrix(const MAST::ElementBase& e) const {
 
 std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
 MAST::Solid1DSectionElementPropertyCard::
+transverse_shear_stiffness_matrix() const {
+    
+    
+    // make sure that the init method has been called on the card
+    libmesh_assert(_initialized);
+
+    MAST::FieldFunction<RealMatrixX>* rval =
+    new MAST::Solid1DSectionProperty::TransverseStiffnessMatrix
+    (_material->transverse_shear_stiffness_matrix(),
+     *_A);
+    
+    return std::unique_ptr<MAST::FieldFunction<RealMatrixX> > (rval);
+}
+
+
+std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+MAST::Solid1DSectionElementPropertyCard::
 prestress_A_matrix(MAST::ElementBase& e) const {
+    
+    // make sure that the init method has been called on the card
+    libmesh_assert(_initialized);
+
+    MAST::FieldFunction<RealMatrixX>* rval;
+    // TODO: figure out the interface for prestress and T matrix
+    libmesh_assert(false);
+    // = new MAST::Solid1DSectionProperty::PrestressAMatrix
+    //(this->get<MAST::FieldFunction<RealMatrixX> >("prestress"),
+    // e.local_elem().T_matrix(),
+    // *_A);
+    
+    return std::unique_ptr<MAST::FieldFunction<RealMatrixX> > (rval);
+}
+
+
+std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+MAST::Solid1DSectionElementPropertyCard::
+prestress_A_matrix() const {
     
     // make sure that the init method has been called on the card
     libmesh_assert(_initialized);
@@ -1846,6 +1990,25 @@ prestress_B_matrix(MAST::ElementBase& e) const {
 }
 
 
+std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+MAST::Solid1DSectionElementPropertyCard::
+prestress_B_matrix() const {
+    
+    // make sure that the init method has been called on the card
+    libmesh_assert(_initialized);
+
+    MAST::FieldFunction<RealMatrixX>* rval;
+    // TODO: figure out the interface for prestress and T matrix
+    libmesh_assert(false);
+    // = new MAST::Solid1DSectionProperty::PrestressBMatrix
+    //(this->get<MAST::FieldFunction<RealMatrixX> >("prestress"),
+    // e.local_elem().T_matrix(),
+    // *_Ay,
+    // *_Az);
+    
+    return std::unique_ptr<MAST::FieldFunction<RealMatrixX> > (rval);
+}
+
 
 std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
 MAST::Solid1DSectionElementPropertyCard::
@@ -1863,10 +2026,41 @@ thermal_conductance_matrix(const MAST::ElementBase& e) const {
 }
 
 
+std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+MAST::Solid1DSectionElementPropertyCard::
+thermal_conductance_matrix() const {
+    
+    // make sure that the init method has been called on the card
+    libmesh_assert(_initialized);
+    
+    MAST::FieldFunction<RealMatrixX>* rval =
+    new MAST::Solid1DSectionProperty::ThermalConductanceMatrix
+    (_material->conductance_matrix(1),
+     *_A);
+    
+    return std::unique_ptr<MAST::FieldFunction<RealMatrixX> > (rval);
+}
+
 
 std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
 MAST::Solid1DSectionElementPropertyCard::
 thermal_capacitance_matrix(const MAST::ElementBase& e) const {
+    
+    // make sure that the init method has been called on the card
+    libmesh_assert(_initialized);
+    
+    MAST::FieldFunction<RealMatrixX>* rval =
+    new MAST::Solid1DSectionProperty::ThermalCapacitanceMatrix
+    (_material->capacitance_matrix(1),
+     *_A);
+    
+    return std::unique_ptr<MAST::FieldFunction<RealMatrixX> > (rval);
+}
+
+
+std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+MAST::Solid1DSectionElementPropertyCard::
+thermal_capacitance_matrix() const {
     
     // make sure that the init method has been called on the card
     libmesh_assert(_initialized);
@@ -1887,3 +2081,10 @@ section(const MAST::ElementBase& e) const {
     return *_A;
 }
 
+
+const MAST::FieldFunction<Real>&
+MAST::Solid1DSectionElementPropertyCard::
+section() const {
+    
+    return *_A;
+}

--- a/src/property_cards/solid_1d_section_element_property_card.h
+++ b/src/property_cards/solid_1d_section_element_property_card.h
@@ -75,16 +75,54 @@ namespace MAST {
         virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
         prestress_B_matrix(MAST::ElementBase& e) const;
 
-        
         virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
         thermal_conductance_matrix(const MAST::ElementBase& e) const;
         
-
         virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
         thermal_capacitance_matrix(const MAST::ElementBase& e) const;
 
         virtual const MAST::FieldFunction<Real>&
         section(const MAST::ElementBase& e) const;
+        
+        virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+        stiffness_A_matrix() const;
+        
+        virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+        stiffness_B_matrix() const;
+        
+        virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+        stiffness_D_matrix() const;
+        
+        virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+        damping_matrix() const;
+        
+        virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+        inertia_matrix() const;
+        
+        virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+        thermal_expansion_A_matrix() const;
+        
+        virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+        thermal_expansion_B_matrix() const;
+        
+        virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+        transverse_shear_stiffness_matrix() const;
+        
+        virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+        prestress_A_matrix() const;
+        
+        virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+        prestress_B_matrix() const;
+        
+        virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+        thermal_conductance_matrix() const;
+        
+        virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+        thermal_capacitance_matrix() const;
+
+        virtual const MAST::FieldFunction<Real>&
+        section() const;
+        
 
         /*!
          *    sets the material card

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,8 +15,8 @@ target_link_libraries(mast_catch_tests mast)
 # TODO: May be better to use Catch2's built in CMake support rather than manually adding through ctest
 
 add_subdirectory(base)
-#add_subdirectory(boundary_condition)
 add_subdirectory(material)
+add_subdirectory(boundary_condition)
 #add_subdirectory(property)
 #add_subdirectory(element)
 
@@ -54,21 +54,3 @@ endif()
 # having to run the entire "make check" command.
 add_custom_target(test_graph
     COMMAND python ${CMAKE_CURRENT_LIST_DIR}/GenerateTestDependencyGraph.py ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt)
-
-
-# TODO: Add the tests below back in later.
-# add_test(NAME MAST::IsotropicMaterial_Constant_Structural_1D 
-#          COMMAND mast_catch_tests constant_isotropic_structural_material_1d)
-# set_tests_properties(MAST::IsotropicMaterial_Constant_Structural_1D
-#                      PROPERTIES FIXTURES_REQUIRED MAST::ConstantFieldFunction)
-#     
-# add_test(NAME MAST::IsotropicMaterial_Constant_HeatTransfer_1D 
-#          COMMAND mast_catch_tests constant_isotropic_heat_transfer_material_1d)
-# set_tests_properties(MAST::IsotropicMaterial_Constant_HeatTransfer_1D
-#                      PROPERTIES FIXTURES_REQUIRED MAST::ConstantFieldFunction)
-#                     
-#                     
-# add_test(NAME MAST::IsotropicMaterial_Constant_HeatTransfer_2D
-#          COMMAND mast_catch_tests constant_isotropic_heat_transfer_material_2d)
-# set_tests_properties(MAST::IsotropicMaterial_Constant_HeatTransfer_2D
-#                     PROPERTIES FIXTURES_REQUIRED MAST::ConstantFieldFunction)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,9 +15,9 @@ target_link_libraries(mast_catch_tests mast)
 # TODO: May be better to use Catch2's built in CMake support rather than manually adding through ctest
 
 add_subdirectory(base)
-add_subdirectory(material)
 add_subdirectory(boundary_condition)
-#add_subdirectory(property)
+add_subdirectory(material)
+add_subdirectory(property)
 #add_subdirectory(element)
 
 message(NOTICE "It is recommended to run 'make check' instead of 'make test'. Alternatively, for 'ctest' or \

--- a/tests/boundary_condition/CMakeLists.txt
+++ b/tests/boundary_condition/CMakeLists.txt
@@ -1,0 +1,21 @@
+target_sources( mast_catch_tests
+                PRIVATE
+                ${CMAKE_CURRENT_LIST_DIR}/mast_thermoelastic_load.cpp)
+
+
+# # BoundaryConditionBase tests that depend on FunctionSetBase tests being successful
+# add_test(NAME BoundaryConditionBase
+#          COMMAND mast_catch_tests "boundary_condition_base")
+# set_tests_properties(BoundaryConditionBase
+#                      PROPERTIES 
+#                      FIXTURES_REQUIRED FunctionSetBase
+#                      FIXTURES_SETUP BoundaryConditionBase)
+
+
+# Temperature Boundary Condition Test
+add_test(NAME Thermoelastic_Load
+         COMMAND mast_catch_tests "create_thermoelastic_load")
+set_tests_properties(Thermoelastic_Load
+                     PROPERTIES 
+                     FIXTURES_REQUIRED BoundaryConditionBase
+                     FIXTURES_SETUP Thermoelastic_Load)

--- a/tests/boundary_condition/CMakeLists.txt
+++ b/tests/boundary_condition/CMakeLists.txt
@@ -1,15 +1,16 @@
 target_sources( mast_catch_tests
                 PRIVATE
+                ${CMAKE_CURRENT_LIST_DIR}/mast_boundary_condition_base.cpp
                 ${CMAKE_CURRENT_LIST_DIR}/mast_thermoelastic_load.cpp)
 
 
-# # BoundaryConditionBase tests that depend on FunctionSetBase tests being successful
-# add_test(NAME BoundaryConditionBase
-#          COMMAND mast_catch_tests "boundary_condition_base")
-# set_tests_properties(BoundaryConditionBase
-#                      PROPERTIES 
-#                      FIXTURES_REQUIRED FunctionSetBase
-#                      FIXTURES_SETUP BoundaryConditionBase)
+# BoundaryConditionBase tests that depend on FunctionSetBase tests being successful
+add_test(NAME BoundaryConditionBase
+         COMMAND mast_catch_tests "boundary_condition_base")
+set_tests_properties(BoundaryConditionBase
+                     PROPERTIES 
+                     FIXTURES_REQUIRED FunctionSetBase
+                     FIXTURES_SETUP BoundaryConditionBase)
 
 
 # Temperature Boundary Condition Test

--- a/tests/boundary_condition/CMakeLists.txt
+++ b/tests/boundary_condition/CMakeLists.txt
@@ -1,22 +1,39 @@
-target_sources( mast_catch_tests
-                PRIVATE
-                ${CMAKE_CURRENT_LIST_DIR}/mast_boundary_condition_base.cpp
-                ${CMAKE_CURRENT_LIST_DIR}/mast_thermoelastic_load.cpp)
+target_sources(mast_catch_tests
+    PRIVATE
+        ${CMAKE_CURRENT_LIST_DIR}/mast_boundary_condition_base.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/mast_thermoelastic_load.cpp)
 
 
 # BoundaryConditionBase tests that depend on FunctionSetBase tests being successful
 add_test(NAME BoundaryConditionBase
-         COMMAND mast_catch_tests "boundary_condition_base")
+    COMMAND mast_catch_tests -w NoTests "boundary_condition_base")
 set_tests_properties(BoundaryConditionBase
-                     PROPERTIES 
-                     FIXTURES_REQUIRED FunctionSetBase
-                     FIXTURES_SETUP BoundaryConditionBase)
+    PROPERTIES
+        LABELS "SEQ"
+        FIXTURES_REQUIRED FunctionSetBase
+        FIXTURES_SETUP BoundaryConditionBase)
 
+add_test(NAME BoundaryConditionBase_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "boundary_condition_base")
+set_tests_properties(BoundaryConditionBase_mpi
+    PROPERTIES
+        LABELS "MPI"
+        FIXTURES_REQUIRED FunctionSetBase_mpi
+        FIXTURES_SETUP BoundaryConditionBase_mpi)
 
 # Temperature Boundary Condition Test
 add_test(NAME Thermoelastic_Load
-         COMMAND mast_catch_tests "create_thermoelastic_load")
+    COMMAND mast_catch_tests -w NoTests "create_thermoelastic_load")
 set_tests_properties(Thermoelastic_Load
-                     PROPERTIES 
-                     FIXTURES_REQUIRED BoundaryConditionBase
-                     FIXTURES_SETUP Thermoelastic_Load)
+    PROPERTIES
+        LABELS "SEQ"
+        FIXTURES_REQUIRED BoundaryConditionBase
+        FIXTURES_SETUP Thermoelastic_Load)
+
+add_test(NAME Thermoelastic_Load_mpi
+        COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "create_thermoelastic_load")
+set_tests_properties(Thermoelastic_Load_mpi
+    PROPERTIES
+        LABELS "MPI"
+        FIXTURES_REQUIRED BoundaryConditionBase_mpi
+        FIXTURES_SETUP Thermoelastic_Load_mpi)

--- a/tests/boundary_condition/mast_boundary_condition_base.cpp
+++ b/tests/boundary_condition/mast_boundary_condition_base.cpp
@@ -1,0 +1,46 @@
+#include "catch.hpp"
+
+#include "base/parameter.h"
+#include "base/constant_field_function.h"
+#include "base/boundary_condition_base.h"
+
+TEST_CASE("boundary_condition_base",
+          "[boundary_condition][base]")
+{
+    MAST::Parameter param1("dummy_param", 482.222);
+    
+    MAST::ConstantFieldFunction dummy_f("dummy", param1);
+    
+    // Ensure that this is a derived calss of MAST::FunctionSetBase
+    // This is important becasue we assume that if the FunctionSetBase tests 
+    // pass, then all methods that BoundaryConditionBase inherits from it
+    // will automatically pass as well.  If this changes, we need to detect
+    // this so we can rewrite these tests for MAST::BoundaryConditionBase.
+    REQUIRE( std::is_base_of<MAST::FunctionSetBase, MAST::BoundaryConditionBase>::value );
+    
+    MAST::BoundaryConditionBase bc1(MAST::SURFACE_PRESSURE);   
+    REQUIRE( bc1.type() == MAST::SURFACE_PRESSURE ); 
+    
+    MAST::BoundaryConditionBase bc2(MAST::POINT_LOAD);
+    MAST::BoundaryConditionBase bc3(MAST::POINT_MOMENT);
+    MAST::BoundaryConditionBase bc4(MAST::PISTON_THEORY);
+    MAST::BoundaryConditionBase bc5(MAST::DIRICHLET);
+    
+    MAST::BoundaryConditionBase bc6(MAST::TEMPERATURE);
+    REQUIRE( bc6.type() == MAST::TEMPERATURE );
+    
+    MAST::BoundaryConditionBase bc7(MAST::HEAT_FLUX);
+    MAST::BoundaryConditionBase bc8(MAST::CONVECTION_HEAT_FLUX);
+    MAST::BoundaryConditionBase bc9(MAST::SURFACE_RADIATION_HEAT_FLUX);
+    MAST::BoundaryConditionBase bc10(MAST::HEAT_SOURCE);
+    REQUIRE( bc10.type() == MAST::HEAT_SOURCE );
+    
+    MAST::BoundaryConditionBase bc11(MAST::NO_SLIP_WALL);
+    MAST::BoundaryConditionBase bc12(MAST::SYMMETRY_WALL);
+    MAST::BoundaryConditionBase bc13(MAST::SLIP_WALL);
+    MAST::BoundaryConditionBase bc14(MAST::FAR_FIELD);
+    MAST::BoundaryConditionBase bc15(MAST::EXHAUST);
+    MAST::BoundaryConditionBase bc16(MAST::ISOTHERMAL);
+    MAST::BoundaryConditionBase bc17(MAST::ADIABATIC);
+    //MAST::BoundaryConditionBase bc18(MAST::DOF_DIRICHLET);
+}

--- a/tests/boundary_condition/mast_boundary_condition_base.cpp
+++ b/tests/boundary_condition/mast_boundary_condition_base.cpp
@@ -1,3 +1,22 @@
+/*
+ * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
+ * Copyright (C) 2013-2020  Manav Bhatia and MAST authors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 #include "catch.hpp"
 
 #include "base/parameter.h"

--- a/tests/boundary_condition/mast_thermoelastic_load.cpp
+++ b/tests/boundary_condition/mast_thermoelastic_load.cpp
@@ -1,0 +1,39 @@
+#include "catch.hpp"
+
+#include "test_helpers.h"
+
+// MAST includes
+#include "base/parameter.h"
+#include "base/constant_field_function.h"
+#include "base/boundary_condition_base.h"
+
+/** 
+ * NOTE: In this test, we aren't really checking anything new that wasn't
+ * already checked in the function_set_base and boundary_condition_base tests.
+ * We are more or least double checking that the strings specific to a 
+ * thermoelastic load work.
+ */
+TEST_CASE("create_thermoelastic_load",
+          "[thermoelastic],[load]")
+{
+    MAST::Parameter temperature("T", 482.222);
+    MAST::Parameter ref_temperature("T0", 0.0);
+    
+    MAST::ConstantFieldFunction temperature_f("temperature", temperature);
+    MAST::ConstantFieldFunction ref_temperature_f("ref_temperature", ref_temperature);
+    
+    MAST::BoundaryConditionBase temperature_load(MAST::TEMPERATURE);   // Initialize a thermoelastic load
+    
+    REQUIRE( temperature_load.type() == MAST::TEMPERATURE );
+    
+    temperature_load.add(temperature_f);                               // Add the field function defining the temperature to the thermoelastic load object
+    temperature_load.add(ref_temperature_f);                           // Add the field function defining the reference temperature to the thermoelastic load object
+    
+    REQUIRE( temperature_load.contains("temperature") );
+    REQUIRE( temperature_load.contains("ref_temperature") );
+    REQUIRE( temperature_load.depends_on(temperature) );
+    REQUIRE( temperature_load.depends_on(ref_temperature) );
+    
+    REQUIRE_NOTHROW( temperature_load.get<MAST::FieldFunction<Real>>("temperature") );
+    REQUIRE_NOTHROW( temperature_load.get<MAST::FieldFunction<Real>>("ref_temperature") );
+}

--- a/tests/boundary_condition/mast_thermoelastic_load.cpp
+++ b/tests/boundary_condition/mast_thermoelastic_load.cpp
@@ -1,3 +1,22 @@
+/*
+ * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
+ * Copyright (C) 2013-2020  Manav Bhatia and MAST authors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 #include "catch.hpp"
 
 #include "test_helpers.h"

--- a/tests/property/CMakeLists.txt
+++ b/tests/property/CMakeLists.txt
@@ -1,0 +1,400 @@
+target_sources(mast_catch_tests
+    PRIVATE
+        ${CMAKE_CURRENT_LIST_DIR}/mast_solid_2d_section_element_property_card.cpp)
+       
+
+# ## ============================================================================
+# ##                              3D Property Card Tests
+# ## ============================================================================
+# add_test(NAME Element_Property_Card_Isotropic_3D_Thermoelastic
+#          COMMAND mast_catch_tests "element_property_card_constant_thermoelastic_isotropic_3d")
+# set_tests_properties(Element_Property_Card_Isotropic_3D_Thermoelastic
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED Isotropic_Material_3D_Thermoelastic
+#                      FIXTURES_SETUP Element_Property_Card_Isotropic_3D_Thermoelastic)
+# 
+# add_test(NAME Element_Property_Card_Isotropic_3D_Structural
+#          COMMAND mast_catch_tests "element_property_card_constant_structural_isotropic_3d")
+# set_tests_properties(Element_Property_Card_Isotropic_3D_Structural
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED Isotropic_Material_3D_Structural
+#                      FIXTURES_SETUP Element_Property_Card_Isotropic_3D_Structural)
+# 
+# add_test(NAME Element_Property_Card_Isotropic_3D_Dynamic
+#          COMMAND mast_catch_tests "element_property_card_constant_dynamic_isotropic_3d")
+# set_tests_properties(Element_Property_Card_Isotropic_3D_Dynamic
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED Isotropic_Material_3D_Dynamic
+#                      FIXTURES_SETUP Element_Property_Card_Isotropic_3D_Dynamic)
+# 
+# add_test(NAME Element_Property_Card_Isotropic_3D_Heat_Transfer
+#          COMMAND mast_catch_tests "element_property_card_constant_heat_transfer_isotropic_3d")
+# set_tests_properties(Element_Property_Card_Isotropic_3D_Heat_Transfer
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED Isotropic_Material_3D_Heat_Transfer
+#                      FIXTURES_SETUP Element_Property_Card_3D_Heat_Transfer)
+#                      
+# add_test(NAME Element_Property_Card_Isotropic_3D_Transient_Heat_Transfer
+#          COMMAND mast_catch_tests "element_property_card_constant_transient_heat_transfer_isotropic_3d")
+# set_tests_properties(Element_Property_Card_Isotropic_3D_Transient_Heat_Transfer
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED Isotropic_Material_3D_Transient_Heat_Transfer
+#                      FIXTURES_SETUP Element_Property_Card_3D_Transient_Heat_Transfer)
+
+## ============================================================================
+##                              2D Property Card Tests
+## ============================================================================
+# Structural
+add_test(NAME Element_Property_Card_2D_Structural
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "element_property_card_constant_structural_2d")
+set_tests_properties(Element_Property_Card_2D_Structural
+    PROPERTIES
+        FIXTURES_REQUIRED Isotropic_Material_2D_Structural
+        FIXTURES_SETUP Element_Property_Card_2D_Structural)
+
+add_test(NAME Element_Property_Card_2D_Structural_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "element_property_card_constant_structural_2d")
+set_tests_properties(Element_Property_Card_2D_Structural_mpi
+    PROPERTIES
+        FIXTURES_REQUIRED Isotropic_Material_2D_Structural_mpi
+        FIXTURES_SETUP Element_Property_Card_2D_Structural_mpi)
+
+
+# Thermoelastic
+add_test(NAME Element_Property_Card_2D_Thermoelastic
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "element_property_card_constant_thermoelastic_2d")
+set_tests_properties(Element_Property_Card_2D_Thermoelastic
+    PROPERTIES
+        FIXTURES_REQUIRED Isotropic_Material_2D_Thermoelastic
+        FIXTURES_SETUP Element_Property_Card_2D_Thermoelastic)
+
+add_test(NAME Element_Property_Card_2D_Thermoelastic_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "element_property_card_constant_thermoelastic_2d")
+set_tests_properties(Element_Property_Card_2D_Thermoelastic_mpi
+    PROPERTIES
+        FIXTURES_REQUIRED Isotropic_Material_2D_Thermoelastic_mpi
+        FIXTURES_SETUP Element_Property_Card_2D_Thermoelastic_mpi)
+
+
+# Dynamic
+add_test(NAME Element_Property_Card_2D_Dynamic
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "element_property_card_constant_dynamic_2d")
+set_tests_properties(Element_Property_Card_2D_Dynamic
+    PROPERTIES
+        FIXTURES_SETUP Element_Property_Card_2D_Dynamic)
+
+add_test(NAME Element_Property_Card_2D_Dynamic_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "element_property_card_constant_dynamic_2d")
+set_tests_properties(Element_Property_Card_2D_Dynamic_mpi
+    PROPERTIES
+        FIXTURES_SETUP Element_Property_Card_2D_Dynamic_mpi)
+
+
+# Heat Transfer
+add_test(NAME Element_Property_Card_2D_Heat_Transfer
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "element_property_card_constant_heat_transfer_2d")
+set_tests_properties(Element_Property_Card_2D_Heat_Transfer
+    PROPERTIES
+        FIXTURES_REQUIRED Isotropic_Material_2D_Heat_Transfer
+        FIXTURES_SETUP Element_Property_Card_2D_Heat_Transfer)
+
+add_test(NAME Element_Property_Card_2D_Heat_Transfer_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "element_property_card_constant_heat_transfer_2d")
+set_tests_properties(Element_Property_Card_2D_Heat_Transfer_mpi
+    PROPERTIES
+        FIXTURES_REQUIRED Isotropic_Material_2D_Heat_Transfer_mpi
+        FIXTURES_SETUP Element_Property_Card_2D_Heat_Transfer_mpi)
+
+
+# Transient Heat Transfer
+add_test(NAME Element_Property_Card_2D_Transient_Heat_Transfer
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "element_property_card_constant_transient_heat_transfer_2d")
+set_tests_properties(Element_Property_Card_2D_Transient_Heat_Transfer
+    PROPERTIES
+        FIXTURES_REQUIRED Isotropic_Material_2D_Transient_Heat_Transfer
+        FIXTURES_SETUP Element_Property_Card_2D_Transient_Heat_Transfer)
+
+add_test(NAME Element_Property_Card_2D_Transient_Heat_Transfer_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "element_property_card_constant_transient_heat_transfer_2d")
+set_tests_properties(Element_Property_Card_2D_Transient_Heat_Transfer_mpi
+    PROPERTIES
+        FIXTURES_REQUIRED Isotropic_Material_2D_Transient_Heat_Transfer_mpi
+        FIXTURES_SETUP Element_Property_Card_2D_Transient_Heat_Transfer_mpi)
+
+
+# ## ============================================================================
+# ##                              1D Property Card Tests
+# ## ============================================================================
+#      
+# # 1D Property Card Tests
+# # add_test(NAME Element_Property_Card_1D_Base
+# #          COMMAND mast_catch_tests element_property_card_constant_base_1d)
+# # set_tests_properties(Element_Property_Card_1D_Base
+# #                      PROPERTIES
+# #                      FIXTURES_REQUIRED Isotropic_Material_1D_Heat_Transfer)
+# 
+# ## ============================================================================
+# # 1D Arbitrary Cross Section
+# add_test(NAME Arbitrary_Element_Property_Card_1D_Base
+#          COMMAND mast_catch_tests "arbitrary_element_property_card_constant_base_1d")
+# set_tests_properties(Arbitrary_Element_Property_Card_1D_Base
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED Isotropic_Material_1D_Structural)
+# ## ============================================================================
+
+
+# ## ============================================================================
+# # 1D BAR Cross Section
+# add_test(NAME Bar_Element_Property_Card_1D_Base
+#          COMMAND mast_catch_tests "bar_element_property_card_constant_base_1d")
+# set_tests_properties(Bar_Element_Property_Card_1D_Base
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED Isotropic_Material_1D_Structural)
+#                      
+# add_test(NAME Bar_Element_Property_Card_1D_Base_Sensitivity
+#          COMMAND mast_catch_tests "bar_element_property_card_constant_base_sensitivity_1d")
+# set_tests_properties(Bar_Element_Property_Card_1D_Base_Sensitivity
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED Bar_Element_Property_Card_1D_Base)
+#                      
+# add_test(NAME Bar_Element_Property_Card_1D_Heat_Transfer
+#          COMMAND mast_catch_tests "bar_element_property_card_constant_heat_transfer_1d")
+# set_tests_properties(Bar_Element_Property_Card_1D_Heat_Transfer
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED Isotropic_Material_1D_Heat_Transfer)
+# 
+# add_test(NAME Bar_Element_Property_Card_1D_Thermoelastic
+#          COMMAND mast_catch_tests "bar_element_property_card_constant_thermoelastic_1d")
+# set_tests_properties(Bar_Element_Property_Card_1D_Thermoelastic
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED Isotropic_Material_1D_Thermoelastic)
+# 
+# add_test(NAME Bar_Element_Property_Card_1D_Structural
+#          COMMAND mast_catch_tests "bar_element_property_card_constant_structural_1d")
+# set_tests_properties(Bar_Element_Property_Card_1D_Structural
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED  Isotropic_Material_1D_Structural)
+#                      
+# add_test(NAME Bar_Element_Property_Card_1D_Dynamic
+#          COMMAND mast_catch_tests "bar_element_property_card_constant_dynamic_1d")
+# set_tests_properties(Bar_Element_Property_Card_1D_Dynamic
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED Isotropic_Material_1D_Dynamic)
+# ## ============================================================================
+
+
+# ## ============================================================================
+# # 1D ROD Cross Section
+# add_test(NAME Rod_Element_Property_Card_1D_Base
+#          COMMAND mast_catch_tests "rod_element_property_card_constant_base_1d")
+# set_tests_properties(Rod_Element_Property_Card_1D_Base
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED Isotropic_Material_1D_Structural)
+# 
+# add_test(NAME Rod_Element_Property_Card_1D_Base_Sensitivity
+#          COMMAND mast_catch_tests "rod_element_property_card_constant_base_sensitivity_1d")
+# set_tests_properties(Rod_Element_Property_Card_1D_Base_Sensitivity
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED Rod_Element_Property_Card_1D_Base)
+#                      
+# add_test(NAME Rod_Element_Property_Card_1D_Heat_Transfer
+#          COMMAND mast_catch_tests "rod_element_property_card_constant_heat_transfer_1d")
+# set_tests_properties(Rod_Element_Property_Card_1D_Heat_Transfer
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED Isotropic_Material_1D_Heat_Transfer)
+# 
+# add_test(NAME Rod_Element_Property_Card_1D_Thermoelastic
+#          COMMAND mast_catch_tests "rod_element_property_card_constant_thermoelastic_1d")
+# set_tests_properties(Rod_Element_Property_Card_1D_Thermoelastic
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED Isotropic_Material_1D_Thermoelastic)
+# 
+# add_test(NAME Rod_Element_Property_Card_1D_Structural
+#          COMMAND mast_catch_tests "rod_element_property_card_constant_structural_1d")
+# set_tests_properties(Rod_Element_Property_Card_1D_Structural
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED  Isotropic_Material_1D_Structural)
+#                      
+# add_test(NAME Rod_Element_Property_Card_1D_Dynamic
+#          COMMAND mast_catch_tests "rod_element_property_card_constant_dynamic_1d")
+# set_tests_properties(Rod_Element_Property_Card_1D_Dynamic
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED Isotropic_Material_1D_Dynamic)
+# ## ============================================================================
+
+
+# ## ============================================================================
+# # 1D TUBE Cross Section
+# add_test(NAME Tube_Element_Property_Card_1D_Base
+#          COMMAND mast_catch_tests "tube_element_property_card_constant_base_1d")
+# set_tests_properties(Tube_Element_Property_Card_1D_Base
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED Isotropic_Material_1D_Structural)
+#                      
+# add_test(NAME Tube_Element_Property_Card_1D_Heat_Transfer
+#          COMMAND mast_catch_tests "tube_element_property_card_constant_heat_transfer_1d")
+# set_tests_properties(Tube_Element_Property_Card_1D_Heat_Transfer
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED Isotropic_Material_1D_Heat_Transfer)
+# 
+# add_test(NAME Tube_Element_Property_Card_1D_Thermoelastic
+#          COMMAND mast_catch_tests "tube_element_property_card_constant_thermoelastic_1d")
+# set_tests_properties(Tube_Element_Property_Card_1D_Thermoelastic
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED Isotropic_Material_1D_Thermoelastic)
+# 
+# add_test(NAME Tube_Element_Property_Card_1D_Structural
+#          COMMAND mast_catch_tests "tube_element_property_card_constant_structural_1d")
+# set_tests_properties(Tube_Element_Property_Card_1D_Structural
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED  Isotropic_Material_1D_Structural)
+#                      
+# add_test(NAME Tube_Element_Property_Card_1D_Dynamic
+#          COMMAND mast_catch_tests "tube_element_property_card_constant_dynamic_1d")
+# set_tests_properties(Tube_Element_Property_Card_1D_Dynamic
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED Isotropic_Material_1D_Dynamic)
+# ## ============================================================================
+
+
+# ## ============================================================================
+# # 1D TUBE2 Cross Section
+# add_test(NAME Tube2_Element_Property_Card_1D_Base
+#          COMMAND mast_catch_tests "tube2_element_property_card_constant_base_1d")
+# set_tests_properties(Tube2_Element_Property_Card_1D_Base
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED Isotropic_Material_1D_Structural)
+#                      
+# add_test(NAME Tube2_Element_Property_Card_1D_Heat_Transfer
+#          COMMAND mast_catch_tests "tube2_element_property_card_constant_heat_transfer_1d")
+# set_tests_properties(Tube2_Element_Property_Card_1D_Heat_Transfer
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED Isotropic_Material_1D_Heat_Transfer)
+# 
+# add_test(NAME Tube2_Element_Property_Card_1D_Thermoelastic
+#          COMMAND mast_catch_tests "tube2_element_property_card_constant_thermoelastic_1d")
+# set_tests_properties(Tube2_Element_Property_Card_1D_Thermoelastic
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED Isotropic_Material_1D_Thermoelastic)
+# 
+# add_test(NAME Tube2_Element_Property_Card_1D_Structural
+#          COMMAND mast_catch_tests "tube2_element_property_card_constant_structural_1d")
+# set_tests_properties(Tube2_Element_Property_Card_1D_Structural
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED  Isotropic_Material_1D_Structural)
+#                      
+# add_test(NAME Tube2_Element_Property_Card_1D_Dynamic
+#          COMMAND mast_catch_tests "tube2_element_property_card_constant_dynamic_1d")
+# set_tests_properties(Tube2_Element_Property_Card_1D_Dynamic
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED Isotropic_Material_1D_Dynamic)
+# ## ============================================================================
+
+
+# ## ============================================================================
+# # 1D I1 Cross Section
+# add_test(NAME I1_Element_Property_Card_1D_Base
+#          COMMAND mast_catch_tests "I1_element_property_card_constant_base_1d")
+# set_tests_properties(I1_Element_Property_Card_1D_Base
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED Isotropic_Material_1D_Structural)
+#                      
+# add_test(NAME I1_Element_Property_Card_1D_Base_Sensitivity
+#          COMMAND mast_catch_tests "I1_element_property_card_constant_base_sensitivity_1d")
+# set_tests_properties(I1_Element_Property_Card_1D_Base_Sensitivity
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED I1_Element_Property_Card_1D_Base)
+#                      
+# add_test(NAME I1_Element_Property_Card_1D_Heat_Transfer
+#          COMMAND mast_catch_tests "I1_element_property_card_constant_heat_transfer_1d")
+# set_tests_properties(I1_Element_Property_Card_1D_Heat_Transfer
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED Isotropic_Material_1D_Heat_Transfer)
+# 
+# add_test(NAME I1_Element_Property_Card_1D_Thermoelastic
+#          COMMAND mast_catch_tests "I1_element_property_card_constant_thermoelastic_1d")
+# set_tests_properties(I1_Element_Property_Card_1D_Thermoelastic
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED Isotropic_Material_1D_Thermoelastic)
+# 
+# add_test(NAME I1_Element_Property_Card_1D_Structural
+#          COMMAND mast_catch_tests "I1_element_property_card_constant_structural_1d")
+# set_tests_properties(I1_Element_Property_Card_1D_Structural
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED  Isotropic_Material_1D_Structural)
+#                      
+# add_test(NAME I1_Element_Property_Card_1D_Dynamic
+#          COMMAND mast_catch_tests "I1_element_property_card_constant_dynamic_1d")
+# ## ============================================================================
+                     
+
+# ## ============================================================================
+# # 1D L Cross Section
+# add_test(NAME L_Element_Property_Card_1D_Base
+#          COMMAND mast_catch_tests "L_element_property_card_constant_base_1d")
+# set_tests_properties(L_Element_Property_Card_1D_Base
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED Isotropic_Material_1D_Structural)
+#                      
+# add_test(NAME L_Element_Property_Card_1D_Heat_Transfer
+#          COMMAND mast_catch_tests "L_element_property_card_constant_heat_transfer_1d")
+# set_tests_properties(L_Element_Property_Card_1D_Heat_Transfer
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED Isotropic_Material_1D_Heat_Transfer)
+# 
+# add_test(NAME L_Element_Property_Card_1D_Thermoelastic
+#          COMMAND mast_catch_tests "L_element_property_card_constant_thermoelastic_1d")
+# set_tests_properties(L_Element_Property_Card_1D_Thermoelastic
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED Isotropic_Material_1D_Thermoelastic)
+# 
+# add_test(NAME L_Element_Property_Card_1D_Structural
+#          COMMAND mast_catch_tests "L_element_property_card_constant_structural_1d")
+# set_tests_properties(L_Element_Property_Card_1D_Structural
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED  Isotropic_Material_1D_Structural)
+#                      
+# add_test(NAME L_Element_Property_Card_1D_Dynamic
+#          COMMAND mast_catch_tests "L_element_property_card_constant_dynamic_1d")
+# set_tests_properties(L_Element_Property_Card_1D_Dynamic
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED Isotropic_Material_1D_Dynamic)
+# ## ============================================================================
+                     
+                     
+                     
+# add_test(NAME Element_Property_Card_1D_Heat_Transfer
+#          COMMAND mast_catch_tests element_property_card_constant_heat_transfer_1d)
+# set_tests_properties(Element_Property_Card_1D_Heat_Transfer
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED Isotropic_Material_1D_Heat_Transfer)
+# 
+#                      
+# add_test(NAME Element_Property_Card_1D_Thermoelastic
+#          COMMAND mast_catch_tests element_property_card_constant_thermoelastic_1d)
+# set_tests_properties(Element_Property_Card_1D_Thermoelastic
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED Isotropic_Material_1D_Thermoelastic)
+#                      
+#                      
+# add_test(NAME Element_Property_Card_1D_Structural
+#          COMMAND mast_catch_tests element_property_card_constant_structural_1d)
+# set_tests_properties(Element_Property_Card_1D_Structural
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED  Isotropic_Material_1D_Structural
+#                      FIXTURES_SETUP     Element_Property_Card_1D_Structural)
+#          
+# 
+# add_test(NAME Element_Property_Card_1D_Dynamic
+#          COMMAND mast_catch_tests element_property_card_constant_dynamic_1d)
+# set_tests_properties(Element_Property_Card_1D_Dynamic
+#                      PROPERTIES
+#                      FIXTURES_REQUIRED Isotropic_Material_1D_Dynamic)
+
+           
+
+         
+
+         
+         
+

--- a/tests/property/CMakeLists.txt
+++ b/tests/property/CMakeLists.txt
@@ -1,5 +1,6 @@
 target_sources(mast_catch_tests
     PRIVATE
+        ${CMAKE_CURRENT_LIST_DIR}/mast_solid_1d_section_element_property_card.cpp
         ${CMAKE_CURRENT_LIST_DIR}/mast_solid_2d_section_element_property_card.cpp
         ${CMAKE_CURRENT_LIST_DIR}/mast_3d_isotropic_element_property_card.cpp)
        
@@ -187,17 +188,102 @@ set_tests_properties(Element_Property_Card_2D_Transient_Heat_Transfer_mpi
         FIXTURES_SETUP Element_Property_Card_2D_Transient_Heat_Transfer_mpi)
 
 
-# ## ============================================================================
-# ##                              1D Property Card Tests
-# ## ============================================================================
-#      
-# # 1D Property Card Tests
-# # add_test(NAME Element_Property_Card_1D_Base
-# #          COMMAND mast_catch_tests element_property_card_constant_base_1d)
-# # set_tests_properties(Element_Property_Card_1D_Base
-# #                      PROPERTIES
-# #                      FIXTURES_REQUIRED Isotropic_Material_1D_Heat_Transfer)
-# 
+## ============================================================================
+##                              1D Property Card Tests
+## ============================================================================
+     
+## ============================================================================
+# 1D (Default, Rectangular) Property Card Tests
+add_test(NAME Element_Property_Card_1D_Base
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "solid_element_property_card_constant_base_1d")
+set_tests_properties(Element_Property_Card_1D_Base
+    PROPERTIES
+        LABELS "SEQ"
+        FIXTURES_REQUIRED Isotropic_Material_1D_Structural)
+
+add_test(NAME Element_Property_Card_1D_Base_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "solid_element_property_card_constant_base_1d")
+set_tests_properties(Element_Property_Card_1D_Base_mpi
+    PROPERTIES
+        LABELS "MPI"
+        FIXTURES_REQUIRED Isotropic_Material_1D_Structural_mpi)
+
+                     
+add_test(NAME Element_Property_Card_1D_Base_Sensitivity
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "solid_element_property_card_constant_base_sensitivity_1d")
+set_tests_properties(Element_Property_Card_1D_Base_Sensitivity
+    PROPERTIES
+        LABELS "SEQ"
+        FIXTURES_REQUIRED Element_Property_Card_1D_Base)
+
+add_test(NAME Element_Property_Card_1D_Base_Sensitivity_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "solid_element_property_card_constant_base_sensitivity_1d")
+set_tests_properties(Element_Property_Card_1D_Base_Sensitivity_mpi
+    PROPERTIES
+        LABELS "MPI"
+        FIXTURES_REQUIRED Element_Property_Card_1D_Base_mpi)
+
+
+add_test(NAME Element_Property_Card_1D_Heat_Transfer
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "solid_element_property_card_constant_heat_transfer_1d")
+set_tests_properties(Element_Property_Card_1D_Heat_Transfer
+    PROPERTIES
+        LABELS "SEQ"
+        FIXTURES_REQUIRED Isotropic_Material_1D_Heat_Transfer)
+
+add_test(NAME Element_Property_Card_1D_Heat_Transfer_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "solid_element_property_card_constant_heat_transfer_1d")
+set_tests_properties(Element_Property_Card_1D_Heat_Transfer_mpi
+    PROPERTIES
+        LABELS "MPI"
+        FIXTURES_REQUIRED Isotropic_Material_1D_Heat_Transfer_mpi)
+
+
+add_test(NAME Element_Property_Card_1D_Thermoelastic
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "solid_element_property_card_constant_thermoelastic_1d")
+set_tests_properties(Element_Property_Card_1D_Thermoelastic
+    PROPERTIES
+        LABELS "SEQ"
+        FIXTURES_REQUIRED Isotropic_Material_1D_Thermoelastic)
+
+add_test(NAME Element_Property_Card_1D_Thermoelastic_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "solid_element_property_card_constant_thermoelastic_1d")
+set_tests_properties(Element_Property_Card_1D_Thermoelastic_mpi
+    PROPERTIES
+        LABELS "MPI"
+        FIXTURES_REQUIRED Isotropic_Material_1D_Thermoelastic_mpi)
+
+
+add_test(NAME Element_Property_Card_1D_Structural
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "solid_element_property_card_constant_structural_1d")
+set_tests_properties(Element_Property_Card_1D_Structural
+    PROPERTIES
+        LABELS "SEQ"
+        FIXTURES_REQUIRED  Isotropic_Material_1D_Structural)
+
+add_test(NAME Element_Property_Card_1D_Structural_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "solid_element_property_card_constant_structural_1d")
+set_tests_properties(Element_Property_Card_1D_Structural_mpi
+    PROPERTIES
+        LABELS "MPI"
+        FIXTURES_REQUIRED  Isotropic_Material_1D_Structural_mpi)
+
+
+add_test(NAME Element_Property_Card_1D_Dynamic
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "solid_element_property_card_constant_dynamic_1d")
+set_tests_properties(Element_Property_Card_1D_Dynamic
+    PROPERTIES
+        LABELS "SEQ"
+        FIXTURES_REQUIRED Isotropic_Material_1D_Dynamic)
+
+add_test(NAME Element_Property_Card_1D_Dynamic_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "solid_element_property_card_constant_dynamic_1d")
+set_tests_properties(Element_Property_Card_1D_Dynamic_mpi
+    PROPERTIES
+        LABELS "MPI"
+        FIXTURES_REQUIRED Isotropic_Material_1D_Dynamic_mpi)
+
+
 # ## ============================================================================
 # # 1D Arbitrary Cross Section
 # add_test(NAME Arbitrary_Element_Property_Card_1D_Base
@@ -425,41 +511,3 @@ set_tests_properties(Element_Property_Card_2D_Transient_Heat_Transfer_mpi
 #                      PROPERTIES
 #                      FIXTURES_REQUIRED Isotropic_Material_1D_Dynamic)
 # ## ============================================================================
-                     
-                     
-                     
-# add_test(NAME Element_Property_Card_1D_Heat_Transfer
-#          COMMAND mast_catch_tests element_property_card_constant_heat_transfer_1d)
-# set_tests_properties(Element_Property_Card_1D_Heat_Transfer
-#                      PROPERTIES
-#                      FIXTURES_REQUIRED Isotropic_Material_1D_Heat_Transfer)
-# 
-#                      
-# add_test(NAME Element_Property_Card_1D_Thermoelastic
-#          COMMAND mast_catch_tests element_property_card_constant_thermoelastic_1d)
-# set_tests_properties(Element_Property_Card_1D_Thermoelastic
-#                      PROPERTIES
-#                      FIXTURES_REQUIRED Isotropic_Material_1D_Thermoelastic)
-#                      
-#                      
-# add_test(NAME Element_Property_Card_1D_Structural
-#          COMMAND mast_catch_tests element_property_card_constant_structural_1d)
-# set_tests_properties(Element_Property_Card_1D_Structural
-#                      PROPERTIES
-#                      FIXTURES_REQUIRED  Isotropic_Material_1D_Structural
-#                      FIXTURES_SETUP     Element_Property_Card_1D_Structural)
-#          
-# 
-# add_test(NAME Element_Property_Card_1D_Dynamic
-#          COMMAND mast_catch_tests element_property_card_constant_dynamic_1d)
-# set_tests_properties(Element_Property_Card_1D_Dynamic
-#                      PROPERTIES
-#                      FIXTURES_REQUIRED Isotropic_Material_1D_Dynamic)
-
-           
-
-         
-
-         
-         
-

--- a/tests/property/CMakeLists.txt
+++ b/tests/property/CMakeLists.txt
@@ -1,45 +1,100 @@
 target_sources(mast_catch_tests
     PRIVATE
-        ${CMAKE_CURRENT_LIST_DIR}/mast_solid_2d_section_element_property_card.cpp)
+        ${CMAKE_CURRENT_LIST_DIR}/mast_solid_2d_section_element_property_card.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/mast_3d_isotropic_element_property_card.cpp)
        
 
-# ## ============================================================================
-# ##                              3D Property Card Tests
-# ## ============================================================================
-# add_test(NAME Element_Property_Card_Isotropic_3D_Thermoelastic
-#          COMMAND mast_catch_tests "element_property_card_constant_thermoelastic_isotropic_3d")
-# set_tests_properties(Element_Property_Card_Isotropic_3D_Thermoelastic
-#                      PROPERTIES
-#                      FIXTURES_REQUIRED Isotropic_Material_3D_Thermoelastic
-#                      FIXTURES_SETUP Element_Property_Card_Isotropic_3D_Thermoelastic)
-# 
-# add_test(NAME Element_Property_Card_Isotropic_3D_Structural
-#          COMMAND mast_catch_tests "element_property_card_constant_structural_isotropic_3d")
-# set_tests_properties(Element_Property_Card_Isotropic_3D_Structural
-#                      PROPERTIES
-#                      FIXTURES_REQUIRED Isotropic_Material_3D_Structural
-#                      FIXTURES_SETUP Element_Property_Card_Isotropic_3D_Structural)
-# 
-# add_test(NAME Element_Property_Card_Isotropic_3D_Dynamic
-#          COMMAND mast_catch_tests "element_property_card_constant_dynamic_isotropic_3d")
-# set_tests_properties(Element_Property_Card_Isotropic_3D_Dynamic
-#                      PROPERTIES
-#                      FIXTURES_REQUIRED Isotropic_Material_3D_Dynamic
-#                      FIXTURES_SETUP Element_Property_Card_Isotropic_3D_Dynamic)
-# 
-# add_test(NAME Element_Property_Card_Isotropic_3D_Heat_Transfer
-#          COMMAND mast_catch_tests "element_property_card_constant_heat_transfer_isotropic_3d")
-# set_tests_properties(Element_Property_Card_Isotropic_3D_Heat_Transfer
-#                      PROPERTIES
-#                      FIXTURES_REQUIRED Isotropic_Material_3D_Heat_Transfer
-#                      FIXTURES_SETUP Element_Property_Card_3D_Heat_Transfer)
-#                      
-# add_test(NAME Element_Property_Card_Isotropic_3D_Transient_Heat_Transfer
-#          COMMAND mast_catch_tests "element_property_card_constant_transient_heat_transfer_isotropic_3d")
-# set_tests_properties(Element_Property_Card_Isotropic_3D_Transient_Heat_Transfer
-#                      PROPERTIES
-#                      FIXTURES_REQUIRED Isotropic_Material_3D_Transient_Heat_Transfer
-#                      FIXTURES_SETUP Element_Property_Card_3D_Transient_Heat_Transfer)
+## ============================================================================
+##                              3D Property Card Tests
+## ============================================================================
+# Thermoelastic
+add_test(NAME Element_Property_Card_Isotropic_3D_Thermoelastic
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "element_property_card_constant_thermoelastic_isotropic_3d")
+set_tests_properties(Element_Property_Card_Isotropic_3D_Thermoelastic
+    PROPERTIES
+        LABELS "SEQ"
+        FIXTURES_REQUIRED Isotropic_Material_3D_Thermoelastic
+        FIXTURES_SETUP Element_Property_Card_Isotropic_3D_Thermoelastic)
+
+add_test(NAME Element_Property_Card_Isotropic_3D_Thermoelastic_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "element_property_card_constant_thermoelastic_isotropic_3d")
+set_tests_properties(Element_Property_Card_Isotropic_3D_Thermoelastic_mpi
+    PROPERTIES
+        LABELS "MPI"
+        FIXTURES_REQUIRED Isotropic_Material_3D_Thermoelastic_mpi
+        FIXTURES_SETUP Element_Property_Card_Isotropic_3D_Thermoelastic_mpi)
+
+
+# Structural
+add_test(NAME Element_Property_Card_Isotropic_3D_Structural
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "element_property_card_constant_structural_isotropic_3d")
+set_tests_properties(Element_Property_Card_Isotropic_3D_Structural
+    PROPERTIES
+        LABELS "SEQ"
+        FIXTURES_REQUIRED Isotropic_Material_3D_Structural
+        FIXTURES_SETUP Element_Property_Card_Isotropic_3D_Structural)
+
+add_test(NAME Element_Property_Card_Isotropic_3D_Structural_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "element_property_card_constant_structural_isotropic_3d")
+set_tests_properties(Element_Property_Card_Isotropic_3D_Structural_mpi
+    PROPERTIES
+        LABELS "MPI"
+        FIXTURES_REQUIRED Isotropic_Material_3D_Structural_mpi
+        FIXTURES_SETUP Element_Property_Card_Isotropic_3D_Structural_mpi)
+
+
+# Dynamic
+add_test(NAME Element_Property_Card_Isotropic_3D_Dynamic
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "element_property_card_constant_dynamic_isotropic_3d")
+set_tests_properties(Element_Property_Card_Isotropic_3D_Dynamic
+    PROPERTIES
+        LABELS "SEQ"
+        FIXTURES_REQUIRED Isotropic_Material_3D_Dynamic
+        FIXTURES_SETUP Element_Property_Card_Isotropic_3D_Dynamic)
+
+add_test(NAME Element_Property_Card_Isotropic_3D_Dynamic_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "element_property_card_constant_dynamic_isotropic_3d")
+set_tests_properties(Element_Property_Card_Isotropic_3D_Dynamic_mpi
+    PROPERTIES
+        LABELS "MPI"
+        FIXTURES_REQUIRED Isotropic_Material_3D_Dynamic_mpi
+        FIXTURES_SETUP Element_Property_Card_Isotropic_3D_Dynamic_mpi)
+
+
+# Heat Transfer
+add_test(NAME Element_Property_Card_Isotropic_3D_Heat_Transfer
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "element_property_card_constant_heat_transfer_isotropic_3d")
+set_tests_properties(Element_Property_Card_Isotropic_3D_Heat_Transfer
+    PROPERTIES
+        LABELS "SEQ"
+        FIXTURES_REQUIRED Isotropic_Material_3D_Heat_Transfer
+        FIXTURES_SETUP Element_Property_Card_3D_Heat_Transfer)
+
+add_test(NAME Element_Property_Card_Isotropic_3D_Heat_Transfer_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "element_property_card_constant_heat_transfer_isotropic_3d")
+set_tests_properties(Element_Property_Card_Isotropic_3D_Heat_Transfer_mpi
+    PROPERTIES
+        LABELS "MPI"
+        FIXTURES_REQUIRED Isotropic_Material_3D_Heat_Transfer_mpi
+        FIXTURES_SETUP Element_Property_Card_3D_Heat_Transfer_mpi)
+
+
+# Transient Heat Transfer
+add_test(NAME Element_Property_Card_Isotropic_3D_Transient_Heat_Transfer
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "element_property_card_constant_transient_heat_transfer_isotropic_3d")
+set_tests_properties(Element_Property_Card_Isotropic_3D_Transient_Heat_Transfer
+    PROPERTIES
+        LABELS "SEQ"
+        FIXTURES_REQUIRED Isotropic_Material_3D_Transient_Heat_Transfer
+        FIXTURES_SETUP Element_Property_Card_3D_Transient_Heat_Transfer)
+
+add_test(NAME Element_Property_Card_Isotropic_3D_Transient_Heat_Transfer_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "element_property_card_constant_transient_heat_transfer_isotropic_3d")
+set_tests_properties(Element_Property_Card_Isotropic_3D_Transient_Heat_Transfer_mpi
+    PROPERTIES
+        LABELS "MPI"
+        FIXTURES_REQUIRED Isotropic_Material_3D_Transient_Heat_Transfer_mpi
+        FIXTURES_SETUP Element_Property_Card_3D_Transient_Heat_Transfer_mpi)
 
 ## ============================================================================
 ##                              2D Property Card Tests
@@ -49,6 +104,7 @@ add_test(NAME Element_Property_Card_2D_Structural
     COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "element_property_card_constant_structural_2d")
 set_tests_properties(Element_Property_Card_2D_Structural
     PROPERTIES
+        LABELS "SEQ"
         FIXTURES_REQUIRED Isotropic_Material_2D_Structural
         FIXTURES_SETUP Element_Property_Card_2D_Structural)
 
@@ -56,6 +112,7 @@ add_test(NAME Element_Property_Card_2D_Structural_mpi
     COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "element_property_card_constant_structural_2d")
 set_tests_properties(Element_Property_Card_2D_Structural_mpi
     PROPERTIES
+        LABELS "MPI"
         FIXTURES_REQUIRED Isotropic_Material_2D_Structural_mpi
         FIXTURES_SETUP Element_Property_Card_2D_Structural_mpi)
 
@@ -65,6 +122,7 @@ add_test(NAME Element_Property_Card_2D_Thermoelastic
     COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "element_property_card_constant_thermoelastic_2d")
 set_tests_properties(Element_Property_Card_2D_Thermoelastic
     PROPERTIES
+        LABELS "SEQ"
         FIXTURES_REQUIRED Isotropic_Material_2D_Thermoelastic
         FIXTURES_SETUP Element_Property_Card_2D_Thermoelastic)
 
@@ -72,6 +130,7 @@ add_test(NAME Element_Property_Card_2D_Thermoelastic_mpi
     COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "element_property_card_constant_thermoelastic_2d")
 set_tests_properties(Element_Property_Card_2D_Thermoelastic_mpi
     PROPERTIES
+        LABELS "MPI"
         FIXTURES_REQUIRED Isotropic_Material_2D_Thermoelastic_mpi
         FIXTURES_SETUP Element_Property_Card_2D_Thermoelastic_mpi)
 
@@ -81,12 +140,14 @@ add_test(NAME Element_Property_Card_2D_Dynamic
     COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "element_property_card_constant_dynamic_2d")
 set_tests_properties(Element_Property_Card_2D_Dynamic
     PROPERTIES
+        LABELS "SEQ"
         FIXTURES_SETUP Element_Property_Card_2D_Dynamic)
 
 add_test(NAME Element_Property_Card_2D_Dynamic_mpi
     COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "element_property_card_constant_dynamic_2d")
 set_tests_properties(Element_Property_Card_2D_Dynamic_mpi
     PROPERTIES
+        LABELS "MPI"
         FIXTURES_SETUP Element_Property_Card_2D_Dynamic_mpi)
 
 
@@ -95,6 +156,7 @@ add_test(NAME Element_Property_Card_2D_Heat_Transfer
     COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "element_property_card_constant_heat_transfer_2d")
 set_tests_properties(Element_Property_Card_2D_Heat_Transfer
     PROPERTIES
+        LABELS "SEQ"
         FIXTURES_REQUIRED Isotropic_Material_2D_Heat_Transfer
         FIXTURES_SETUP Element_Property_Card_2D_Heat_Transfer)
 
@@ -102,6 +164,7 @@ add_test(NAME Element_Property_Card_2D_Heat_Transfer_mpi
     COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "element_property_card_constant_heat_transfer_2d")
 set_tests_properties(Element_Property_Card_2D_Heat_Transfer_mpi
     PROPERTIES
+        LABELS "MPI"
         FIXTURES_REQUIRED Isotropic_Material_2D_Heat_Transfer_mpi
         FIXTURES_SETUP Element_Property_Card_2D_Heat_Transfer_mpi)
 
@@ -111,6 +174,7 @@ add_test(NAME Element_Property_Card_2D_Transient_Heat_Transfer
     COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "element_property_card_constant_transient_heat_transfer_2d")
 set_tests_properties(Element_Property_Card_2D_Transient_Heat_Transfer
     PROPERTIES
+        LABELS "SEQ"
         FIXTURES_REQUIRED Isotropic_Material_2D_Transient_Heat_Transfer
         FIXTURES_SETUP Element_Property_Card_2D_Transient_Heat_Transfer)
 
@@ -118,6 +182,7 @@ add_test(NAME Element_Property_Card_2D_Transient_Heat_Transfer_mpi
     COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "element_property_card_constant_transient_heat_transfer_2d")
 set_tests_properties(Element_Property_Card_2D_Transient_Heat_Transfer_mpi
     PROPERTIES
+        LABELS "MPI"
         FIXTURES_REQUIRED Isotropic_Material_2D_Transient_Heat_Transfer_mpi
         FIXTURES_SETUP Element_Property_Card_2D_Transient_Heat_Transfer_mpi)
 

--- a/tests/property/mast_3d_isotropic_element_property_card.cpp
+++ b/tests/property/mast_3d_isotropic_element_property_card.cpp
@@ -1,0 +1,448 @@
+// Catch2 includes
+#include "catch.hpp"
+
+// libMesh includes
+#include "libmesh/point.h"
+
+// MAST includes
+#include "base/parameter.h"
+#include "base/constant_field_function.h"
+#include "property_cards/isotropic_material_property_card.h"
+#include "property_cards/isotropic_element_property_card_3D.h"
+
+// Custom includes
+#include "test_helpers.h"
+
+// TODO: Need to test with other types of materials.
+// TODO: Need to test function that gets material.
+
+extern libMesh::LibMeshInit* p_global_init;
+
+TEST_CASE("element_property_card_constant_heat_transfer_isotropic_3d",
+          "[heat_transfer],[3D],[isotropic],[constant],[property]")
+{
+    const uint dim = 3;
+    
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter k("k_param",     237.0);          // Thermal Conductivity
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction k_f("k_th", k);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(k_f);
+    
+    // Initialize the section
+    MAST::IsotropicElementPropertyCard3D section;
+        
+    // Add the material card to the section card
+    section.set_material(material);
+    
+    REQUIRE( section.dim() == dim);
+    REQUIRE( section.depends_on(k) );
+    
+    SECTION("3D section thermal conductance matrix")
+    {
+        /** 
+         * As of Dec. 17, 2019, inertia_matrix requires the input of an
+         * MAST::ElementBase object, but does not actually use it. To get 
+         * around requiring the creation of such an object (and therefore 
+         * the creation of a MAST::SystemInitialization, MAST::AssemblyBase,
+         * and MAST::GeomElem objects as well).
+         * 
+         * To remedy this, an additional method was added to MAST which allows
+         * inertia_matrix to be obtained without any input arguments.
+         */
+        std::unique_ptr<MAST::FieldFunction<RealMatrixX>> conduct_mat = section.thermal_conductance_matrix();
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_sec_conduc;
+        conduct_mat->operator()(point, time, D_sec_conduc);
+        
+        // Hard-coded value of the section's extension stiffness
+        RealMatrixX D_sec_conduc_true = RealMatrixX::Zero(3,3);
+        D_sec_conduc_true(0,0) = 237.0;
+        D_sec_conduc_true(1,1) = 237.0;
+        D_sec_conduc_true(2,2) = 237.0;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_conduc);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_conduc_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("element_property_card_constant_transient_heat_transfer_isotropic_3d",
+          "[heat_transfer],[3D],[isotropic],[constant],[property],[transient]")
+{
+    const uint dim = 3;
+    
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter rho("rho_param", 1420.5);         // Density
+    MAST::Parameter cp("cp_param",   908.0);          // Specific Heat Capacity
+        
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction rho_f("rho", rho);
+    MAST::ConstantFieldFunction cp_f("cp", cp);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(rho_f);
+    material.add(cp_f);
+    
+    // Initialize the section
+    MAST::IsotropicElementPropertyCard3D section;
+    
+    // Add the material card to the section card
+    section.set_material(material);
+    
+    REQUIRE( section.dim() == dim);
+    REQUIRE( section.depends_on(cp) );
+    REQUIRE( section.depends_on(rho) );
+    
+    SECTION("3D section thermal capacitance matrix")
+    {
+        /** 
+         * As of Dec. 17, 2019, inertia_matrix requires the input of an
+         * MAST::ElementBase object, but does not actually use it. To get 
+         * around requiring the creation of such an object (and therefore 
+         * the creation of a MAST::SystemInitialization, MAST::AssemblyBase,
+         * and MAST::GeomElem objects as well).
+         * 
+         * To remedy this, an additional method was added to MAST which allows
+         * inertia_matrix to be obtained without any input arguments.
+         */
+        std::unique_ptr<MAST::FieldFunction<RealMatrixX>> capaci_mat = section.thermal_capacitance_matrix();
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_sec_capac;
+        capaci_mat->operator()(point, time, D_sec_capac);
+        
+        // Hard-coded value of the section's extension stiffness
+        RealMatrixX D_sec_capac_true = RealMatrixX::Zero(1,1);
+        D_sec_capac_true(0,0) = 908.0*1420.5;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_capac);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_capac_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("element_property_card_constant_thermoelastic_isotropic_3d",
+          "[thermoelastic],[3D],[isotropic],[constant],[property]")
+{
+    const uint dim = 3;
+    
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
+    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
+    MAST::Parameter alpha("alpha_param", 5.43e-05);   // Coefficient of thermal expansion
+        
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction E_f("E", E);
+    MAST::ConstantFieldFunction nu_f("nu", nu);
+    MAST::ConstantFieldFunction alpha_f("alpha_expansion", alpha);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(E_f);
+    material.add(nu_f);
+    material.add(alpha_f);
+    
+    // Initialize the section
+    MAST::IsotropicElementPropertyCard3D section;
+        
+    // Add the material card to the section card
+    section.set_material(material);
+    
+    REQUIRE( section.dim() == dim); // Ensure section is 2 dimensional
+    REQUIRE( section.depends_on(alpha) );
+    
+    SECTION("3D plane stress thermal expansion A matrix")
+    {
+        /*!
+         *  thermal expansion A matrix is defined as D * alpha_vec
+         */
+                        
+        /** 
+         * As of Dec. 17, 2019, thermal_expansion_A_matrix requires the input of an
+         * MAST::ElementBase object, but does not actually use it. To get 
+         * around requiring the creation of such an object (and therefore 
+         * the creation of a MAST::SystemInitialization, MAST::AssemblyBase,
+         * and MAST::GeomElem objects as well).
+         * 
+         * To remedy this, an additional method was added to MAST which allows
+         * thermal_expansion_A_matrix to be obtained without any input arguments.
+         */
+        std::unique_ptr<MAST::FieldFunction<RealMatrixX>> texp_A_mat = section.thermal_expansion_A_matrix();
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_sec_texpA;
+        texp_A_mat->operator()(point, time, D_sec_texpA);
+        
+        // Hard-coded value of the section's extension stiffness
+        RealMatrixX D_sec_texpA_true = RealMatrixX::Zero(6,1);
+        D_sec_texpA_true(0,0) = 1.149882352941177e+07;
+        D_sec_texpA_true(1,0) = 1.149882352941177e+07;
+        D_sec_texpA_true(2,0) = 1.149882352941177e+07;
+        
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_texpA);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_texpA_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    
+    SECTION("3D plane stress thermal expansion B matrix")
+    {
+        /*!
+         *  thermal expansion B matrix is defined as D * alpha_vec
+         */
+                
+        /** 
+         * As of Dec. 17, 2019, thermal_expansion_B_matrix requires the input of an
+         * MAST::ElementBase object, but does not actually use it. To get 
+         * around requiring the creation of such an object (and therefore 
+         * the creation of a MAST::SystemInitialization, MAST::AssemblyBase,
+         * and MAST::GeomElem objects as well).
+         * 
+         * To remedy this, an additional method was added to MAST which allows
+         * thermal_expansion_B_matrix to be obtained without any input arguments.
+         */
+        std::unique_ptr<MAST::FieldFunction<RealMatrixX>> texp_B_mat = section.thermal_expansion_B_matrix();
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_sec_texpB;
+        texp_B_mat->operator()(point, time, D_sec_texpB);
+        
+        // Hard-coded value of the section's extension stiffness
+        RealMatrixX D_sec_texpB_true = RealMatrixX::Zero(6,1);
+        D_sec_texpB_true(0,0) = 1.149882352941177e+07;
+        D_sec_texpB_true(1,0) = 1.149882352941177e+07;
+        D_sec_texpB_true(2,0) = 1.149882352941177e+07;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_texpB);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_texpB_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("element_property_card_constant_dynamic_isotropic_3d",
+          "[dynamic],[3D],[isotropic],[constant],[property]")
+{
+    const uint dim = 3;
+    
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter rho("rho_param", 1420.5);         // Density
+    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
+    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
+        
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction rho_f("rho", rho);
+    MAST::ConstantFieldFunction E_f("E", E);
+    MAST::ConstantFieldFunction nu_f("nu", nu);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(rho_f);
+    material.add(E_f);                                             
+    material.add(nu_f);
+    
+    // Initialize the section
+    MAST::IsotropicElementPropertyCard3D section;
+    
+    // Add the material card to the section card
+    section.set_material(material);
+    
+    REQUIRE( section.dim() == dim); // Ensure section is 2 dimensional
+    REQUIRE( section.depends_on(E) );
+    REQUIRE( section.depends_on(nu) );
+    
+    REQUIRE_FALSE( section.if_diagonal_mass_matrix() );
+    
+    section.set_diagonal_mass_matrix(true);
+    REQUIRE( section.if_diagonal_mass_matrix() );
+    
+    SECTION("3D section inertia matrix")
+    {
+        /** 
+         * As of Dec. 17, 2019, inertia_matrix requires the input of an
+         * MAST::ElementBase object, but does not actually use it. To get 
+         * around requiring the creation of such an object (and therefore 
+         * the creation of a MAST::SystemInitialization, MAST::AssemblyBase,
+         * and MAST::GeomElem objects as well).
+         * 
+         * To remedy this, an additional method was added to MAST which allows
+         * inertia_matrix to be obtained without any input arguments.
+         */
+        std::unique_ptr<MAST::FieldFunction<RealMatrixX>> inertia_mat = section.inertia_matrix();
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_sec_inertia;
+        inertia_mat->operator()(point, time, D_sec_inertia);
+        
+        // Hard-coded value of the section's extension stiffness
+        RealMatrixX D_sec_inertia_true = RealMatrixX::Identity(3,3);        
+        
+        D_sec_inertia_true *= 1420.5;
+
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_inertia);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_inertia_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+
+TEST_CASE("element_property_card_constant_structural_isotropic_3d",
+          "[structural],[3D],[isotropic],[constant],[property]")
+{
+    const uint dim = 3;
+    
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
+    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
+    
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction E_f("E", E);
+    MAST::ConstantFieldFunction nu_f("nu", nu);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(E_f);                                             
+    material.add(nu_f);
+    
+    // Initialize the section
+    MAST::IsotropicElementPropertyCard3D section;
+        
+    // Add the material card to the section card
+    section.set_material(material);
+    
+    REQUIRE( section.dim() == dim); // Ensure section is 2 dimensional
+    REQUIRE( section.depends_on(E) );
+    REQUIRE( section.depends_on(nu) );
+    
+    SECTION("solid_2d_section is isotropic")
+    {
+        CHECK( section.if_isotropic() );
+    }
+    
+    SECTION("set_get_strain_type")
+    {
+        // Check that the default is linear strain
+        REQUIRE( section.strain_type() == MAST::LINEAR_STRAIN );
+        
+        section.set_strain(MAST::LINEAR_STRAIN);
+        REQUIRE( section.strain_type() == MAST::LINEAR_STRAIN );
+        REQUIRE_FALSE( section.strain_type() == MAST::NONLINEAR_STRAIN );
+        
+        section.set_strain(MAST::NONLINEAR_STRAIN);
+        REQUIRE( section.strain_type() == MAST::NONLINEAR_STRAIN );
+        REQUIRE_FALSE( section.strain_type() == MAST::LINEAR_STRAIN );
+    }
+    
+//     SECTION("quadrature_order")
+//     {
+//         section.set_bending_model(MAST::MINDLIN);
+//         REQUIRE( section.extra_quadrature_order(elem) == 0 );
+//         
+//         section.set_bending_model(MAST::DKT);
+//         REQUIRE( section.extra_quadrature_order(elem) == 2 );
+//     }
+    
+    SECTION("3D stiffness matrix")
+    {
+        /** 
+         * As of Dec. 17, 2019, stiffness_A_matrix requires the input of an
+         * MAST::ElementBase object, but does not actually use it. To get 
+         * around requiring the creation of such an object (and therefore 
+         * the creation of a MAST::SystemInitialization, MAST::AssemblyBase,
+         * and MAST::GeomElem objects as well).
+         * 
+         * To remedy this, an additional method was added to MAST which allows
+         * stiffness_A_matrix to be obtained without any input arguments.
+         */
+        std::unique_ptr<MAST::FieldFunction<RealMatrixX>> stiffness_mat = section.stiffness_A_matrix();
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_stiff;
+        stiffness_mat->operator()(point, time, D_stiff);
+        
+        // Hard-coded value of the section's extension stiffness
+        RealMatrixX D_stiff_true = RealMatrixX::Zero(6,6);
+        D_stiff_true(0,0) = 1.066784608580274e+11;
+        D_stiff_true(1,1) = 1.066784608580274e+11;
+        D_stiff_true(2,2) = 1.066784608580274e+11;
+        D_stiff_true(3,3) = 0.541353383458647e+11/2.0;
+        D_stiff_true(4,4) = 0.541353383458647e+11/2.0;
+        D_stiff_true(5,5) = 0.541353383458647e+11/2.0;
+        
+        D_stiff_true(0,1) = D_stiff_true(1,0) = 0.525431225121628e+11;
+        D_stiff_true(0,2) = D_stiff_true(2,0) = 0.525431225121628e+11;
+        D_stiff_true(1,2) = D_stiff_true(2,1) = 0.525431225121628e+11;
+        
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_stiff);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_stiff_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    
+   
+}

--- a/tests/property/mast_solid_1d_section_element_property_card.cpp
+++ b/tests/property/mast_solid_1d_section_element_property_card.cpp
@@ -1,0 +1,1574 @@
+// Catch2 includes
+#include "catch.hpp"
+
+// libMesh includes
+#include "libmesh/point.h"
+
+// MAST includes
+#include "base/parameter.h"
+#include "base/constant_field_function.h"
+#include "property_cards/isotropic_material_property_card.h"
+#include "property_cards/solid_1d_section_element_property_card.h"
+
+// Custom includes
+#include "test_helpers.h"
+
+extern libMesh::LibMeshInit* p_global_init;
+
+
+/**
+ * The default 1D solid section is defined as a solid rectangular cross section 
+ * defined by two parameters, similar to BAR from Nastran.
+ */
+TEST_CASE("solid_element_property_card_constant_base_1d",
+          "[1D],[isotropic],[constant],[property]")
+{
+    const uint dim = 1;
+    
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter rho("rho_param", 1420.5);         // Density
+    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
+    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
+    MAST::Parameter kappa("kappa_param", 5.0/6.0);    // Shear coefficient
+    MAST::Parameter cp("cp_param",   908.0);          // Specific Heat Capacity
+    MAST::Parameter k("k_param",     237.0);          // Thermal Conductivity
+    
+    // Define Section Properties as MAST Parameters
+    MAST::Parameter thickness_y("hz", 3.0);   // Section thickness in z-direction
+    MAST::Parameter thickness_z("hy", 0.75);   // Section thickness in y-direction
+    MAST::Parameter offset_y("offy_param", 0.287);     // Section offset in y-direction
+    MAST::Parameter offset_z("offz_param", 1.654);     // Section offset in z-direction
+    MAST::Parameter Kzz("Kzz", 8.3330248143102326e-01);
+    MAST::Parameter Kyy("Kyy", 5.5763491072129889e-01);
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    // Section Property Field Functions
+    MAST::ConstantFieldFunction thickness_y_f("hz", thickness_y);
+    MAST::ConstantFieldFunction thickness_z_f("hy", thickness_z);
+    MAST::ConstantFieldFunction offsety_f("hy_off", offset_y);
+    MAST::ConstantFieldFunction offsetz_f("hz_off", offset_z);
+    MAST::ConstantFieldFunction Kzz_f("Kappazz", Kzz);
+    MAST::ConstantFieldFunction Kyy_f("Kappayy", Kyy);
+    
+    // Material Property Field Functions
+    MAST::ConstantFieldFunction rho_f("rho", rho);
+    MAST::ConstantFieldFunction E_f("E", E);
+    MAST::ConstantFieldFunction nu_f("nu", nu);
+    MAST::ConstantFieldFunction cp_f("cp", cp);
+    MAST::ConstantFieldFunction k_f("k_th", k);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(rho_f);
+    material.add(k_f);
+    material.add(cp_f);
+    material.add(E_f);
+    material.add(nu_f);
+    
+    // Initialize the section
+    MAST::Solid1DSectionElementPropertyCard section;
+    
+    // Add the section property constant field functions to the section card
+    section.add(thickness_y_f);
+    section.add(thickness_z_f);
+    section.add(offsety_f);
+    section.add(offsetz_f);
+    section.add(Kzz_f);
+    section.add(Kyy_f);
+    
+    // Add the material card to the section card
+    section.set_material(material);
+    
+    // Specify a section orientation point and add it to the section.
+    RealVectorX orientation = RealVectorX::Zero(3);
+    orientation(1) = 1.0;
+    section.y_vector() = orientation;
+    
+    // Now initialize the section
+    section.init();
+    
+    REQUIRE( section.dim() == dim); // Ensure section is 1 dimensional
+    REQUIRE( section.depends_on(thickness_y) );
+    REQUIRE( section.depends_on(offset_y) );
+    REQUIRE( section.depends_on(thickness_z) );
+    REQUIRE( section.depends_on(offset_z) );
+    REQUIRE( section.depends_on(k) );
+    REQUIRE( section.depends_on(cp) );
+    REQUIRE( section.depends_on(rho) );
+    REQUIRE( section.if_isotropic() );
+    
+    // True values calculated using the sectionproperties module in python BAR.py
+    const Real area_true = 2.2500000000000004e+00;
+    const Real torsion_constant_true = 3.5540414988249380e-01;
+    const Real first_area_moment_z_true = 6.4574999999999994e-01;
+    const Real first_area_moment_y_true = 3.7214999999999945e+00;
+    const Real second_area_moment_zz_true = 2.9079899999999986e-01;
+    const Real second_area_moment_yy_true = 7.8428609999999814e+00;
+    const Real second_area_moment_zy_true = 1.0680705000000006e+00;
+    const Real second_area_moment_polar_true = 8.1336599999999812e+00;
+    const Real Izzc_true = 1.0546874999999994e-01;
+    const Real Iyyc_true = 1.6875000000000009e+00;
+    const Real Izyc_true = 2.4424906541753444e-15;
+    const Real warping_constant_true = 6.1030611538894504e-02;
+    const Real kappa_z_true = 8.3330248143102326e-01;
+    const Real kappa_y_true = 5.5763491072129889e-01;
+    const Real xs_true = 1.6540000458463804e+00;
+    const Real ys_true = 2.8700000023051281e-01;
+    const Real xst_true = 1.6540000458463804e+00;
+    const Real yst_true = 2.8700000023051281e-01;
+    const libMesh::Point shear_center_true(xs_true, ys_true, 0.);
+    const libMesh::Point centroid_true(1.654, 0.287, 0.);
+    
+    // NOTE: The default 1D section is rectangular
+    const libMesh::Point point(4.3, -3.5, -6.7);
+    const Real time = 8.22;
+    
+    Real area;
+    const MAST::FieldFunction<Real>& Area = section.A();
+    Area(point, time, area);
+    REQUIRE( area == Approx(area_true) );
+    
+    Real first_area_moment_y;
+    const MAST::FieldFunction<Real>& Ay = section.Ay();
+    Ay(point, time, first_area_moment_y);
+    CHECK( first_area_moment_y == Approx(first_area_moment_y_true) );
+    
+    Real first_area_moment_z;
+    const MAST::FieldFunction<Real>& Az = section.Az();
+    Az(point, time, first_area_moment_z);
+    CHECK( first_area_moment_z == Approx(first_area_moment_z_true) );
+    
+    RealMatrixX I;
+    const MAST::FieldFunction<RealMatrixX>& Inertias = section.I();
+    Inertias(point, time, I);
+    REQUIRE( I(0,1) == I(1,0) );
+    Real Iyy = I(1,1);
+    Real Izz = I(0,0);
+    Real Izy = I(0,1);
+    REQUIRE( Izz == Approx(second_area_moment_zz_true) );
+    REQUIRE( Iyy == Approx(second_area_moment_yy_true) );
+    REQUIRE( Izy == Approx(second_area_moment_zy_true) );
+    
+    Real Ip;
+    const MAST::FieldFunction<Real>& PolarInertia = section.Ip();
+    PolarInertia(point, time, Ip);
+    REQUIRE( Ip == Approx(second_area_moment_polar_true) );
+    
+    Real torsion_constant;
+    const MAST::FieldFunction<Real>& TorsionConstant = section.J();
+    TorsionConstant(point, time, torsion_constant);
+    REQUIRE( torsion_constant == Approx(torsion_constant_true).epsilon(0.005) );
+    
+//     Real warping_constant;
+//     const MAST::FieldFunction<Real>& WarpingConstant = section.Gam();
+//     WarpingConstant(point, time, warping_constant);
+//     REQUIRE( warping_constant == Approx(warping_constant_true) );
+    
+    RealMatrixX shear_coefficients;
+    const MAST::FieldFunction<RealMatrixX>& ShearCoefficientMatrix = section.Kap();
+    ShearCoefficientMatrix(point, time, shear_coefficients);
+    REQUIRE( shear_coefficients(0,0) == Approx(kappa_z_true) );
+    REQUIRE( shear_coefficients(1,1) == Approx(kappa_y_true) );
+    
+//     libMesh::Point centroid = section.cross_section->get_centroid(p, t);
+//     REQUIRE( centroid(0) == Approx(centroid_true(0)) );
+//     REQUIRE( centroid(1) == Approx(centroid_true(1)) );
+    
+//     libMesh::Point shear_center = section.cross_section->get_shear_center(p, t);
+//     REQUIRE(shear_center(0) == Approx(xs_true));
+//     REQUIRE(shear_center(1) == Approx(ys_true));
+    
+    REQUIRE_FALSE( section.if_diagonal_mass_matrix() );
+    
+    section.set_diagonal_mass_matrix(true);
+    REQUIRE( section.if_diagonal_mass_matrix() );
+}
+
+
+/*!
+ * These sensitivity checks are performed against a 4th order accurate
+ * central difference approximation with a perturbation of 1.22e-04.
+ */
+TEST_CASE("solid_element_property_card_constant_base_sensitivity_1d",
+          "[1D],[isotropic],[constant],[property],[sensitivity]")
+{
+    const uint dim = 1;
+    
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter rho("rho_param", 1420.5);         // Density
+    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
+    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
+    MAST::Parameter kappa("kappa_param", 5.0/6.0);    // Shear coefficient
+    MAST::Parameter cp("cp_param",   908.0);          // Specific Heat Capacity
+    MAST::Parameter k("k_param",     237.0);          // Thermal Conductivity
+    
+    // Define Section Properties as MAST Parameters
+    MAST::Parameter thickness_y("hz", 3.0);   // Section thickness in z-direction
+    MAST::Parameter thickness_z("hy", 0.75);   // Section thickness in y-direction
+    MAST::Parameter offset_y("offy_param", 0.287);     // Section offset in y-direction
+    MAST::Parameter offset_z("offz_param", 1.654);     // Section offset in z-direction
+    MAST::Parameter Kzz("Kzz", 8.3330248143102326e-01);
+    MAST::Parameter Kyy("Kyy", 5.5763491072129889e-01);
+    
+    // Define Sensitivity Parameters
+    std::vector<MAST::Parameter*> sens_params = {&thickness_y, &thickness_z};
+    uint n_s = sens_params.size();
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    // Section Property Field Functions
+    MAST::ConstantFieldFunction thickness_y_f("hz", thickness_y);
+    MAST::ConstantFieldFunction thickness_z_f("hy", thickness_z);
+    MAST::ConstantFieldFunction offsety_f("hy_off", offset_y);
+    MAST::ConstantFieldFunction offsetz_f("hz_off", offset_z);
+    MAST::ConstantFieldFunction Kzz_f("Kappazz", Kzz);
+    MAST::ConstantFieldFunction Kyy_f("Kappayy", Kyy);
+    
+    // Material Property Field Functions
+    MAST::ConstantFieldFunction rho_f("rho", rho);
+    MAST::ConstantFieldFunction E_f("E", E);
+    MAST::ConstantFieldFunction nu_f("nu", nu);
+    MAST::ConstantFieldFunction cp_f("cp", cp);
+    MAST::ConstantFieldFunction k_f("k_th", k);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(rho_f);
+    material.add(k_f);
+    material.add(cp_f);
+    material.add(E_f);
+    material.add(nu_f);
+    
+    // Initialize the section
+    MAST::Solid1DSectionElementPropertyCard section;
+    
+    // Add the section property constant field functions to the section card
+    section.add(thickness_y_f);
+    section.add(thickness_z_f);
+    section.add(offsety_f);
+    section.add(offsetz_f);
+    section.add(Kzz_f);
+    section.add(Kyy_f);
+    
+    // Add the material card to the section card
+    section.set_material(material);
+    
+    // Specify a section orientation point and add it to the section.
+    RealVectorX orientation = RealVectorX::Zero(3);
+    orientation(1) = 1.0;
+    section.y_vector() = orientation;
+    
+    // Now initialize the section
+    section.init();
+    
+    REQUIRE( section.dim() == dim); // Ensure section is 1 dimensional
+    REQUIRE( section.depends_on(thickness_y) );
+    REQUIRE( section.depends_on(offset_y) );
+    REQUIRE( section.depends_on(thickness_z) );
+    REQUIRE( section.depends_on(offset_z) );
+    REQUIRE( section.depends_on(k) );
+    REQUIRE( section.depends_on(cp) );
+    REQUIRE( section.depends_on(rho) );
+    REQUIRE( section.if_isotropic() );
+    
+    // True values calculated using the sectionproperties module in python BAR.py
+    const Real area_true = 2.2500000000000004e+00;
+    const Real torsion_constant_true = 3.5540414988249380e-01;
+    const Real first_area_moment_z_true = 6.4574999999999994e-01;
+    const Real first_area_moment_y_true = 3.7214999999999945e+00;
+    const Real second_area_moment_zz_true = 2.9079899999999986e-01;
+    const Real second_area_moment_yy_true = 7.8428609999999814e+00;
+    const Real second_area_moment_zy_true = 1.0680705000000006e+00;
+    const Real second_area_moment_polar_true = 8.1336599999999812e+00;
+    const Real Izzc_true = 1.0546874999999994e-01;
+    const Real Iyyc_true = 1.6875000000000009e+00;
+    const Real Izyc_true = 2.4424906541753444e-15;
+    const Real warping_constant_true = 6.1030611538894504e-02;
+    const Real kappa_z_true = 8.3330248143102326e-01;
+    const Real kappa_y_true = 5.5763491072129889e-01;
+    const Real xs_true = 1.6540000458463804e+00;
+    const Real ys_true = 2.8700000023051281e-01;
+    const Real xst_true = 1.6540000458463804e+00;
+    const Real yst_true = 2.8700000023051281e-01;
+    const libMesh::Point shear_center_true(xs_true, ys_true, 0.);
+    
+    const libMesh::Point centroid_true(1.654, 0.287);
+    Real stress_C_x, stress_C_y, stress_D_x, stress_D_y;
+    Real stress_E_x, stress_E_y, stress_F_x, stress_F_y;
+    
+    const libMesh::Point point(4.3, -3.5, -6.7);
+    const Real time = 8.22;
+    
+    Real dA_dthickness_y, dA_dthickness_z;
+    Real dCz_dthickness_y, dCz_dthickness_z;
+    Real dCy_dthickness_y, dCy_dthickness_z;
+    Real dQz_dthickness_y, dQz_dthickness_z;
+    Real dQy_dthickness_y, dQy_dthickness_z;
+    Real dIzz_dthickness_y, dIzz_dthickness_z;
+    Real dIyy_dthickness_y, dIyy_dthickness_z;
+    Real dIzy_dthickness_y, dIzy_dthickness_z;
+    Real dIp_dthickness_y, dIp_dthickness_z;
+    Real dIzzc_dthickness_y, dIzzc_dthickness_z;
+    Real dIyyc_dthickness_y, dIyyc_dthickness_z;
+    Real dIzyc_dthickness_y, dIzyc_dthickness_z;
+    Real dIpc_dthickness_y, dIpc_dthickness_z;
+    Real dJ_dthickness_y, dJ_dthickness_z;
+    Real dxs_dthickness_y, dxs_dthickness_z;
+    Real dys_dthickness_y, dys_dthickness_z;
+    Real dW_dthickness_y, dW_dthickness_z;
+    
+    Real f_h, f_2h, f_n, f_2n;
+    RealVectorX fv_h, fv_2h, fv_n, fv_2n;
+    RealMatrixX fm_h, fm_2h, fm_n, fm_2n;
+    
+    const Real delta = 1.220703125e-04; // (np.spacing(1))**(0.25)
+    
+    // Area Sensitivity Check
+    const MAST::FieldFunction<Real>& Area = section.A();
+    std::vector<Real> dA(n_s);
+    for (uint i=0; i<n_s; i++)
+    {
+        Area.derivative(*sens_params[i], point, time, dA[i]);
+    }
+    
+    std::vector<Real> dA_cd(n_s);
+    for (uint i=0; i<n_s; i++)
+    {
+        (*sens_params[i])() += delta;
+        Area(point, time, f_h);
+        
+        (*sens_params[i])() += delta;
+        Area(point, time, f_2h);
+        
+        (*sens_params[i])() -= 3.0*delta;
+        Area(point, time, f_n);
+        
+        (*sens_params[i])() -= delta;
+        Area(point, time, f_2n);
+        
+        (*sens_params[i])() += 2.0*delta;
+        
+        dA_cd[i] = (f_2n - 8.*f_n + 8*f_h - f_2h)/(12.*delta);
+        
+        libMesh::out << "dA_d" << sens_params[i]->name() << " = " << dA[i] << "\tdA_cd = " << dA_cd[i] << std::endl;
+        REQUIRE(dA[i] == Approx(dA_cd[i]));
+    }
+    
+    
+//     // Centroid Sensitivity Check
+//     std::vector<libMesh::Point> dC(n_s);
+//     for (uint i=0; i<n_s; i++)
+//     {
+//         dC[i] = section.cross_section->get_centroid_derivative(*sens_params[i], point, time);
+//     }
+//     
+//     libMesh::Point fp_h, fp_2h, fp_n, fp_2n;
+//     std::vector<libMesh::Point> dC_cd(n_s);
+//     for (uint i=0; i<n_s; i++)
+//     {
+//         (*sens_params[i])() += delta;
+//         fp_h = section.cross_section->get_centroid(point, time);
+//         
+//         (*sens_params[i])() += delta;
+//         fp_2h = section.cross_section->get_centroid(point, time);
+//         
+//         (*sens_params[i])() -= 3.0*delta;
+//         fp_n = section.cross_section->get_centroid(point, time);
+//         
+//         (*sens_params[i])() -= delta;
+//         fp_2n = section.cross_section->get_centroid(point, time);
+//         
+//         (*sens_params[i])() += 2.0*delta;
+//         
+//         dC_cd[i] = (fp_2n - 8.*fp_n + 8*fp_h - fp_2h)/(12.*delta);
+//         
+//         libMesh::out << "dC_d" << sens_params[i]->name() << " = " << dC[i] << "\tdC_cd = " << dC_cd[i] << std::endl;
+//         REQUIRE(dC[i](0) == Approx(dC_cd[i](0)).margin(1.49e-08) );
+//         REQUIRE(dC[i](1) == Approx(dC_cd[i](1)).margin(1.49e-08) );
+//     }
+    
+    // First Area Moments Sensitivity Check
+    const MAST::FieldFunction<Real>& Area_y = section.Ay();
+    std::vector<Real> dAy(n_s);
+    for (uint i=0; i<n_s; i++)
+    {
+        Area_y.derivative(*sens_params[i], point, time, dAy[i]);
+    }
+    
+    std::vector<Real> dAy_cd(n_s);
+    for (uint i=0; i<n_s; i++)
+    {
+        (*sens_params[i])() += delta;
+        Area_y(point, time, f_h);
+        
+        (*sens_params[i])() += delta;
+        Area_y(point, time, f_2h);
+        
+        (*sens_params[i])() -= 3.0*delta;
+        Area_y(point, time, f_n);
+        
+        (*sens_params[i])() -= delta;
+        Area_y(point, time, f_2n);
+        
+        (*sens_params[i])() += 2.0*delta;
+        
+        dAy_cd[i] = (f_2n - 8.*f_n + 8*f_h - f_2h)/(12.*delta);
+        
+        libMesh::out << "dAy_d" << sens_params[i]->name() << " = " << dAy[i] << "\tdAy_cd = " << dAy_cd[i] << std::endl;
+        REQUIRE(dAy[i] == Approx(dAy_cd[i]));
+    }
+    
+    
+    const MAST::FieldFunction<Real>& Area_z = section.Az();
+    std::vector<Real> dAz(n_s);
+    for (uint i=0; i<n_s; i++)
+    {
+        Area_z.derivative(*sens_params[i], point, time, dAz[i]);
+    }
+    
+    std::vector<Real> dAz_cd(n_s);
+    for (uint i=0; i<n_s; i++)
+    {
+        (*sens_params[i])() += delta;
+        Area_z(point, time, f_h);
+        
+        (*sens_params[i])() += delta;
+        Area_z(point, time, f_2h);
+        
+        (*sens_params[i])() -= 3.0*delta;
+        Area_z(point, time, f_n);
+        
+        (*sens_params[i])() -= delta;
+        Area_z(point, time, f_2n);
+        
+        (*sens_params[i])() += 2.0*delta;
+        
+        dAz_cd[i] = (f_2n - 8.*f_n + 8*f_h - f_2h)/(12.*delta);
+        
+        libMesh::out << "dAz_d" << sens_params[i]->name() << " = " << dAz[i] << "\tdAz_cd = " << dAz_cd[i] << std::endl;
+        REQUIRE(dAz[i] == Approx(dAz_cd[i]));
+    }
+    
+    
+    // Second Area Moments Sensitivity Check
+    const MAST::FieldFunction<RealMatrixX>& Inertia = section.I();
+    std::vector<RealMatrixX> dI(n_s);
+    for (uint i=0; i<n_s; i++)
+    {
+        Inertia.derivative(*sens_params[i], point, time, dI[i]);
+    }
+    
+    std::vector<RealMatrixX> dI_cd(n_s);
+    for (uint i=0; i<n_s; i++)
+    {
+        (*sens_params[i])() += delta;
+        Inertia(point, time, fm_h);
+        
+        (*sens_params[i])() += delta;
+        Inertia(point, time, fm_2h);
+        
+        (*sens_params[i])() -= 3.0*delta;
+        Inertia(point, time, fm_n);
+        
+        (*sens_params[i])() -= delta;
+        Inertia(point, time, fm_2n);
+        
+        (*sens_params[i])() += 2.0*delta;
+        
+        dI_cd[i] = (fm_2n - 8.*fm_n + 8*fm_h - fm_2h)/(12.*delta);
+        
+        libMesh::out << "dI_d" << sens_params[i]->name() << " =\n" << dI[i] << "\ndI_cd = \n" << dI_cd[i] << std::endl;
+        
+        Real dIzz = dI[i](0,0);
+        Real dIyy = dI[i](1,1);
+        Real dIyz = dI[i](1,0);
+        Real dIzy = dI[i](0,1);
+        
+        Real dIzz_cd = dI_cd[i](0,0);
+        Real dIyy_cd = dI_cd[i](1,1);
+        Real dIyz_cd = dI_cd[i](1,0);
+        Real dIzy_cd = dI_cd[i](0,1);
+        
+        REQUIRE(dIzz == Approx(dIzz_cd));
+        REQUIRE(dIyy == Approx(dIyy_cd));
+        REQUIRE(dIyz == Approx(dIyz_cd));
+        REQUIRE(dIzy == Approx(dIzy_cd));
+        REQUIRE(dIyz == dIzy); // symmetry check
+    }
+    
+    
+    // Second Area Polar Moment Sensitivity Check
+    const MAST::FieldFunction<Real>& PolarInertia = section.Ip();
+    std::vector<Real> dIp(n_s);
+    for (uint i=0; i<n_s; i++)
+    {
+        PolarInertia.derivative(*sens_params[i], point, time, dIp[i]);
+    }
+    
+    std::vector<Real> dIp_cd(n_s);
+    for (uint i=0; i<n_s; i++)
+    {
+        (*sens_params[i])() += delta;
+        PolarInertia(point, time, f_h);
+        
+        (*sens_params[i])() += delta;
+        PolarInertia(point, time, f_2h);
+        
+        (*sens_params[i])() -= 3.0*delta;
+        PolarInertia(point, time, f_n);
+        
+        (*sens_params[i])() -= delta;
+        PolarInertia(point, time, f_2n);
+        
+        (*sens_params[i])() += 2.0*delta;
+        
+        dIp_cd[i] = (f_2n - 8.*f_n + 8.*f_h - f_2h)/(12.*delta);
+        
+        libMesh::out << "dIp_d" << sens_params[i]->name() << " = " << dIp[i] << "\tdIp_cd = " << dIp_cd[i] << std::endl;
+        REQUIRE(dIp[i] == Approx(dIp_cd[i]));
+    }
+    
+    
+//     // Shear Center Sensitivity Check
+//     std::vector<libMesh::Point> dCs(n_s);
+//     for (uint i=0; i<n_s; i++)
+//     {
+//         dCs[i] = section.cross_section->get_shear_center_derivative(*sens_params[i], point, time);
+//     }
+//     
+//     std::vector<libMesh::Point> dCs_cd(n_s);
+//     for (uint i=0; i<n_s; i++)
+//     {
+//         (*sens_params[i])() += delta;
+//         fp_h = section.cross_section->get_shear_center(point, time);
+//         
+//         (*sens_params[i])() += delta;
+//         fp_2h = section.cross_section->get_shear_center(point, time);
+//         
+//         (*sens_params[i])() -= 3.0*delta;
+//         fp_n = section.cross_section->get_shear_center(point, time);
+//         
+//         (*sens_params[i])() -= delta;
+//         fp_2n = section.cross_section->get_shear_center(point, time);
+//         
+//         (*sens_params[i])() += 2.0*delta;
+//         
+//         dCs_cd[i] = (fp_2n - 8.*fp_n + 8.*fp_h - fp_2h)/(12.*delta);
+//         
+//         libMesh::out << "dCs_d" << sens_params[i]->name() << " = " << dCs[i] << "\tdCs_cd = " << dCs_cd[i] << std::endl;
+//         REQUIRE(dCs[i](0) == Approx(dCs_cd[i](0)) );
+//         REQUIRE(dCs[i](1) == Approx(dCs_cd[i](1)) );
+//     }
+    
+    
+    // Torsion Constant Sensitivity Check
+    // NOTE: The field function below is not made constant because currently a finite difference is used to calculate sensitivity.
+    MAST::FieldFunction<Real>& TorsionConstant = section.J();
+    std::vector<Real> dJ(n_s);
+    for (uint i=0; i<n_s; i++)
+    {
+        TorsionConstant.derivative(*sens_params[i], point, time, dJ[i]);
+    }
+    
+    std::vector<Real> dJ_cd(n_s);
+    for (uint i=0; i<n_s; i++)
+    {
+        (*sens_params[i])() += delta;
+        TorsionConstant(point, time, f_h);
+        
+        (*sens_params[i])() += delta;
+        TorsionConstant(point, time, f_2h);
+        
+        (*sens_params[i])() -= 3.0*delta;
+        TorsionConstant(point, time, f_n);
+        
+        (*sens_params[i])() -= delta;
+        TorsionConstant(point, time, f_2n);
+        
+        (*sens_params[i])() += 2.0*delta;
+        
+        dJ_cd[i] = (f_2n - 8.*f_n + 8*f_h - f_2h)/(12.*delta);
+        
+        libMesh::out << "dJ_d" << sens_params[i]->name() << " = " << dJ[i] << "\tdJ_cd = " << dJ_cd[i] << std::endl;
+        REQUIRE(dJ[i] == Approx(dJ_cd[i]).epsilon(0.1) );
+        // NOTE: 10% error margin due to 'exact' sensitivity being calculated using finite difference
+    }
+    
+    
+//     // Shear Coefficient Sensitivity Check
+//     // NOTE: The field function below is not made constant because currently a finite difference is used to calculate sensitivity.
+//     MAST::FieldFunction<RealMatrixX>& Kappa = section.Kap();
+//     std::vector<RealMatrixX> dK(n_s);
+//     for (uint i=0; i<n_s; i++)
+//     {
+//         Kappa.derivative(*sens_params[i], point, time, dK[i]);
+//     }
+//     
+//     std::vector<RealMatrixX> dK_cd(n_s);
+//     for (uint i=0; i<n_s; i++)
+//     {
+//         (*sens_params[i])() += delta;
+//         Kappa(point, time, fm_h);
+//         
+//         (*sens_params[i])() += delta;
+//         Kappa(point, time, fm_2h);
+//         
+//         (*sens_params[i])() -= 3.0*delta;
+//         Kappa(point, time, fm_n);
+//         
+//         (*sens_params[i])() -= delta;
+//         Kappa(point, time, fm_2n);
+//         
+//         (*sens_params[i])() += 2.0*delta;
+//         
+//         dK_cd[i] = (fm_2n - 8.*fm_n + 8*fm_h - fm_2h)/(12.*delta);
+//         
+//         libMesh::out << "dK_d" << sens_params[i]->name() << " =\n" << dK[i] << "\ndK_cd = \n" << dK_cd[i] << std::endl;
+//         
+//         Real dKzz = dK[i](0,0);
+//         Real dKyy = dK[i](1,1);
+//         Real dKyz = dK[i](1,0);
+//         Real dKzy = dK[i](0,1);
+//         
+//         Real dKzz_cd = dK_cd[i](0,0);
+//         Real dKyy_cd = dK_cd[i](1,1);
+//         Real dKyz_cd = dK_cd[i](1,0);
+//         Real dKzy_cd = dK_cd[i](0,1);
+//         
+//         REQUIRE(dKzz == Approx(dKzz_cd).epsilon(0.1));
+//         REQUIRE(dKyy == Approx(dKyy_cd).epsilon(0.1));
+//         //REQUIRE(dKyz == Approx(dKyz_cd).epsilon(0.1)); // Comparison can be hard when this is nearly infinite (~1e+13)
+//         //REQUIRE(dKzy == Approx(dKzy_cd).epsilon(0.1)); // Comparison can be hard when this is nearly infinite (~1e+13)
+//         // NOTE: 10% error margin due to 'exact' sensitivity being calculated using finite difference
+//         REQUIRE(dKyz == dKzy); // symmetry check
+//     }
+    
+    
+    // Warping Constant Sensitivity Check
+    // NOTE: The field function below is not made constant because currently a finite difference is used to calculate sensitivity.
+    MAST::FieldFunction<Real>& WarpingConstant = section.Gam();
+    std::vector<Real> dW(n_s);
+    for (uint i=0; i<n_s; i++)
+    {
+        WarpingConstant.derivative(*sens_params[i], point, time, dW[i]);
+    }
+    
+    std::vector<Real> dW_cd(n_s);
+    for (uint i=0; i<n_s; i++)
+    {
+        (*sens_params[i])() += delta;
+        WarpingConstant(point, time, f_h);
+        
+        (*sens_params[i])() += delta;
+        WarpingConstant(point, time, f_2h);
+        
+        (*sens_params[i])() -= 3.0*delta;
+        WarpingConstant(point, time, f_n);
+        
+        (*sens_params[i])() -= delta;
+        WarpingConstant(point, time, f_2n);
+        
+        (*sens_params[i])() += 2.0*delta;
+        
+        dW_cd[i] = (f_2n - 8.*f_n + 8*f_h - f_2h)/(12.*delta);
+        
+        libMesh::out << "dW_d" << sens_params[i]->name() << " = " << dW[i] << "\tdW_cd = " << dW_cd[i] << std::endl;
+        REQUIRE(dW[i] == Approx(dW_cd[i]).epsilon(0.1) );
+        // NOTE: 10% error margin due to 'exact' sensitivity being calculated using finite difference
+    }
+}
+
+
+TEST_CASE("solid_element_property_card_constant_heat_transfer_1d",
+          "[heat_transfer],[1D],[isotropic],[constant],[property]")
+{
+    const uint dim = 1;
+    
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter rho("rho_param", 1420.5);         // Density
+    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
+    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
+    MAST::Parameter kappa("kappa_param", 5.0/6.0);    // Shear coefficient
+    MAST::Parameter cp("cp_param",   908.0);          // Specific Heat Capacity
+    MAST::Parameter k("k_param",     237.0);          // Thermal Conductivity
+    
+    // Define Section Properties as MAST Parameters
+    MAST::Parameter thickness_y("hz", 3.0);   // Section thickness in z-direction
+    MAST::Parameter thickness_z("hy", 0.75);   // Section thickness in y-direction
+    MAST::Parameter offset_y("offy_param", 0.287);     // Section offset in y-direction
+    MAST::Parameter offset_z("offz_param", 1.654);     // Section offset in z-direction
+    MAST::Parameter Kzz("Kzz", 8.3330248143102326e-01);
+    MAST::Parameter Kyy("Kyy", 5.5763491072129889e-01);
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    // Section Property Field Functions
+    MAST::ConstantFieldFunction thickness_y_f("hz", thickness_y);
+    MAST::ConstantFieldFunction thickness_z_f("hy", thickness_z);
+    MAST::ConstantFieldFunction offsety_f("hy_off", offset_y);
+    MAST::ConstantFieldFunction offsetz_f("hz_off", offset_z);
+    MAST::ConstantFieldFunction Kzz_f("Kappazz", Kzz);
+    MAST::ConstantFieldFunction Kyy_f("Kappayy", Kyy);
+    
+    // Material Property Field Functions
+    MAST::ConstantFieldFunction rho_f("rho", rho);
+    MAST::ConstantFieldFunction E_f("E", E);
+    MAST::ConstantFieldFunction nu_f("nu", nu);
+    MAST::ConstantFieldFunction cp_f("cp", cp);
+    MAST::ConstantFieldFunction k_f("k_th", k);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(rho_f);
+    material.add(k_f);
+    material.add(cp_f);
+    material.add(E_f);
+    material.add(nu_f);
+    
+    // Initialize the section
+    MAST::Solid1DSectionElementPropertyCard section;
+    
+    // Add the section property constant field functions to the section card
+    section.add(thickness_y_f);
+    section.add(thickness_z_f);
+    section.add(offsety_f);
+    section.add(offsetz_f);
+    section.add(Kzz_f);
+    section.add(Kyy_f);
+    
+    // Add the material card to the section card
+    section.set_material(material);
+    
+//     // Specify a section orientation point and add it to the section.
+//     RealVectorX orientation = RealVectorX::Zero(3);
+//     orientation(1) = 1.0;
+//     section.y_vector() = orientation;
+    
+    // Now initialize the section
+    section.init();
+    
+    REQUIRE( section.dim() == dim); // Ensure section is 1 dimensional
+    REQUIRE( section.depends_on(thickness_y) );
+    REQUIRE( section.depends_on(offset_y) );
+    REQUIRE( section.depends_on(thickness_z) );
+    REQUIRE( section.depends_on(offset_z) );
+    REQUIRE( section.depends_on(k) );
+    REQUIRE( section.depends_on(cp) );
+    REQUIRE( section.depends_on(rho) );
+    REQUIRE( section.if_isotropic() );
+    
+    // True values calculated using the sectionproperties module in python BAR.py
+    const Real area_true = 2.2500000000000004e+00;
+    
+    // NOTE: The default 1D section is rectangular
+    const libMesh::Point point(4.3, -3.5, -6.7);
+    const Real time = 8.22;
+    
+    Real area;
+    const MAST::FieldFunction<Real>& Area = section.A();
+    Area(point, time, area);
+    REQUIRE( area == Approx(area_true) );
+    
+
+    SECTION("1D section thermal conductance matrix")
+    {
+        /** 
+         * As of Dec. 17, 2019, inertia_matrix requires the input of an
+         * MAST::ElementBase object, but does not actually use it. To get 
+         * around requiring the creation of such an object (and therefore 
+         * the creation of a MAST::SystemInitialization, MAST::AssemblyBase,
+         * and MAST::GeomElem objects as well).
+         * 
+         * To remedy this, an additional method was added to MAST which allows
+         * inertia_matrix to be obtained without any input arguments.
+         */
+        std::unique_ptr<MAST::FieldFunction<RealMatrixX>> conduct_mat = section.thermal_conductance_matrix();
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_sec_conduc;
+        conduct_mat->operator()(point, time, D_sec_conduc);
+        
+        // Hard-coded value of the section's extension stiffness
+        RealMatrixX D_sec_conduc_true = RealMatrixX::Zero(1,1);
+        D_sec_conduc_true(0,0) = k() * area_true;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_conduc);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_conduc_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    SECTION("1D section thermal capacitance matrix")
+    {
+        /** 
+         * As of Dec. 17, 2019, inertia_matrix requires the input of an
+         * MAST::ElementBase object, but does not actually use it. To get 
+         * around requiring the creation of such an object (and therefore 
+         * the creation of a MAST::SystemInitialization, MAST::AssemblyBase,
+         * and MAST::GeomElem objects as well).
+         * 
+         * To remedy this, an additional method was added to MAST which allows
+         * inertia_matrix to be obtained without any input arguments.
+         */
+        std::unique_ptr<MAST::FieldFunction<RealMatrixX>> capaci_mat = section.thermal_capacitance_matrix();
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_sec_capac;
+        capaci_mat->operator()(point, time, D_sec_capac);
+        
+        // Hard-coded value of the section's extension stiffness
+        RealMatrixX D_sec_capac_true = RealMatrixX::Zero(1,1);
+        D_sec_capac_true(0,0) = cp() * rho() * area_true;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_capac);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_capac_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("solid_element_property_card_constant_thermoelastic_1d",
+          "[thermoelastic],[1D],[isotropic],[constant],[property]")
+{
+    const uint dim = 1;
+    
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter rho("rho_param", 1420.5);         // Density
+    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
+    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
+    MAST::Parameter kappa("kappa_param", 5.0/6.0);    // Shear coefficient
+    MAST::Parameter cp("cp_param",   908.0);          // Specific Heat Capacity
+    MAST::Parameter k("k_param",     237.0);          // Thermal Conductivity
+    MAST::Parameter alpha("alpha_param", 5.43e-05);   // Coefficient of thermal expansion
+    
+    // Define Section Properties as MAST Parameters
+    MAST::Parameter thickness_y("hz", 3.0);   // Section thickness in z-direction
+    MAST::Parameter thickness_z("hy", 0.75);   // Section thickness in y-direction
+    MAST::Parameter offset_y("offy_param", 0.287);     // Section offset in y-direction
+    MAST::Parameter offset_z("offz_param", 1.654);     // Section offset in z-direction
+    MAST::Parameter Kzz("Kzz", 8.3330248143102326e-01);
+    MAST::Parameter Kyy("Kyy", 5.5763491072129889e-01);
+    
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    // Section Property Field Functions
+    MAST::ConstantFieldFunction thickness_y_f("hz", thickness_y);
+    MAST::ConstantFieldFunction thickness_z_f("hy", thickness_z);
+    MAST::ConstantFieldFunction offsety_f("hy_off", offset_y);
+    MAST::ConstantFieldFunction offsetz_f("hz_off", offset_z);
+    MAST::ConstantFieldFunction Kzz_f("Kappazz", Kzz);
+    MAST::ConstantFieldFunction Kyy_f("Kappayy", Kyy);
+    
+    
+    // Material Property Field Functions
+    MAST::ConstantFieldFunction rho_f("rho", rho);
+    MAST::ConstantFieldFunction E_f("E", E);
+    MAST::ConstantFieldFunction nu_f("nu", nu);
+    MAST::ConstantFieldFunction cp_f("cp", cp);
+    MAST::ConstantFieldFunction k_f("k_th", k);
+    MAST::ConstantFieldFunction alpha_f("alpha_expansion", alpha);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(rho_f);
+    material.add(k_f);
+    material.add(cp_f);
+    material.add(E_f);
+    material.add(nu_f);
+    material.add(alpha_f);
+    
+    // Initialize the section
+    MAST::Solid1DSectionElementPropertyCard section;
+    
+    // Add the section property constant field functions to the section card
+    section.add(thickness_y_f);
+    section.add(thickness_z_f);
+    section.add(offsety_f);
+    section.add(offsetz_f);
+    section.add(Kzz_f);
+    section.add(Kyy_f);
+    
+    // Add the material card to the section card
+    section.set_material(material);
+    
+    // Specify a section orientation point and add it to the section.
+    RealVectorX orientation = RealVectorX::Zero(3);
+    orientation(1) = 1.0;
+    section.y_vector() = orientation;
+    
+    // Now initialize the section
+    section.init();
+    
+    REQUIRE( section.dim() == dim); // Ensure section is 1 dimensional
+    REQUIRE( section.depends_on(thickness_y) );
+    REQUIRE( section.depends_on(offset_y) );
+    REQUIRE( section.depends_on(thickness_z) );
+    REQUIRE( section.depends_on(offset_z) );
+    REQUIRE( section.depends_on(E) );
+    REQUIRE( section.depends_on(nu) );
+    REQUIRE( section.depends_on(alpha) );
+    REQUIRE( section.if_isotropic() );
+    
+    // True values calculated using the sectionproperties module in python BAR.py
+    // NOTE: The default 1D section is rectangular
+    const libMesh::Point point(4.3, -3.5, -6.7);
+    const Real time = 8.22;
+    
+// True values calculated using the sectionproperties module in python BAR.py
+    const Real area_true = 2.2500000000000004e+00;
+    const Real first_area_moment_z_true = 6.4574999999999994e-01;
+    const Real first_area_moment_y_true = 3.7214999999999945e+00;
+
+    SECTION("1D thermal expansion A matrix")
+    {
+        /** 
+         * As of Dec. 17, 2019, thermal_expansion_A_matrix requires the input of an
+         * MAST::ElementBase object, but does not actually use it. To get 
+         * around requiring the creation of such an object (and therefore 
+         * the creation of a MAST::SystemInitialization, MAST::AssemblyBase,
+         * and MAST::GeomElem objects as well).
+         * 
+         * To remedy this, an additional method was added to MAST which allows
+         * thermal_expansion_A_matrix to be obtained without any input arguments.
+         */
+        
+        Real area;
+        const MAST::FieldFunction<Real>& Area = section.A();
+        Area(point, time, area);
+        CHECK( area == Approx(area_true) );
+        
+        std::unique_ptr<MAST::FieldFunction<RealMatrixX>> texp_A_mat = section.thermal_expansion_A_matrix();
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_sec_texpA;
+        texp_A_mat->operator()(point, time, D_sec_texpA);
+                
+        // Hard-coded value of the section's extension stiffness
+        RealMatrixX D_sec_texpA_true = RealMatrixX::Zero(2,1);
+        D_sec_texpA_true(0,0) = E() * alpha() * area_true;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_texpA);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_texpA_true);
+        
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    SECTION("1D thermal expansion B matrix")
+    {
+        /** 
+         * As of Dec. 17, 2019, thermal_expansion_B_matrix requires the input of an
+         * MAST::ElementBase object, but does not actually use it. To get 
+         * around requiring the creation of such an object (and therefore 
+         * the creation of a MAST::SystemInitialization, MAST::AssemblyBase,
+         * and MAST::GeomElem objects as well).
+         * 
+         * To remedy this, an additional method was added to MAST which allows
+         * thermal_expansion_B_matrix to be obtained without any input arguments.
+         */
+        
+        Real first_area_moment_y;
+        const MAST::FieldFunction<Real>& Ay = section.Ay();
+        Ay(point, time, first_area_moment_y);
+        CHECK( first_area_moment_y == Approx(first_area_moment_y_true) );
+        
+        Real first_area_moment_z;
+        const MAST::FieldFunction<Real>& Az = section.Az();
+        Az(point, time, first_area_moment_z);
+        CHECK( first_area_moment_z == Approx(first_area_moment_z_true) );
+        
+        std::unique_ptr<MAST::FieldFunction<RealMatrixX>> texp_B_mat = section.thermal_expansion_B_matrix();
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_sec_texpB;
+        texp_B_mat->operator()(point, time, D_sec_texpB);
+        
+        libMesh::out << "texp_B_mat =\n" << D_sec_texpB << std::endl;
+        
+        // Hard-coded value of the section's extension stiffness
+        RealMatrixX D_sec_texpB_true = RealMatrixX::Zero(2,1);
+        D_sec_texpB_true(0,0) = E() * alpha() * area_true * offset_y();
+        D_sec_texpB_true(1,0) = E() * alpha() * area_true * offset_z();
+        
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_texpB);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_texpB_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("solid_element_property_card_constant_dynamic_1d",
+          "[dynamic],[1D],[isotropic],[constant],[property]")
+{
+    const uint dim = 1;
+    
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter rho("rho_param", 1420.5);         // Density
+    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
+    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
+    MAST::Parameter kappa("kappa_param", 5.0/6.0);    // Shear coefficient
+    MAST::Parameter cp("cp_param",   908.0);          // Specific Heat Capacity
+    MAST::Parameter k("k_param",     237.0);          // Thermal Conductivity
+    MAST::Parameter alpha("alpha_param", 5.43e-05);   // Coefficient of thermal expansion
+    
+    // Define Section Properties as MAST Parameters
+    MAST::Parameter thickness_y("hz", 3.0);   // Section thickness in z-direction
+    MAST::Parameter thickness_z("hy", 0.75);   // Section thickness in y-direction
+    MAST::Parameter offset_y("offy_param", 0.287);     // Section offset in y-direction
+    MAST::Parameter offset_z("offz_param", 1.654);     // Section offset in z-direction
+    MAST::Parameter Kzz("Kzz", 8.3330248143102326e-01);
+    MAST::Parameter Kyy("Kyy", 5.5763491072129889e-01);
+    
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    // Section Property Field Functions
+    MAST::ConstantFieldFunction thickness_y_f("hz", thickness_y);
+    MAST::ConstantFieldFunction thickness_z_f("hy", thickness_z);
+    MAST::ConstantFieldFunction offsety_f("hy_off", offset_y);
+    MAST::ConstantFieldFunction offsetz_f("hz_off", offset_z);
+    MAST::ConstantFieldFunction Kzz_f("Kappazz", Kzz);
+    MAST::ConstantFieldFunction Kyy_f("Kappayy", Kyy);
+    
+    
+    // Material Property Field Functions
+    MAST::ConstantFieldFunction rho_f("rho", rho);
+    MAST::ConstantFieldFunction E_f("E", E);
+    MAST::ConstantFieldFunction nu_f("nu", nu);
+    MAST::ConstantFieldFunction cp_f("cp", cp);
+    MAST::ConstantFieldFunction k_f("k_th", k);
+    MAST::ConstantFieldFunction alpha_f("alpha_expansion", alpha);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(rho_f);
+    material.add(k_f);
+    material.add(cp_f);
+    material.add(E_f);
+    material.add(nu_f);
+    material.add(alpha_f);
+    
+    // Initialize the section
+    MAST::Solid1DSectionElementPropertyCard section;
+    
+    // Add the section property constant field functions to the section card
+    section.add(thickness_y_f);
+    section.add(thickness_z_f);
+    section.add(offsety_f);
+    section.add(offsetz_f);
+    section.add(Kzz_f);
+    section.add(Kyy_f);
+    
+    // Add the material card to the section card
+    section.set_material(material);
+    
+    // Specify a section orientation point and add it to the section.
+    RealVectorX orientation = RealVectorX::Zero(3);
+    orientation(1) = 1.0;
+    section.y_vector() = orientation;
+    
+    // Now initialize the section
+    section.init();
+    
+    REQUIRE( section.dim() == dim); // Ensure section is 1 dimensional
+    REQUIRE( section.depends_on(thickness_y) );
+    REQUIRE( section.depends_on(offset_y) );
+    REQUIRE( section.depends_on(thickness_z) );
+    REQUIRE( section.depends_on(offset_z) );
+    REQUIRE( section.depends_on(k) );
+    REQUIRE( section.depends_on(cp) );
+    REQUIRE( section.depends_on(rho) );
+    REQUIRE( section.if_isotropic() );
+    
+    // True values calculated using the sectionproperties module in python BAR.py
+    const Real area_true = 2.2500000000000004e+00;
+    const Real torsion_constant_true = 3.5540414988249380e-01;
+    const Real first_area_moment_z_true = 6.4574999999999994e-01;
+    const Real first_area_moment_y_true = 3.7214999999999945e+00;
+    const Real second_area_moment_zz_true = 2.9079899999999986e-01;
+    const Real second_area_moment_yy_true = 7.8428609999999814e+00;
+    const Real second_area_moment_zy_true = 1.0680705000000006e+00;
+    const Real second_area_moment_polar_true = 8.1336599999999812e+00;
+    const Real Izzc_true = 1.0546874999999994e-01;
+    const Real Iyyc_true = 1.6875000000000009e+00;
+    const Real Izyc_true = 2.4424906541753444e-15;
+    const Real warping_constant_true = 6.1030611538894504e-02;
+    const Real kappa_z_true = 8.3330248143102326e-01;
+    const Real kappa_y_true = 5.5763491072129889e-01;
+    const Real xs_true = 1.6540000458463804e+00;
+    const Real ys_true = 2.8700000023051281e-01;
+    const Real xst_true = 1.6540000458463804e+00;
+    const Real yst_true = 2.8700000023051281e-01;
+    const libMesh::Point shear_center_true(xs_true, ys_true, 0.);
+    const libMesh::Point centroid_true(1.654, 0.287, 0.);
+    
+    // NOTE: The default 1D section is rectangular
+    const libMesh::Point point(4.3, -3.5, -6.7);
+    const Real time = 8.22;
+    
+    SECTION("1D section inertia matrix")
+    {
+        /** 
+         * As of Dec. 17, 2019, inertia_matrix requires the input of an
+         * MAST::ElementBase object, but does not actually use it. To get 
+         * around requiring the creation of such an object (and therefore 
+         * the creation of a MAST::SystemInitialization, MAST::AssemblyBase,
+         * and MAST::GeomElem objects as well).
+         * 
+         * To remedy this, an additional method was added to MAST which allows
+         * inertia_matrix to be obtained without any input arguments.
+         */
+        std::unique_ptr<MAST::FieldFunction<RealMatrixX>> inertia_mat = section.inertia_matrix();
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_sec_iner;
+        inertia_mat->operator()(point, time, D_sec_iner);
+        
+        // Hard-coded value of the section's extension stiffness
+        RealMatrixX D_sec_iner_true = RealMatrixX::Zero(6,6);
+        
+        
+        Real area;
+        const MAST::FieldFunction<Real>& Area = section.A();
+        Area(point, time, area);
+        REQUIRE( area == Approx(area_true) );
+        D_sec_iner_true(0,0) = D_sec_iner_true(1,1) = D_sec_iner_true(2,2) = area_true;
+        
+        Real Ip;
+        const MAST::FieldFunction<Real>& PolarInertia = section.Ip();
+        PolarInertia(point, time, Ip);
+        CHECK( Ip == Approx(second_area_moment_polar_true) );
+        D_sec_iner_true(3,3) = second_area_moment_polar_true;
+        
+        
+        Real first_area_moment_y;
+        const MAST::FieldFunction<Real>& Ay = section.Ay();
+        Ay(point, time, first_area_moment_y);
+        CHECK( first_area_moment_y == Approx(first_area_moment_y_true) );
+        D_sec_iner_true(0,4) = D_sec_iner_true(4,0) = first_area_moment_y_true;
+        
+        Real first_area_moment_z;
+        const MAST::FieldFunction<Real>& Az = section.Az();
+        Az(point, time, first_area_moment_z);
+        CHECK( first_area_moment_z == Approx(first_area_moment_z_true) );
+        D_sec_iner_true(0,5) = D_sec_iner_true(5,0) = first_area_moment_z_true;
+        
+        
+        RealMatrixX I;
+        const MAST::FieldFunction<RealMatrixX>& Inertias = section.I();
+        Inertias(point, time, I);
+        REQUIRE( I(0,1) == I(1,0) );
+        Real Iyy = I(1,1);
+        Real Izz = I(0,0);
+        Real Izy = I(0,1);
+        REQUIRE( Izz == Approx(second_area_moment_zz_true) );
+        REQUIRE( Iyy == Approx(second_area_moment_yy_true) );
+        REQUIRE( Izy == Approx(second_area_moment_zy_true) );
+        D_sec_iner_true(4,4) = Iyy; // TODO: Should this be Izz?
+        D_sec_iner_true(4,5) = Izy;
+        D_sec_iner_true(5,4) = Izy;
+        D_sec_iner_true(5,5) = Izz; // TODO: Should this be Iyy??
+        
+        D_sec_iner_true *= rho();
+
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_iner);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_iner_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("solid_element_property_card_constant_structural_1d",
+          "[structural],[1D],[isotropic],[constant],[property]")
+{
+    const uint dim = 1;
+    
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter rho("rho_param", 1420.5);         // Density
+    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
+    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
+    MAST::Parameter kappa("kappa_param", 5.0/6.0);    // Shear coefficient
+    MAST::Parameter cp("cp_param",   908.0);          // Specific Heat Capacity
+    MAST::Parameter k("k_param",     237.0);          // Thermal Conductivity
+    MAST::Parameter alpha("alpha_param", 5.43e-05);   // Coefficient of thermal expansion
+    
+    // Define Section Properties as MAST Parameters
+    MAST::Parameter thickness_y("hz", 3.0);   // Section thickness in z-direction
+    MAST::Parameter thickness_z("hy", 0.75);   // Section thickness in y-direction
+    MAST::Parameter offset_y("offy_param", 0.287);     // Section offset in y-direction
+    MAST::Parameter offset_z("offz_param", 1.654);     // Section offset in z-direction
+    MAST::Parameter Kzz("Kzz", 8.3330248143102326e-01);
+    MAST::Parameter Kyy("Kyy", 5.5763491072129889e-01);
+    
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    // Section Property Field Functions
+    MAST::ConstantFieldFunction thickness_y_f("hz", thickness_y);
+    MAST::ConstantFieldFunction thickness_z_f("hy", thickness_z);
+    MAST::ConstantFieldFunction offsety_f("hy_off", offset_y);
+    MAST::ConstantFieldFunction offsetz_f("hz_off", offset_z);
+    MAST::ConstantFieldFunction Kzz_f("Kappazz", Kzz);
+    MAST::ConstantFieldFunction Kyy_f("Kappayy", Kyy);
+    
+    
+    // Material Property Field Functions
+    MAST::ConstantFieldFunction rho_f("rho", rho);
+    MAST::ConstantFieldFunction E_f("E", E);
+    MAST::ConstantFieldFunction nu_f("nu", nu);
+    MAST::ConstantFieldFunction cp_f("cp", cp);
+    MAST::ConstantFieldFunction k_f("k_th", k);
+    MAST::ConstantFieldFunction alpha_f("alpha_expansion", alpha);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(rho_f);
+    material.add(k_f);
+    material.add(cp_f);
+    material.add(E_f);
+    material.add(nu_f);
+    material.add(alpha_f);
+    
+    // Initialize the section
+    MAST::Solid1DSectionElementPropertyCard section;
+    
+    // Add the section property constant field functions to the section card
+    section.add(thickness_y_f);
+    section.add(thickness_z_f);
+    section.add(offsety_f);
+    section.add(offsetz_f);
+    section.add(Kzz_f);
+    section.add(Kyy_f);
+    
+    // Add the material card to the section card
+    section.set_material(material);
+    
+    // Specify a section orientation point and add it to the section.
+    RealVectorX orientation = RealVectorX::Zero(3);
+    orientation(1) = 1.0;
+    section.y_vector() = orientation;
+    
+    // Now initialize the section
+    section.init();
+    
+    REQUIRE( section.dim() == dim); // Ensure section is 1 dimensional
+    REQUIRE( section.depends_on(thickness_y) );
+    REQUIRE( section.depends_on(offset_y) );
+    REQUIRE( section.depends_on(thickness_z) );
+    REQUIRE( section.depends_on(offset_z) );
+    REQUIRE( section.depends_on(E) );
+    REQUIRE( section.depends_on(nu) );
+    REQUIRE( section.depends_on(Kzz) );
+    REQUIRE( section.depends_on(Kyy) );
+    REQUIRE( section.depends_on(rho) );
+    REQUIRE( section.if_isotropic() );
+    
+    // True values calculated using the sectionproperties module in python BAR.py
+    const Real area_true = 2.2500000000000004e+00;
+    const Real torsion_constant_true = 3.5540414988249380e-01;
+    const Real first_area_moment_z_true = 6.4574999999999994e-01;
+    const Real first_area_moment_y_true = 3.7214999999999945e+00;
+    const Real second_area_moment_zz_true = 2.9079899999999986e-01;
+    const Real second_area_moment_yy_true = 7.8428609999999814e+00;
+    const Real second_area_moment_zy_true = 1.0680705000000006e+00;
+    const Real second_area_moment_polar_true = 8.1336599999999812e+00;
+    const Real Izzc_true = 1.0546874999999994e-01;
+    const Real Iyyc_true = 1.6875000000000009e+00;
+    const Real Izyc_true = 2.4424906541753444e-15;
+    const Real warping_constant_true = 6.1030611538894504e-02;
+    const Real kappa_z_true = 8.3330248143102326e-01;
+    const Real kappa_y_true = 5.5763491072129889e-01;
+    const Real xs_true = 1.6540000458463804e+00;
+    const Real ys_true = 2.8700000023051281e-01;
+    const Real xst_true = 1.6540000458463804e+00;
+    const Real yst_true = 2.8700000023051281e-01;
+    const libMesh::Point shear_center_true(xs_true, ys_true, 0.);
+    const libMesh::Point centroid_true(1.654, 0.287, 0.);
+    
+    // NOTE: The default 1D section is rectangular
+    const libMesh::Point point(4.3, -3.5, -6.7);
+    const Real time = 8.22;
+    
+    SECTION("set_get_bending_model")
+    {
+        // NOTE: MAST::DKT and MAST::MINDLIN are not valid options for 1D sections, even though their input is accepted.
+        section.set_bending_model(MAST::BERNOULLI);
+        section.set_bending_model(MAST::DEFAULT_BENDING);
+        section.set_bending_model(MAST::NO_BENDING);
+        section.set_bending_model(MAST::TIMOSHENKO);
+        
+        // TODO: Implement element creation for testing of getting bending_model and checking default
+        //REQUIRE( section.bending_model()
+    }
+    
+//     SECTION("quadrature_order")
+//     {
+//         section.set_bending_model(MAST::MINDLIN);
+//         REQUIRE( section.extra_quadrature_order(elem) == 0 );
+//         
+//         section.set_bending_model(MAST::DKT);
+//         REQUIRE( section.extra_quadrature_order(elem) == 2 );
+//     }
+    
+    SECTION("1D extension stiffness matrix")
+    {                
+        /** 
+         * As of Dec. 17, 2019, stiffness_A_matrix requires the input of an
+         * MAST::ElementBase object, but does not actually use it. To get 
+         * around requiring the creation of such an object (and therefore 
+         * the creation of a MAST::SystemInitialization, MAST::AssemblyBase,
+         * and MAST::GeomElem objects as well).
+         * 
+         * To remedy this, an additional method was added to MAST which allows
+         * stiffness_A_matrix to be obtained without any input arguments.
+         */
+        Real area;
+        const MAST::FieldFunction<Real>& Area = section.A();
+        Area(point, time, area);
+        REQUIRE( area == Approx(area_true) );
+        
+        Real torsion_constant;
+        const MAST::FieldFunction<Real>& TorsionConstant = section.J();
+        TorsionConstant(point, time, torsion_constant);
+        REQUIRE( torsion_constant == Approx(torsion_constant_true).epsilon(0.05) );
+        
+        std::unique_ptr<MAST::FieldFunction<RealMatrixX>> extension_stiffness_mat = section.stiffness_A_matrix();
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_sec_ext;
+        extension_stiffness_mat->operator()(point, time, D_sec_ext);
+        
+        libMesh::out << "D_sec_ext\n" << D_sec_ext << std::endl;
+        
+        // Hard-coded value of the section's extension stiffness
+        Real G = E() / (2. * (1.+nu()));
+        RealMatrixX D_sec_ext_true = RealMatrixX::Zero(2,2);
+        D_sec_ext_true(0,0) = E() * area_true;
+        D_sec_ext_true(1,1) = G   * torsion_constant_true;
+        
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_ext);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_ext_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth).epsilon(0.05) );
+    }
+    
+    
+    SECTION("1D bending section stiffness matrix")
+    {
+        /** 
+         * As of Dec. 17, 2019, stiffness_D_matrix requires the input of an
+         * MAST::ElementBase object, but does not actually use it. To get 
+         * around requiring the creation of such an object (and therefore 
+         * the creation of a MAST::SystemInitialization, MAST::AssemblyBase,
+         * and MAST::GeomElem objects as well).
+         * 
+         * To remedy this, an additional method was added to MAST which allows
+         * stiffness_D_matrix to be obtained without any input arguments.
+         */
+        RealMatrixX I;
+        const MAST::FieldFunction<RealMatrixX>& Inertias = section.I();
+        Inertias(point, time, I);
+        REQUIRE( I(0,1) == I(1,0) );
+        Real Izz = I(0,0);
+        Real Iyy = I(1,1);
+        Real Izy = I(0,1);
+        REQUIRE( Izz == Approx(second_area_moment_zz_true) );
+        REQUIRE( Iyy == Approx(second_area_moment_yy_true) );
+        REQUIRE( Izy == Approx(second_area_moment_zy_true) );
+        
+        std::unique_ptr<MAST::FieldFunction<RealMatrixX>> bending_stiffness_mat = section.stiffness_D_matrix();
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_sec_bnd;
+        bending_stiffness_mat->operator()(point, time, D_sec_bnd);
+        
+        // Hard-coded value of the section's extension stiffness
+        RealMatrixX D_sec_bnd_true = RealMatrixX::Zero(2,2);
+        D_sec_bnd_true(0,0) = E() * second_area_moment_zz_true;
+        D_sec_bnd_true(1,1) = E() * second_area_moment_yy_true;
+        D_sec_bnd_true(0,1) = E() * second_area_moment_zy_true;
+        D_sec_bnd_true(1,0) = E() * second_area_moment_zy_true;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_bnd);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_bnd_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    SECTION("1D extension-bending section stiffness matrix")
+    {
+        /** 
+         * As of Dec. 17, 2019, stiffness_B_matrix requires the input of an
+         * MAST::ElementBase object, but does not actually use it. To get 
+         * around requiring the creation of such an object (and therefore 
+         * the creation of a MAST::SystemInitialization, MAST::AssemblyBase,
+         * and MAST::GeomElem objects as well).
+         * 
+         * To remedy this, an additional method was added to MAST which allows
+         * stiffness_B_matrix to be obtained without any input arguments.
+         */
+        Real first_area_moment_y;
+        const MAST::FieldFunction<Real>& Ay = section.Ay();
+        Ay(point, time, first_area_moment_y);
+        CHECK( first_area_moment_y == Approx(first_area_moment_y_true) );
+        
+        Real first_area_moment_z;
+        const MAST::FieldFunction<Real>& Az = section.Az();
+        Az(point, time, first_area_moment_z);
+        CHECK( first_area_moment_z == Approx(first_area_moment_z_true) );
+        
+        std::unique_ptr<MAST::FieldFunction<RealMatrixX>> bndext_stiffness_mat = section.stiffness_B_matrix();
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_sec_bndext;
+        bndext_stiffness_mat->operator()(point, time, D_sec_bndext);
+        
+        // Hard-coded value of the section's extension stiffness
+        RealMatrixX D_sec_bndext_true = RealMatrixX::Zero(2,2);
+        D_sec_bndext_true(0,0) = E() * first_area_moment_z_true;
+        D_sec_bndext_true(0,1) = E() * first_area_moment_y_true;
+        // TODO: Add checks for torsion bending coupling when added to MAST.
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_bndext);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_bndext_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    SECTION("1D transverse shear section stiffness matrix")
+    {
+        /** 
+         * As of Dec. 17, 2019, transverse_shear_stiffness_matrix requires the input of an
+         * MAST::ElementBase object, but does not actually use it. To get 
+         * around requiring the creation of such an object (and therefore 
+         * the creation of a MAST::SystemInitialization, MAST::AssemblyBase,
+         * and MAST::GeomElem objects as well).
+         * 
+         * To remedy this, an additional method was added to MAST which allows
+         * transverse_shear_stiffness_matrix to be obtained without any input arguments.
+         */
+        Real area;
+        const MAST::FieldFunction<Real>& Area = section.A();
+        Area(point, time, area);
+        REQUIRE( area == Approx(area_true) );
+        
+        std::unique_ptr<MAST::FieldFunction<RealMatrixX>> trans_shear_stiffness_mat = section.transverse_shear_stiffness_matrix();
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_sec_shr;
+        trans_shear_stiffness_mat->operator()(point, time, D_sec_shr);
+        
+        // Hard-coded value of the section's extension stiffness
+        Real G = E() / (2. * (1.+nu()));
+        RealMatrixX D_sec_shr_true = RealMatrixX::Zero(2,2);
+        D_sec_shr_true(0,0) = G*area_true*kappa_z_true; 
+        D_sec_shr_true(1,1) = G*area_true*kappa_y_true; 
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_shr);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_shr_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    
+//     SECTION("1D spring section stiffness matrix")
+//     {
+//         /** 
+//          * As of Dec. 17, 2019, spring_stiffness_matrix requires the input of an
+//          * MAST::ElementBase object, but does not actually use it. To get 
+//          * around requiring the creation of such an object (and therefore 
+//          * the creation of a MAST::SystemInitialization, MAST::AssemblyBase,
+//          * and MAST::GeomElem objects as well).
+//          * 
+//          * To remedy this, an additional method was added to MAST which allows
+//          * transverse_shear_stiffness_matrix to be obtained without any input arguments.
+//          */
+//         std::unique_ptr<MAST::FieldFunction<RealMatrixX>> spring_stiffness_mat = section.stiffness_S_matrix();
+//         
+//         const libMesh::Point point(2.3, 3.1, 5.2);
+//         const Real time = 2.34;
+//         RealMatrixX D_sec_spring;
+//         spring_stiffness_mat->operator()(point, time, D_sec_spring);
+//         
+//         // Hard-coded value of the section's extension stiffness
+//         // NOTE: Should be all zero's for non-bushing sections
+//         RealMatrixX D_sec_spring_true = RealMatrixX::Zero(4,6);
+//         
+//         // Convert the test and truth Eigen::Matrix objects to std::vector
+//         // since Catch2 has built in methods to compare vectors
+//         std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_spring);
+//         std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_spring_true);
+//         
+//         // Floating point approximations are diffcult to compare since the
+//         // values typically aren't exactly equal due to numerical error.
+//         // Therefore, we use the Approx comparison instead of Equals
+//         CHECK_THAT( test, Catch::Approx<double>(truth) );
+//     }
+}

--- a/tests/property/mast_solid_2d_section_element_property_card.cpp
+++ b/tests/property/mast_solid_2d_section_element_property_card.cpp
@@ -1,0 +1,906 @@
+// Catch2 includes
+#include "catch.hpp"
+
+// libMesh includes
+#include "libmesh/point.h"
+
+// MAST includes
+#include "base/parameter.h"
+#include "base/constant_field_function.h"
+#include "property_cards/isotropic_material_property_card.h"
+#include "property_cards/solid_2d_section_element_property_card.h"
+
+// Custom includes
+#include "test_helpers.h"
+
+// TODO: Need to test with other types of materials.
+// TODO: Need to test function that gets material.
+
+extern libMesh::LibMeshInit* p_global_init;
+
+TEST_CASE("element_property_card_constant_heat_transfer_2d",
+          "[heat_transfer],[2D],[isotropic],[constant],[property]")
+{
+    const uint dim = 2;
+    
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter k("k_param",     237.0);          // Thermal Conductivity
+    
+    // Define Section Properties as MAST Parameters
+    MAST::Parameter thickness("th_param", 0.06);      // Section thickness
+    MAST::Parameter offset("off_param", 0.03);        // Section offset
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction k_f("k_th", k);
+    MAST::ConstantFieldFunction thickness_f("h", thickness);
+    MAST::ConstantFieldFunction offset_f("off", offset);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(k_f);
+    
+    // Initialize the section
+    MAST::Solid2DSectionElementPropertyCard section;
+    
+    // Add the section property constant field functions to the section card
+    section.add(thickness_f);
+    section.add(offset_f);
+    
+    // Add the material card to the section card
+    section.set_material(material);
+    
+    REQUIRE( section.dim() == dim); // Ensure section is 2 dimensional
+    REQUIRE( section.depends_on(thickness) );
+    REQUIRE( section.depends_on(offset) );
+    REQUIRE( section.depends_on(k) );
+    
+    SECTION("2D section thermal conductance matrix")
+    {
+        /** 
+         * As of Dec. 17, 2019, inertia_matrix requires the input of an
+         * MAST::ElementBase object, but does not actually use it. To get 
+         * around requiring the creation of such an object (and therefore 
+         * the creation of a MAST::SystemInitialization, MAST::AssemblyBase,
+         * and MAST::GeomElem objects as well).
+         * 
+         * To remedy this, an additional method was added to MAST which allows
+         * inertia_matrix to be obtained without any input arguments.
+         */
+        std::unique_ptr<MAST::FieldFunction<RealMatrixX>> conduct_mat = section.thermal_conductance_matrix();
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_sec_conduc;
+        conduct_mat->operator()(point, time, D_sec_conduc);
+        
+        // Hard-coded value of the section's extension stiffness
+        RealMatrixX D_sec_conduc_true = RealMatrixX::Zero(2,2);
+        D_sec_conduc_true(0,0) = 237.0*0.06;
+        D_sec_conduc_true(1,1) = 237.0*0.06;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_conduc);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_conduc_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("element_property_card_constant_transient_heat_transfer_2d",
+          "[heat_transfer],[2D],[isotropic],[constant],[property],[transient]")
+{
+    const uint dim = 2;
+    
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter rho("rho_param", 1420.5);         // Density
+    MAST::Parameter cp("cp_param",   908.0);          // Specific Heat Capacity
+    
+    // Define Section Properties as MAST Parameters
+    MAST::Parameter thickness("th_param", 0.06);      // Section thickness
+    MAST::Parameter offset("off_param", 0.03);        // Section offset
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction rho_f("rho", rho);
+    MAST::ConstantFieldFunction cp_f("cp", cp);
+    MAST::ConstantFieldFunction thickness_f("h", thickness);
+    MAST::ConstantFieldFunction offset_f("off", offset);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(rho_f);
+    material.add(cp_f);
+    
+    // Initialize the section
+    MAST::Solid2DSectionElementPropertyCard section;
+    
+    // Add the section property constant field functions to the section card
+    section.add(thickness_f);
+    section.add(offset_f);
+    
+    // Add the material card to the section card
+    section.set_material(material);
+    
+    REQUIRE( section.dim() == dim); // Ensure section is 2 dimensional
+    REQUIRE( section.depends_on(thickness) );
+    REQUIRE( section.depends_on(offset) );
+    REQUIRE( section.depends_on(cp) );
+    REQUIRE( section.depends_on(rho) );
+    
+    SECTION("2D section thermal capacitance matrix")
+    {
+        /** 
+         * As of Dec. 17, 2019, inertia_matrix requires the input of an
+         * MAST::ElementBase object, but does not actually use it. To get 
+         * around requiring the creation of such an object (and therefore 
+         * the creation of a MAST::SystemInitialization, MAST::AssemblyBase,
+         * and MAST::GeomElem objects as well).
+         * 
+         * To remedy this, an additional method was added to MAST which allows
+         * inertia_matrix to be obtained without any input arguments.
+         */
+        std::unique_ptr<MAST::FieldFunction<RealMatrixX>> capaci_mat = section.thermal_capacitance_matrix();
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_sec_capac;
+        capaci_mat->operator()(point, time, D_sec_capac);
+        
+        // Hard-coded value of the section's extension stiffness
+        RealMatrixX D_sec_capac_true = RealMatrixX::Zero(1,1);
+        D_sec_capac_true(0,0) = 908.0*1420.5*0.06;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_capac);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_capac_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("element_property_card_constant_thermoelastic_2d",
+          "[thermoelastic],[2D],[isotropic],[constant],[property]")
+{
+    const uint dim = 2;
+    
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
+    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
+    MAST::Parameter alpha("alpha_param", 5.43e-05);   // Coefficient of thermal expansion
+    
+    // Define Section Properties as MAST Parameters
+    MAST::Parameter thickness("th_param", 0.06);      // Section thickness
+    MAST::Parameter offset("off_param", 0.03);        // Section offset
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction E_f("E", E);
+    MAST::ConstantFieldFunction nu_f("nu", nu);
+    MAST::ConstantFieldFunction alpha_f("alpha_expansion", alpha);
+    MAST::ConstantFieldFunction thickness_f("h", thickness);
+    MAST::ConstantFieldFunction offset_f("off", offset);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(E_f);
+    material.add(nu_f);
+    material.add(alpha_f);
+    
+    // Initialize the section
+    MAST::Solid2DSectionElementPropertyCard section;
+    
+    // Add the section property constant field functions to the section card
+    section.add(thickness_f);
+    section.add(offset_f);
+    
+    // Add the material card to the section card
+    section.set_material(material);
+    
+    REQUIRE( section.dim() == dim); // Ensure section is 2 dimensional
+    REQUIRE( section.depends_on(thickness) );
+    REQUIRE( section.depends_on(offset) );
+    REQUIRE( section.depends_on(alpha) );
+    
+    SECTION("2D plane stress thermal expansion A matrix")
+    {
+        /*!
+         *  thermal expansion A matrix is defined as D * alpha_vec * thickness
+         */
+        
+        section.set_plane_stress(true);
+        REQUIRE( section.plane_stress() );
+                
+        /** 
+         * As of Dec. 17, 2019, thermal_expansion_A_matrix requires the input of an
+         * MAST::ElementBase object, but does not actually use it. To get 
+         * around requiring the creation of such an object (and therefore 
+         * the creation of a MAST::SystemInitialization, MAST::AssemblyBase,
+         * and MAST::GeomElem objects as well).
+         * 
+         * To remedy this, an additional method was added to MAST which allows
+         * thermal_expansion_A_matrix to be obtained without any input arguments.
+         */
+        std::unique_ptr<MAST::FieldFunction<RealMatrixX>> texp_A_mat = section.thermal_expansion_A_matrix();
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_sec_texpA;
+        texp_A_mat->operator()(point, time, D_sec_texpA);
+        
+        // Hard-coded value of the section's extension stiffness
+        RealMatrixX D_sec_texpA_true = RealMatrixX::Zero(3,1);
+        D_sec_texpA_true(0,0) = 3.501134328358209e+05;
+        D_sec_texpA_true(1,0) = 3.501134328358209e+05;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_texpA);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_texpA_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    
+    SECTION("2D plane strain thermal expansion A matrix")
+    {
+        /*!
+         *  thermal expansion A matrix is defined as D * alpha_vec * thickness
+         */
+        
+        section.set_plane_stress(false);
+        REQUIRE_FALSE( section.plane_stress() );
+                
+        /** 
+         * As of Dec. 17, 2019, thermal_expansion_A_matrix requires the input of an
+         * MAST::ElementBase object, but does not actually use it. To get 
+         * around requiring the creation of such an object (and therefore 
+         * the creation of a MAST::SystemInitialization, MAST::AssemblyBase,
+         * and MAST::GeomElem objects as well).
+         * 
+         * To remedy this, an additional method was added to MAST which allows
+         * thermal_expansion_A_matrix to be obtained without any input arguments.
+         */
+        std::unique_ptr<MAST::FieldFunction<RealMatrixX>> texp_A_mat = section.thermal_expansion_A_matrix();
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_sec_texpA;
+        texp_A_mat->operator()(point, time, D_sec_texpA);
+        
+        // Hard-coded value of the section's extension stiffness
+        RealMatrixX D_sec_texpA_true = RealMatrixX::Zero(3,1);
+        D_sec_texpA_true(0,0) = 5.187439186200796e+05;
+        D_sec_texpA_true(1,0) = 5.187439186200796e+05;
+                
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_texpA);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_texpA_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    
+    SECTION("2D plane stress thermal expansion B matrix")
+    {
+        /*!
+         *  thermal expansion B matrix is defined as D * alpha_vec * thickness * offset
+         */
+        
+        section.set_plane_stress(true);
+        REQUIRE( section.plane_stress() );
+                
+        /** 
+         * As of Dec. 17, 2019, thermal_expansion_B_matrix requires the input of an
+         * MAST::ElementBase object, but does not actually use it. To get 
+         * around requiring the creation of such an object (and therefore 
+         * the creation of a MAST::SystemInitialization, MAST::AssemblyBase,
+         * and MAST::GeomElem objects as well).
+         * 
+         * To remedy this, an additional method was added to MAST which allows
+         * thermal_expansion_B_matrix to be obtained without any input arguments.
+         */
+        std::unique_ptr<MAST::FieldFunction<RealMatrixX>> texp_B_mat = section.thermal_expansion_B_matrix();
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_sec_texpB;
+        texp_B_mat->operator()(point, time, D_sec_texpB);
+        
+        // Hard-coded value of the section's extension stiffness
+        RealMatrixX D_sec_texpB_true = RealMatrixX::Zero(3,1);
+        D_sec_texpB_true(0,0) = 1.050340298507463e+04;
+        D_sec_texpB_true(1,0) = 1.050340298507463e+04;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_texpB);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_texpB_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    SECTION("2D plane strain thermal expansion B matrix")
+    {
+        /*!
+         *  thermal expansion B matrix is defined as D * alpha_vec * thickness * offset
+         */
+        
+        section.set_plane_stress(false);
+        REQUIRE_FALSE( section.plane_stress() );
+                
+        /** 
+         * As of Dec. 17, 2019, thermal_expansion_B_matrix requires the input of an
+         * MAST::ElementBase object, but does not actually use it. To get 
+         * around requiring the creation of such an object (and therefore 
+         * the creation of a MAST::SystemInitialization, MAST::AssemblyBase,
+         * and MAST::GeomElem objects as well).
+         * 
+         * To remedy this, an additional method was added to MAST which allows
+         * thermal_expansion_B_matrix to be obtained without any input arguments.
+         */
+        std::unique_ptr<MAST::FieldFunction<RealMatrixX>> texp_B_mat = section.thermal_expansion_B_matrix();
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_sec_texpB;
+        texp_B_mat->operator()(point, time, D_sec_texpB);
+        
+        // Hard-coded value of the section's extension stiffness
+        RealMatrixX D_sec_texpB_true = RealMatrixX::Zero(3,1);
+        D_sec_texpB_true(0,0) = 1.556231755860239e+04;
+        D_sec_texpB_true(1,0) = 1.556231755860239e+04;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_texpB);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_texpB_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("element_property_card_constant_dynamic_2d",
+          "[dynamic],[2D],[isotropic],[constant],[property]")
+{
+    const uint dim = 2;
+    
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter rho("rho_param", 1420.5);         // Density
+    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
+    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
+    MAST::Parameter kappa("kappa_param", 5.0/6.0);    // Shear coefficient
+    
+    // Define Section Properties as MAST Parameters
+    MAST::Parameter thickness("th_param", 0.06);      // Section thickness
+    MAST::Parameter offset("off_param", 0.03);        // Section offset
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction rho_f("rho", rho);
+    MAST::ConstantFieldFunction E_f("E", E);
+    MAST::ConstantFieldFunction nu_f("nu", nu);
+    MAST::ConstantFieldFunction kappa_f("kappa", kappa);
+    MAST::ConstantFieldFunction thickness_f("h", thickness);
+    MAST::ConstantFieldFunction offset_f("off", offset);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(rho_f);
+    material.add(E_f);                                             
+    material.add(nu_f);
+    
+    // Initialize the section
+    MAST::Solid2DSectionElementPropertyCard section;
+    
+    // Add the section property constant field functions to the section card
+    section.add(thickness_f);
+    section.add(offset_f);
+    section.add(kappa_f);
+    
+    // Add the material card to the section card
+    section.set_material(material);
+    
+    REQUIRE( section.dim() == dim); // Ensure section is 2 dimensional
+    REQUIRE( section.depends_on(thickness) );
+    REQUIRE( section.depends_on(offset) );
+    REQUIRE( section.depends_on(E) );
+    REQUIRE( section.depends_on(nu) );
+    REQUIRE( section.depends_on(kappa) );
+    
+    REQUIRE_FALSE( section.if_diagonal_mass_matrix() );
+    
+    section.set_diagonal_mass_matrix(true);
+    REQUIRE( section.if_diagonal_mass_matrix() );
+    
+    SECTION("2D section inertia matrix")
+    {
+        /** 
+         * As of Dec. 17, 2019, inertia_matrix requires the input of an
+         * MAST::ElementBase object, but does not actually use it. To get 
+         * around requiring the creation of such an object (and therefore 
+         * the creation of a MAST::SystemInitialization, MAST::AssemblyBase,
+         * and MAST::GeomElem objects as well).
+         * 
+         * To remedy this, an additional method was added to MAST which allows
+         * inertia_matrix to be obtained without any input arguments.
+         */
+        std::unique_ptr<MAST::FieldFunction<RealMatrixX>> inertia_mat = section.inertia_matrix();
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_sec_iner;
+        inertia_mat->operator()(point, time, D_sec_iner);
+        
+        // Hard-coded value of the section's extension stiffness
+        RealMatrixX D_sec_iner_true = RealMatrixX::Zero(6,6);
+        D_sec_iner_true(0,0) = D_sec_iner_true(1,1) = D_sec_iner_true(2,2) = 0.06;
+        D_sec_iner_true(0,4) = D_sec_iner_true(4,0) = 0.03*0.06;
+        D_sec_iner_true(1,3) = D_sec_iner_true(3,1) = -0.03*0.06;
+        D_sec_iner_true(3,3) = D_sec_iner_true(4,4) = pow(0.06,3.0)/12.0 + 0.06*0.03*0.03;
+        D_sec_iner_true(5,5) = pow(0.06,3.0)/12.0 * 1.0e-6; // Ignore this term
+        
+        D_sec_iner_true *= 1420.5;
+
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_iner);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_iner_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+
+TEST_CASE("element_property_card_constant_structural_2d",
+          "[structural],[2D],[isotropic],[constant],[property]")
+{
+    const uint dim = 2;
+    
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
+    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
+    MAST::Parameter kappa("kappa_param", 5.0/6.0);    // Shear coefficient
+    
+    // Define Section Properties as MAST Parameters
+    MAST::Parameter thickness("th_param", 0.06);      // Section thickness
+    MAST::Parameter offset("off_param", 0.03);        // Section offset
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction E_f("E", E);
+    MAST::ConstantFieldFunction nu_f("nu", nu);
+    MAST::ConstantFieldFunction kappa_f("kappa", kappa);
+    MAST::ConstantFieldFunction thickness_f("h", thickness);
+    MAST::ConstantFieldFunction offset_f("off", offset);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(E_f);                                             
+    material.add(nu_f);
+    
+    // Initialize the section
+    MAST::Solid2DSectionElementPropertyCard section;
+    
+    // Add the section property constant field functions to the section card
+    section.add(thickness_f);
+    section.add(offset_f);
+    section.add(kappa_f);
+    
+    // Add the material card to the section card
+    section.set_material(material);
+    
+    REQUIRE( section.dim() == dim); // Ensure section is 2 dimensional
+    REQUIRE( section.depends_on(thickness) );
+    REQUIRE( section.depends_on(offset) );
+    REQUIRE( section.depends_on(E) );
+    REQUIRE( section.depends_on(nu) );
+    REQUIRE( section.depends_on(kappa) );
+    
+    SECTION("solid_2d_section is isotropic")
+    {
+        CHECK( section.if_isotropic() );
+    }
+    
+    SECTION("set_get_strain_type")
+    {
+        // Check that the default is linear strain
+        REQUIRE( section.strain_type() == MAST::LINEAR_STRAIN );
+        
+        section.set_strain(MAST::LINEAR_STRAIN);
+        REQUIRE( section.strain_type() == MAST::LINEAR_STRAIN );
+        REQUIRE_FALSE( section.strain_type() == MAST::NONLINEAR_STRAIN );
+        
+        section.set_strain(MAST::NONLINEAR_STRAIN);
+        REQUIRE( section.strain_type() == MAST::NONLINEAR_STRAIN );
+        REQUIRE_FALSE( section.strain_type() == MAST::LINEAR_STRAIN );
+    }
+    
+    SECTION("set_get_bending_model")
+    {
+        // NOTE: MAST::BERNOULLI AND MAST::TIMOSHENKO are not valid options for 2D sections, even though their input is accepted.
+        section.set_bending_model(MAST::DKT);
+        section.set_bending_model(MAST::DEFAULT_BENDING);
+        section.set_bending_model(MAST::NO_BENDING);
+        section.set_bending_model(MAST::MINDLIN);
+        
+        // TODO: Implement element creation for testing of getting bending_model and checking default
+        //REQUIRE( section.bending_model()
+    }
+    
+    SECTION("set_get_plane_stress_strain")
+    {
+        // Check that default is plane stress
+        REQUIRE( section.plane_stress() == true );
+        
+        section.set_plane_stress(false);
+        REQUIRE( section.plane_stress() == false );
+        
+        section.set_plane_stress(true);
+        REQUIRE( section.plane_stress() == true);
+    }
+    
+    
+//     SECTION("quadrature_order")
+//     {
+//         section.set_bending_model(MAST::MINDLIN);
+//         REQUIRE( section.extra_quadrature_order(elem) == 0 );
+//         
+//         section.set_bending_model(MAST::DKT);
+//         REQUIRE( section.extra_quadrature_order(elem) == 2 );
+//     }
+    
+    SECTION("2D plane stress extension stiffness matrix")
+    {
+        /*!
+         *  extension sitffness matrix is defined as D * thickness
+         */
+        
+        section.set_plane_stress(true);
+        REQUIRE( section.plane_stress() );
+                
+        /** 
+         * As of Dec. 17, 2019, stiffness_A_matrix requires the input of an
+         * MAST::ElementBase object, but does not actually use it. To get 
+         * around requiring the creation of such an object (and therefore 
+         * the creation of a MAST::SystemInitialization, MAST::AssemblyBase,
+         * and MAST::GeomElem objects as well).
+         * 
+         * To remedy this, an additional method was added to MAST which allows
+         * stiffness_A_matrix to be obtained without any input arguments.
+         */
+        std::unique_ptr<MAST::FieldFunction<RealMatrixX>> extension_stiffness_mat = section.stiffness_A_matrix();
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_sec_ext;
+        extension_stiffness_mat->operator()(point, time, D_sec_ext);
+        
+        // Hard-coded value of the section's extension stiffness
+        RealMatrixX D_sec_ext_true = RealMatrixX::Zero(3,3);
+        D_sec_ext_true(0,0) = 4.847940747390865e+09;
+        D_sec_ext_true(1,1) = 4.847940747390865e+09;
+        D_sec_ext_true(0,1) = 1.599820446638986e+09;
+        D_sec_ext_true(1,0) = 1.599820446638986e+09;
+        D_sec_ext_true(2,2) = 1.624060150375940e+09;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_ext);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_ext_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    
+    SECTION("2D plane strain extension stiffness matrix")
+    {
+        /*!
+         *  extension sitffness matrix is defined as D * thickness
+         */
+        
+        section.set_plane_stress(false);
+        REQUIRE_FALSE( section.plane_stress() );
+                
+        /** 
+         * As of Dec. 17, 2019, stiffness_A_matrix requires the input of an
+         * MAST::ElementBase object, but does not actually use it. To get 
+         * around requiring the creation of such an object (and therefore 
+         * the creation of a MAST::SystemInitialization, MAST::AssemblyBase,
+         * and MAST::GeomElem objects as well).
+         * 
+         * To remedy this, an additional method was added to MAST which allows
+         * stiffness_A_matrix to be obtained without any input arguments.
+         */
+        std::unique_ptr<MAST::FieldFunction<RealMatrixX>> extension_stiffness_mat = section.stiffness_A_matrix();
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_sec_ext;
+        extension_stiffness_mat->operator()(point, time, D_sec_ext);
+        
+        // Hard-coded value of the section's extension stiffness
+        RealMatrixX D_sec_ext_true = RealMatrixX::Zero(3,3);
+        D_sec_ext_true(0,0) = 6.400707651481644e+09;
+        D_sec_ext_true(1,1) = 6.400707651481644e+09;
+        D_sec_ext_true(0,1) = 3.152587350729766e+09;
+        D_sec_ext_true(1,0) = 3.152587350729766e+09;
+        D_sec_ext_true(2,2) = 1.624060150375940e+09;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_ext);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_ext_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    
+    SECTION("2D plane stress bending section stiffness matrix")
+    {
+        /*!
+         *  bending section stiffness matrix is defined as D * (thickness^3 / 12 +  thickness*offset^2)
+         */
+        
+        section.set_plane_stress(true);
+        REQUIRE( section.plane_stress() );
+                
+        /** 
+         * As of Dec. 17, 2019, stiffness_D_matrix requires the input of an
+         * MAST::ElementBase object, but does not actually use it. To get 
+         * around requiring the creation of such an object (and therefore 
+         * the creation of a MAST::SystemInitialization, MAST::AssemblyBase,
+         * and MAST::GeomElem objects as well).
+         * 
+         * To remedy this, an additional method was added to MAST which allows
+         * stiffness_D_matrix to be obtained without any input arguments.
+         */
+        std::unique_ptr<MAST::FieldFunction<RealMatrixX>> bending_stiffness_mat = section.stiffness_D_matrix();
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_sec_bnd;
+        bending_stiffness_mat->operator()(point, time, D_sec_bnd);
+        
+        // Hard-coded value of the section's extension stiffness
+        RealMatrixX D_sec_bnd_true = RealMatrixX::Zero(3,3);
+        D_sec_bnd_true(0,0) = 5.817528896869037e+06;
+        D_sec_bnd_true(1,1) = 5.817528896869037e+06;
+        D_sec_bnd_true(0,1) = 1.919784535966782e+06;
+        D_sec_bnd_true(1,0) = 1.919784535966782e+06;
+        D_sec_bnd_true(2,2) = 1.948872180451127e+06;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_bnd);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_bnd_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    
+    SECTION("2D plane strain bending section stiffness matrix")
+    {
+        /*!
+         *  bending section stiffness matrix is defined as D * (thickness^3 / 12 +  thickness*offset^2)
+         */
+        
+        section.set_plane_stress(false);
+        REQUIRE_FALSE( section.plane_stress() );
+                
+        /** 
+         * As of Dec. 17, 2019, stiffness_D_matrix requires the input of an
+         * MAST::ElementBase object, but does not actually use it. To get 
+         * around requiring the creation of such an object (and therefore 
+         * the creation of a MAST::SystemInitialization, MAST::AssemblyBase,
+         * and MAST::GeomElem objects as well).
+         * 
+         * To remedy this, an additional method was added to MAST which allows
+         * stiffness_D_matrix to be obtained without any input arguments.
+         */
+        std::unique_ptr<MAST::FieldFunction<RealMatrixX>> bending_stiffness_mat = section.stiffness_D_matrix();
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_sec_bnd;
+        bending_stiffness_mat->operator()(point, time, D_sec_bnd);
+        
+        // Hard-coded value of the section's extension stiffness
+        RealMatrixX D_sec_bnd_true = RealMatrixX::Zero(3,3);
+        D_sec_bnd_true(0,0) = 7.680849181777972e+06;
+        D_sec_bnd_true(1,1) = 7.680849181777972e+06;
+        D_sec_bnd_true(0,1) = 3.783104820875719e+06;
+        D_sec_bnd_true(1,0) = 3.783104820875719e+06;
+        D_sec_bnd_true(2,2) = 1.948872180451128e+06;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_bnd);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_bnd_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    
+    SECTION("2D plane stress extension-bending section stiffness matrix")
+    {
+        /*!
+         *  extension-bending section stiffness matrix is defined as 
+         *  D * thickness * offset
+         */
+        
+        section.set_plane_stress(true);
+        REQUIRE( section.plane_stress() );
+                
+        /** 
+         * As of Dec. 17, 2019, stiffness_B_matrix requires the input of an
+         * MAST::ElementBase object, but does not actually use it. To get 
+         * around requiring the creation of such an object (and therefore 
+         * the creation of a MAST::SystemInitialization, MAST::AssemblyBase,
+         * and MAST::GeomElem objects as well).
+         * 
+         * To remedy this, an additional method was added to MAST which allows
+         * stiffness_B_matrix to be obtained without any input arguments.
+         */
+        std::unique_ptr<MAST::FieldFunction<RealMatrixX>> bndext_stiffness_mat = section.stiffness_B_matrix();
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_sec_bndext;
+        bndext_stiffness_mat->operator()(point, time, D_sec_bndext);
+        
+        // Hard-coded value of the section's extension stiffness
+        RealMatrixX D_sec_bndext_true = RealMatrixX::Zero(3,3);
+        D_sec_bndext_true(0,0) = 1.454382224217259e+08;
+        D_sec_bndext_true(1,1) = 1.454382224217259e+08;
+        D_sec_bndext_true(0,1) = 0.479946133991696e+08;
+        D_sec_bndext_true(1,0) = 0.479946133991696e+08;
+        D_sec_bndext_true(2,2) = 0.487218045112782e+08;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_bndext);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_bndext_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    
+    SECTION("2D plane strain extension-bending section stiffness matrix")
+    {
+        /*!
+         *  extension-bending section stiffness matrix is defined as 
+         *  D * thickness * offset
+         */
+        
+        section.set_plane_stress(false);
+        REQUIRE_FALSE( section.plane_stress() );
+                
+        /** 
+         * As of Dec. 17, 2019, stiffness_B_matrix requires the input of an
+         * MAST::ElementBase object, but does not actually use it. To get 
+         * around requiring the creation of such an object (and therefore 
+         * the creation of a MAST::SystemInitialization, MAST::AssemblyBase,
+         * and MAST::GeomElem objects as well).
+         * 
+         * To remedy this, an additional method was added to MAST which allows
+         * stiffness_B_matrix to be obtained without any input arguments.
+         */
+        std::unique_ptr<MAST::FieldFunction<RealMatrixX>> bndext_stiffness_mat = section.stiffness_B_matrix();
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_sec_bndext;
+        bndext_stiffness_mat->operator()(point, time, D_sec_bndext);
+        
+        // Hard-coded value of the section's extension stiffness
+        RealMatrixX D_sec_bndext_true = RealMatrixX::Zero(3,3);
+        D_sec_bndext_true(0,0) = 1.920212295444493e+08;
+        D_sec_bndext_true(1,1) = 1.920212295444493e+08;
+        D_sec_bndext_true(0,1) = 0.945776205218930e+08;
+        D_sec_bndext_true(1,0) = 0.945776205218930e+08;
+        D_sec_bndext_true(2,2) = 0.487218045112782e+08;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_bndext);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_bndext_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    
+    SECTION("2D transverse shear section stiffness matrix")
+    {
+        /*!
+         * transverse shear section stiffness matrix is defined as
+         * D * thickness * kappa
+         */
+        
+        section.set_plane_stress(true);
+        REQUIRE( section.plane_stress() );
+                
+        /** 
+         * As of Dec. 17, 2019, transverse_shear_stiffness_matrix requires the input of an
+         * MAST::ElementBase object, but does not actually use it. To get 
+         * around requiring the creation of such an object (and therefore 
+         * the creation of a MAST::SystemInitialization, MAST::AssemblyBase,
+         * and MAST::GeomElem objects as well).
+         * 
+         * To remedy this, an additional method was added to MAST which allows
+         * transverse_shear_stiffness_matrix to be obtained without any input arguments.
+         */
+        std::unique_ptr<MAST::FieldFunction<RealMatrixX>> trans_shear_stiffness_mat = section.transverse_shear_stiffness_matrix();
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_sec_shr;
+        trans_shear_stiffness_mat->operator()(point, time, D_sec_shr);
+        
+        // Hard-coded value of the section's extension stiffness
+        RealMatrixX D_sec_shr_true = RealMatrixX::Zero(2,2);
+        D_sec_shr_true(0,0) = 1.353383458646616e+09;
+        D_sec_shr_true(1,1) = 1.353383458646616e+09;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_shr);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_shr_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}


### PR DESCRIPTION
This PR is an extension of #60 and adds additional tests of existing MAST library capability. Most tests were originally implemented by @JohnDN90.

Below is a checklist of commits implemented by @JohnDN90 in his `add_catch2_tests` branch the whose contents/functionality need rolled in:
- [x] Added catch2 header file for upcoming new tests. (#60)
- [x] Bug fixes and enhancements to CMake files. (#60)
- [x] Added option to use libmesh_devel (development) version. (#60)
- [X] Added catch2 tests for some MAST base functions. (#60)
- [x] Added catch2 test for TEMPERATURE boundary condition.
- [x] Added catch2 tests for mast_boundary_condition_base
- [x] Removed shear coefficient (kappa) from isotropic material. Added plane strain support to isotropic material. (#60)
- [x] Added catch2 tests for mast_isotropic_material. (#60)
- [x] Multiple changes to orthotropic material, including added plane strain support. (#60)
- [x] Added catch2 tests for orthotropic_material_property_card. (#60)
- [x] Moved shear coefficient (kappa) to 2D section card and added overloaded functions to 2D section card. (#60)
- [x] Added catch2 tests for solid_2d_section_element_property_card. (this PR)
- [x] Added overloaded functions to isotropic 3D section property card. (this PR)
- [x] Added catch2 tests for isotropic_element_property_card_3D. (this PR)
- Added new public release statement to README.
- [x] Add overloaded functions to solid_1d_section_element_property_card. (this PR)
- Formatting for README.md
- [x] Multiple changes to 1d_solid_section_element_property_card. (this PR)
- [x] Added catch2 tests for solid_1d_section_element_property_card. (this PR)
- Added basic catch2 tests for generic 1D structural elements.
- Fixed bug in GitHub Issue #41 where NO_BENDING incorrectly called TIMOSHENKO.
- Added catch2 tests for 1D structural element with extension and torsion.
- [x] Fixed bug in GitHub issue #43, where incorrect I value was being used for bending about y-axis. (#75)
- Added many for tests for 1D structural 2-noded (edge2) element.
- Added generic catch2 tests for 2D structrual elements.
- Added many catch2 tests for 4-node quadrilaterial 2D element (quad4).
- [X] UPDATE EXAMPLES MOVING KAPPA FROM MATERIAL TO SECTION CARD (#60)
- [X] Fixed bugs in catch2 tests which caused some to fail when run with a debug version of MAST. (some fixed in this PR)