### PR TITLE
Transient sensitivity analysis

### DIFF
--- a/examples/fluid/example_1/example_1.cpp
+++ b/examples/fluid/example_1/example_1.cpp
@@ -960,6 +960,7 @@ public:
 
         // initialize the fluid solution
         _init_solution();
+        _sys->update();
     }
     
     // \subsection flow_analysis_class_destructor Destructor
@@ -1179,6 +1180,7 @@ public:
         // initialize the solution to zero, or to something that the
         // user may have provided
         _init_solution();
+        _sys->update();
         _sys->solution->swap(solver.solution_sensitivity());
         _init_sensitivity_solution();
         _sys->solution->swap(solver.solution_sensitivity());
@@ -1200,7 +1202,7 @@ public:
         n_steps           = _input("n_transient_steps", "number of transient time-steps", 100);
         solver.dt         = _input("dt", "time-step size",    1.e-3);
         _sys->time        = _input("t_initial", "initial time-step",    0.);
-        solver.beta       = _input("beta", "Newmark solver beta parameter ",  0.5);
+        solver.beta       = _input("beta", "Newmark solver beta parameter ",  0.7);
 
         // ask the solver to update the initial condition for d2(X)/dt2
         // This is recommended only for the initial time step, since the time
@@ -1231,6 +1233,7 @@ public:
             std::ostringstream oss;
             oss << nonlinear_sol_root << t_step;
             _sys->read_in_vector(*_sys->solution, nonlinear_sol_dir, oss.str(), true);
+            _sys->update();
             oss << "_sens_t";
             _sys->write_out_vector(/*solver.dt, _sys->time,*/ solver.solution_sensitivity(), "data", oss.str(), true);
             
@@ -1293,6 +1296,12 @@ public:
         solver.set_discipline_and_system(*_discipline, *_sys_init);
         solver.set_elem_operation_object(elem_ops);
         
+        _init_solution();
+        _sys->update();
+        _sys->solution->swap(solver.solution_sensitivity());
+        _init_sensitivity_solution();
+        _sys->solution->swap(solver.solution_sensitivity());
+
         // file to write the solution for visualization
         libMesh::ExodusII_IO exodus_writer(*_mesh);
         

--- a/src/solver/first_order_newmark_transient_solver.cpp
+++ b/src/solver/first_order_newmark_transient_solver.cpp
@@ -154,8 +154,7 @@ update_velocity(libMesh::NumericVector<Real>&       vec,
     &prev_sol = this->solution(1),
     &prev_vel = this->velocity(1);
     
-    vec.zero();
-    vec.add( 1.,      sol);
+    vec = sol;
     vec.add(-1., prev_sol);
     vec.scale(1./beta/dt);
     vec.close();
@@ -175,8 +174,7 @@ update_sensitivity_velocity(libMesh::NumericVector<Real>&       vec,
     &prev_sol = this->solution_sensitivity(1),
     &prev_vel = this->velocity_sensitivity(1);
     
-    vec.zero();
-    vec.add( 1.,      sol);
+    vec = sol;
     vec.add(-1., prev_sol);
     vec.scale(1./beta/dt);
     vec.close();
@@ -192,8 +190,8 @@ MAST::FirstOrderNewmarkTransientSolver::
 update_delta_velocity(libMesh::NumericVector<Real>&       vec,
                        const libMesh::NumericVector<Real>& sol) {
     
-    vec.zero();
-    vec.add( 1./beta/dt,      sol);
+    vec = sol;
+    vec.scale( 1./beta/dt);
     vec.close();
 }
 

--- a/src/solver/second_order_newmark_transient_solver.cpp
+++ b/src/solver/second_order_newmark_transient_solver.cpp
@@ -168,8 +168,7 @@ update_velocity(libMesh::NumericVector<Real>& vec,
     &prev_acc = this->acceleration(1);
 
     // first calculate the acceleration
-    vec.zero();
-    vec.add(                   1.,      sol);
+    vec = sol;
     vec.add(                  -1., prev_sol);
     vec.scale(gamma/beta/dt);
     vec.add(        1.-gamma/beta, prev_vel);
@@ -191,8 +190,7 @@ update_acceleration(libMesh::NumericVector<Real>& vec,
     &prev_acc = this->acceleration(1);
     
     // first calculate the acceleration
-    vec.zero();
-    vec.add(             1,       sol);
+    vec = sol;
     vec.add(            -1., prev_sol);
     vec.scale(1./beta/dt/dt);
     vec.add(    -1./beta/dt, prev_vel);
@@ -213,8 +211,7 @@ update_sensitivity_velocity(libMesh::NumericVector<Real>& vec,
     &prev_acc = this->acceleration_sensitivity(1);
     
     // first calculate the acceleration
-    vec.zero();
-    vec.add(                   1.,      sol);
+    vec = sol;
     vec.add(                  -1., prev_sol);
     vec.scale(gamma/beta/dt);
     vec.add(        1.-gamma/beta, prev_vel);
@@ -235,8 +232,7 @@ update_sensitivity_acceleration(libMesh::NumericVector<Real>& vec,
     &prev_acc = this->acceleration_sensitivity(1);
     
     // first calculate the acceleration
-    vec.zero();
-    vec.add(             1,       sol);
+    vec = sol;
     vec.add(            -1., prev_sol);
     vec.scale(1./beta/dt/dt);
     vec.add(    -1./beta/dt, prev_vel);
@@ -253,8 +249,8 @@ update_delta_velocity(libMesh::NumericVector<Real>& vec,
                       const libMesh::NumericVector<Real>& sol) {
     
     // first calculate the acceleration
-    vec.zero();
-    vec.add( gamma/beta/dt,      sol);
+    vec = sol;
+    vec.scale( gamma/beta/dt);
     vec.close();
 }
 
@@ -267,8 +263,8 @@ update_delta_acceleration(libMesh::NumericVector<Real>& vec,
                           const libMesh::NumericVector<Real>& sol) {
     
     // first calculate the acceleration
-    vec.zero();
-    vec.add(  1./beta/dt/dt,       sol);
+    vec = sol;
+    vec.scale(  1./beta/dt/dt);
     vec.close();
 }
 

--- a/src/solver/stabilized_first_order_transient_sensitivity_solver.cpp
+++ b/src/solver/stabilized_first_order_transient_sensitivity_solver.cpp
@@ -145,6 +145,7 @@ sensitivity_solve(MAST::AssemblyBase& assembly,
         std::ostringstream oss;
         oss << _sol_name_root << _index1;
         sys.read_in_vector(sol, _sol_dir, oss.str(), true);
+        sys.update();
 
         // assemble the Jacobian matrix
         _assemble_mass = false;
@@ -285,7 +286,8 @@ evaluate_q_sens_for_previous_interval(MAST::AssemblyBase& assembly,
         std::ostringstream oss;
         oss << _sol_name_root << _index1;
         sys.read_in_vector(sol, _sol_dir, oss.str(), true);
-        
+        sys.update();
+
         sys.time  = _t0 + this->dt * ( i - _index0);
         
         eta = (sys.time-_t0)/(t1-_t0);

--- a/src/solver/transient_solver_base.cpp
+++ b/src/solver/transient_solver_base.cpp
@@ -111,11 +111,11 @@ set_elem_operation_object(MAST::TransientAssemblyElemOperations &assembly_ops) {
             nm = "transient_solution_";
             nm += iter.str();
             sys.add_vector(nm, true, libMesh::GHOSTED);
-        }
 
-        nm = "transient_solution_sensitivity_";
-        nm += iter.str();
-        sys.add_vector(nm, true, libMesh::GHOSTED);
+            nm = "transient_solution_sensitivity_";
+            nm += iter.str();
+            sys.add_vector(nm, true, libMesh::GHOSTED);
+        }
 
         // add the velocity
         nm = "transient_velocity_";
@@ -226,11 +226,15 @@ MAST::TransientSolverBase::solution_sensitivity(unsigned int prev_iter) const {
     std::ostringstream oss;
     oss << prev_iter;
 
-    // get references to the solution
-    std::string
-    nm = "transient_solution_sensitivity_" + oss.str();
-    
-    return _system->system().get_vector(nm);
+    if (prev_iter) {
+        // get references to the solution
+        std::string
+        nm = "transient_solution_sensitivity_" + oss.str();
+        
+        return _system->system().get_vector(nm);
+    }
+    else
+        return _system->system().add_sensitivity_solution();
 }
 
 
@@ -407,20 +411,11 @@ solve_highest_derivative_and_advance_time_step(MAST::AssemblyBase& assembly) {
     // next, move all the solutions and velocities into older
     // time step locations
     for (unsigned int i=_n_iters_to_store-1; i>0; i--) {
-        this->solution(i).zero();
-        this->solution(i).add(1., this->solution(i-1));
-        this->solution(i).close();
+        this->solution(i) = this->solution(i-1);
+        this->velocity(i) = this->velocity(i-1);
         
-        this->velocity(i).zero();
-        this->velocity(i).add(1., this->velocity(i-1));
-        this->velocity(i).close();
-        
-        if (_ode_order > 1) {
-            
-            this->acceleration(i).zero();
-            this->acceleration(i).add(1., this->acceleration(i-1));
-            this->acceleration(i).close();
-        }
+        if (_ode_order > 1)
+            this->acceleration(i) = this->acceleration(i-1);
     }
     
     // finally, update the system time
@@ -502,20 +497,11 @@ solve_highest_derivative_and_advance_time_step_with_sensitivity(MAST::AssemblyBa
     // time step locations
     for (unsigned int i=_n_iters_to_store-1; i>0; i--) {
         
-        this->solution_sensitivity(i).zero();
-        this->solution_sensitivity(i).add(1., this->solution_sensitivity(i-1));
-        this->solution_sensitivity(i).close();
+        this->solution_sensitivity(i) = this->solution_sensitivity(i-1);
+        this->velocity_sensitivity(i) = this->velocity_sensitivity(i-1);
         
-        this->velocity_sensitivity(i).zero();
-        this->velocity_sensitivity(i).add(1., this->velocity_sensitivity(i-1));
-        this->velocity_sensitivity(i).close();
-        
-        if (_ode_order > 1) {
-            
-            this->acceleration_sensitivity(i).zero();
-            this->acceleration_sensitivity(i).add(1., this->acceleration_sensitivity(i-1));
-            this->acceleration_sensitivity(i).close();
-        }
+        if (_ode_order > 1)
+            this->acceleration_sensitivity(i) = this->acceleration_sensitivity(i-1);
     }
     
     // finally, update the system time
@@ -767,20 +753,11 @@ MAST::TransientSolverBase::advance_time_step() {
     // next, move all the solutions and velocities into older
     // time step locations
     for (unsigned int i=_n_iters_to_store-1; i>0; i--) {
-        this->solution(i).zero();
-        this->solution(i).add(1., this->solution(i-1));
-        this->solution(i).close();
+        this->solution(i) = this->solution(i-1);
+        this->velocity(i) = this->velocity(i-1);
         
-        this->velocity(i).zero();
-        this->velocity(i).add(1., this->velocity(i-1));
-        this->velocity(i).close();
-        
-        if (_ode_order > 1) {
-            
-            this->acceleration(i).zero();
-            this->acceleration(i).add(1., this->acceleration(i-1));
-            this->acceleration(i).close();
-        }
+        if (_ode_order > 1)
+            this->acceleration(i) = this->acceleration(i-1);
     }
 
     // finally, update the system time
@@ -805,20 +782,11 @@ MAST::TransientSolverBase::advance_time_step_with_sensitivity() {
     // next, move all the solutions and velocities into older
     // time step locations
     for (unsigned int i=_n_iters_to_store-1; i>0; i--) {
-        this->solution_sensitivity(i).zero();
-        this->solution_sensitivity(i).add(1., this->solution_sensitivity(i-1));
-        this->solution_sensitivity(i).close();
+        this->solution_sensitivity(i) = this->solution_sensitivity(i-1);
+        this->velocity_sensitivity(i) = this->velocity_sensitivity(i-1);
         
-        this->velocity_sensitivity(i).zero();
-        this->velocity_sensitivity(i).add(1., this->velocity_sensitivity(i-1));
-        this->velocity_sensitivity(i).close();
-        
-        if (_ode_order > 1) {
-            
-            this->acceleration_sensitivity(i).zero();
-            this->acceleration_sensitivity(i).add(1., this->acceleration_sensitivity(i-1));
-            this->acceleration_sensitivity(i).close();
-        }
+        if (_ode_order > 1)
+            this->acceleration_sensitivity(i) = this->acceleration_sensitivity(i-1);
     }
     
     // finally, update the system time


### PR DESCRIPTION
-- Fixes for transient sensitivity analysis due to mixing of parallel and ghosted vectors of the time-integration schemes. 
-- Fixes for sensitivity analysis in fluid example 1. 