### PR TITLE
Add plane strain support to 2D materials and move kappa from material card to section card

### DIFF
--- a/ci/build_mast.sh
+++ b/ci/build_mast.sh
@@ -51,7 +51,7 @@ if [ "${TRAVIS_OS_NAME}" = linux ]; then # Ubuntu Linux
       else
         make -j 2 || exit
         cd "${DBG_BUILD_DIR}/tests" || exit
-        ctest --force-new-ctest-process --output-on-failure || exit
+        ctest --force-new-ctest-process --output-on-failure --timeout 10
       fi
 
     fi # No Debug build for libMesh < 1.5.0
@@ -86,7 +86,7 @@ if [ "${TRAVIS_OS_NAME}" = linux ]; then # Ubuntu Linux
       make -j 2 || exit
       make install || exit
       cd "${REL_BUILD_DIR}/tests" || exit
-      ctest --force-new-ctest-process --output-on-failure || exit
+      ctest --force-new-ctest-process --output-on-failure --timeout 10
     fi
 
   # elif [ "${TRAVIS_DIST}" = bionic ]; then # Ubuntu 18.04 Bionic Beaver
@@ -142,7 +142,7 @@ elif [ "${TRAVIS_OS_NAME}" = osx ]; then # macOS 10.14, XCode 10.2
 
   make -j 2 || exit
   cd "${DBG_BUILD_DIR}/tests" || exit
-  ctest --force-new-ctest-process --output-on-failure || exit
+  ctest --force-new-ctest-process --output-on-failure --timeout 10
 
   # Now build/install a Release (optimized) version of MAST (-DCMAKE_BUILD_TYPE=Release).
   echo "TEST RELEASE/OPTIMIZED BUILD..."
@@ -176,7 +176,7 @@ elif [ "${TRAVIS_OS_NAME}" = osx ]; then # macOS 10.14, XCode 10.2
   make install || exit
 
   cd "${REL_BUILD_DIR}/tests" || exit
-  ctest --force-new-ctest-process --output-on-failure || exit
+  ctest --force-new-ctest-process --output-on-failure --timeout 10
 
 else
   echo "INVALID OS: ${TRAVIS_OS_NAME}"

--- a/examples/fsi/example_1/example_1.cpp
+++ b/examples/fsi/example_1/example_1.cpp
@@ -317,7 +317,8 @@ int main(int argc, char* argv[]) {
     rho        ("rho", input("str_rho",  "structural material density",         2.7e3)),
     E          ("E",   input("str_E",    "structural material Young's modulus", 72.e9)),
     nu         ("nu",  input("str_nu",   "structural material Poisson's ratio",  0.33)),
-    kappa      ("kappa", 5./6.),
+    kappa_yy   ("kappa_yy", 5./6.),
+    kappa_zz   ("kappa_zz", 5./6.),
     zero       ("zero", 0.);
     
     MAST::ConstantFieldFunction
@@ -326,7 +327,8 @@ int main(int argc, char* argv[]) {
     rho_f      ("rho", rho),
     E_f        ("E", E),
     nu_f       ("nu", nu),
-    kappa_f    ("kappa", kappa),
+    kappa_yy_f ("Kappayy", kappa_yy),
+    kappa_zz_f ("Kappazz", kappa_zz),
     hyoff_f    ("hy_off", zero),
     hzoff_f    ("hz_off", zero);
     
@@ -335,7 +337,6 @@ int main(int argc, char* argv[]) {
     m_card.add(rho_f);
     m_card.add(E_f);
     m_card.add(nu_f);
-    m_card.add(kappa_f);
     
     MAST::Solid1DSectionElementPropertyCard
     p_card;
@@ -350,6 +351,8 @@ int main(int argc, char* argv[]) {
     p_card.add(thz_f);
     p_card.add(hyoff_f);
     p_card.add(hzoff_f);
+    p_card.add(kappa_yy_f);
+    p_card.add(kappa_zz_f);
     
     // tell the section property about the material property
     p_card.set_material(m_card);

--- a/examples/structural/example_1/example_1.cpp
+++ b/examples/structural/example_1/example_1.cpp
@@ -103,6 +103,8 @@ int main(int argc, const char** argv)
     MAST::Parameter nu("nu", 0.33);
     MAST::Parameter zero("zero", 0.0);
     MAST::Parameter pressure("p", 2.0e4);
+    MAST::Parameter kappa_yy("kappa_yy", 5./6.);
+    MAST::Parameter kappa_zz("kappa_zz", 5./6.);
 
     // Create ConstantFieldFunctions used to spread parameters throughout the model.
     MAST::ConstantFieldFunction thy_f("hy", thickness_y);
@@ -112,6 +114,8 @@ int main(int argc, const char** argv)
     MAST::ConstantFieldFunction hyoff_f("hy_off", zero);
     MAST::ConstantFieldFunction hzoff_f("hz_off", zero);
     MAST::ConstantFieldFunction pressure_f("pressure", pressure);
+    MAST::ConstantFieldFunction kappa_yy_f("Kappayy", kappa_yy);
+    MAST::ConstantFieldFunction kappa_zz_f("Kappazz", kappa_zz);
 
     // Initialize load.
     // TODO - Switch this to a concentrated/point load on the right end of the bar.
@@ -131,6 +135,8 @@ int main(int argc, const char** argv)
     section.add(thz_f);
     section.add(hyoff_f);
     section.add(hzoff_f);
+    section.add(kappa_yy_f);
+    section.add(kappa_zz_f);
 
     // Specify a section orientation point and add it to the section.
     RealVectorX orientation = RealVectorX::Zero(3);

--- a/examples/structural/example_2/example_2.cpp
+++ b/examples/structural/example_2/example_2.cpp
@@ -258,7 +258,6 @@ int main(int argc, char* argv[])
     MAST::IsotropicMaterialPropertyCard material;
     material.add(E_f);
     material.add(nu_f);
-    material.add(kappa_f);
     material.add(alpha_f);
     material.add(rho_f);
 
@@ -266,6 +265,7 @@ int main(int argc, char* argv[])
     MAST::Solid2DSectionElementPropertyCard section;
     section.add(th_f);
     section.add(off_f);
+    section.add(kappa_f);
     section.set_strain(MAST::NONLINEAR_STRAIN);
 
     // Attach material to the card.

--- a/examples/structural/example_3/example_3.cpp
+++ b/examples/structural/example_3/example_3.cpp
@@ -206,7 +206,6 @@ int main(int argc, const char** argv)
     MAST::IsotropicMaterialPropertyCard material;
     material.add(E_f);
     material.add(nu_f);
-    material.add(kappa_f);
     material.add(alpha_f);
     material.add(rho_f);
     
@@ -214,6 +213,7 @@ int main(int argc, const char** argv)
     MAST::Solid2DSectionElementPropertyCard section;
     section.add(th_f);
     section.add(off_f);
+    section.add(kappa_f);
     section.set_strain(MAST::NONLINEAR_STRAIN);
     
     // Attach material to the card.

--- a/examples/structural/example_4/example_4.cpp
+++ b/examples/structural/example_4/example_4.cpp
@@ -323,7 +323,6 @@ int main(int argc, const char** argv)
     MAST::IsotropicMaterialPropertyCard material;
     material.add(E_f);
     material.add(nu_f);
-    material.add(kappa_f);
     material.add(alpha_f);
     material.add(rho_f);
     
@@ -331,6 +330,7 @@ int main(int argc, const char** argv)
     MAST::Solid2DSectionElementPropertyCard section;
     section.add(th_f);
     section.add(off_f);
+    section.add(kappa_f);
     
     // Attach material to the card.
     section.set_material(material);

--- a/examples/structural/example_5/example_5.cpp
+++ b/examples/structural/example_5/example_5.cpp
@@ -328,7 +328,6 @@ public:
         Eval      = _input("E", "modulus of elasticity", 72.e9),
         rhoval    = _input("rho", "material density", 2700.),
         nu_val    = _input("nu", "Poisson's ratio",  0.33),
-        kappa_val = _input("kappa", "shear correction factor",  5./6.),
         kval      = _input("k", "thermal conductivity",  1.e-2),
         cpval     = _input("cp", "thermal capacitance",  864.);
         
@@ -338,7 +337,6 @@ public:
         *E_v       = new MAST::Parameter("E_v",          0.),
         *rho       = new MAST::Parameter("rho",      rhoval),
         *nu        = new MAST::Parameter("nu",       nu_val),
-        *kappa     = new MAST::Parameter("kappa", kappa_val),
         *k         = new MAST::Parameter("k",          kval),
         *cp        = new MAST::Parameter("cp",        cpval);
         
@@ -347,7 +345,6 @@ public:
         *E_v_f   = new MAST::ConstantFieldFunction(    "E",    *E_v),
         *rho_f   = new MAST::ConstantFieldFunction(  "rho",    *rho),
         *nu_f    = new MAST::ConstantFieldFunction(   "nu",     *nu),
-        *kappa_f = new MAST::ConstantFieldFunction("kappa",  *kappa),
         *k_f     = new MAST::ConstantFieldFunction( "k_th",      *k),
         *cp_f    = new MAST::ConstantFieldFunction(   "cp",     *cp);
         
@@ -355,14 +352,12 @@ public:
         _parameters[  E_v->name()]     = E_v;
         _parameters[  rho->name()]     = rho;
         _parameters[   nu->name()]     = nu;
-        _parameters[kappa->name()]     = kappa;
         _parameters[    k->name()]     = k;
         _parameters[   cp->name()]     = cp;
         _field_functions.insert(E_f);
         _field_functions.insert(E_v_f);
         _field_functions.insert(rho_f);
         _field_functions.insert(nu_f);
-        _field_functions.insert(kappa_f);
         _field_functions.insert(k_f);
         _field_functions.insert(cp_f);
 
@@ -371,7 +366,6 @@ public:
         _m_card1->add(*E_f);
         _m_card1->add(*rho_f);
         _m_card1->add(*nu_f);
-        _m_card1->add(*kappa_f);
         _m_card1->add(*k_f);
         _m_card1->add(*cp_f);
         
@@ -379,7 +373,6 @@ public:
         _m_card2->add(*E_v_f);
         _m_card2->add(*rho_f);
         _m_card2->add(*nu_f);
-        _m_card2->add(*kappa_f);
         _m_card2->add(*k_f);
         _m_card2->add(*cp_f);
     }
@@ -394,20 +387,25 @@ public:
         
         
         Real
+        kappa_val = _input("kappa", "shear correction factor",  5./6.),
         th_v      =  _input("th", "thickness of 2D element",  0.001);
         
         MAST::Parameter
         *th       = new MAST::Parameter("th", th_v),
+        *kappa    = new MAST::Parameter("kappa", kappa_val),
         *zero     = new MAST::Parameter("zero", 0.);
         
         MAST::ConstantFieldFunction
         *th_f     = new MAST::ConstantFieldFunction("h",       *th),
+        *kappa_f  = new MAST::ConstantFieldFunction("kappa",  *kappa),
         *hoff_f   = new MAST::ConstantFieldFunction("off",   *zero);
         
         
         _parameters[th->name()]    = th;
+        _parameters[kappa->name()] = kappa;
         _parameters[zero->name()]  = zero;
         _field_functions.insert(th_f);
+        _field_functions.insert(kappa_f);
         _field_functions.insert(hoff_f);
         
         MAST::Solid2DSectionElementPropertyCard
@@ -424,11 +422,13 @@ public:
         _p_card2->set_strain(MAST::LINEAR_STRAIN);
 
         p_card1->add(*th_f);
+        p_card1->add(*kappa_f);
         p_card1->add(*hoff_f);
         p_card1->set_material(*_m_card1);
 
         // property card for void
         p_card2->add(*th_f);
+        p_card2->add(*kappa_f);
         p_card2->add(*hoff_f);
         p_card2->set_material(*_m_card2);
         

--- a/examples/structural/example_6/example_6.cpp
+++ b/examples/structural/example_6/example_6.cpp
@@ -298,7 +298,6 @@ public:
         penalty   = _input("rho_penalty", "SIMP modulus of elasticity penalty", 4.),
         rhoval    = _input("rho", "material density", 2700.),
         nu_val    = _input("nu", "Poisson's ratio",  0.33),
-        kappa_val = _input("kappa", "shear correction factor",  5./6.),
         kval      = _input("k", "thermal conductivity",  1.e-2),
         cpval     = _input("cp", "thermal capacitance",  864.);
         
@@ -306,14 +305,12 @@ public:
         MAST::Parameter
         *rho       = new MAST::Parameter("rho",      rhoval),
         *nu        = new MAST::Parameter("nu",       nu_val),
-        *kappa     = new MAST::Parameter("kappa", kappa_val),
         *k         = new MAST::Parameter("k",          kval),
         *cp        = new MAST::Parameter("cp",        cpval);
         
         MAST::ConstantFieldFunction
         *rho_f   = new MAST::ConstantFieldFunction(  "rho",    *rho),
         *nu_f    = new MAST::ConstantFieldFunction(   "nu",     *nu),
-        *kappa_f = new MAST::ConstantFieldFunction("kappa",  *kappa),
         *k_f     = new MAST::ConstantFieldFunction( "k_th",      *k),
         *cp_f    = new MAST::ConstantFieldFunction(   "cp",     *cp);
 
@@ -323,13 +320,11 @@ public:
         
         _parameters[  rho->name()]     = rho;
         _parameters[   nu->name()]     = nu;
-        _parameters[kappa->name()]     = kappa;
         _parameters[    k->name()]     = k;
         _parameters[   cp->name()]     = cp;
         _field_functions.insert(_Ef);
         _field_functions.insert(rho_f);
         _field_functions.insert(nu_f);
-        _field_functions.insert(kappa_f);
         _field_functions.insert(k_f);
         _field_functions.insert(cp_f);
 
@@ -337,7 +332,6 @@ public:
         _m_card->add(*_Ef);
         _m_card->add(*rho_f);
         _m_card->add(*nu_f);
-        _m_card->add(*kappa_f);
         _m_card->add(*k_f);
         _m_card->add(*cp_f);
     }
@@ -352,20 +346,25 @@ public:
         
         
         Real
+        kappa_val = _input("kappa", "shear correction factor",  5./6.),
         th_v      =  _input("th", "thickness of 2D element",  0.001);
         
         MAST::Parameter
         *th       = new MAST::Parameter("th", th_v),
+        *kappa    = new MAST::Parameter("kappa", kappa_val),
         *zero     = new MAST::Parameter("zero", 0.);
         
         MAST::ConstantFieldFunction
         *th_f     = new MAST::ConstantFieldFunction("h",       *th),
+        *kappa_f  = new MAST::ConstantFieldFunction("kappa",  *kappa),
         *hoff_f   = new MAST::ConstantFieldFunction("off",   *zero);
         
         
         _parameters[th->name()]    = th;
+        _parameters[kappa->name()] = kappa;
         _parameters[zero->name()]  = zero;
         _field_functions.insert(th_f);
+        _field_functions.insert(kappa_f);
         _field_functions.insert(hoff_f);
         
         MAST::Solid2DSectionElementPropertyCard
@@ -379,6 +378,7 @@ public:
         if (nonlinear) p_card->set_strain(MAST::NONLINEAR_STRAIN);
         
         p_card->add(*th_f);
+        p_card->add(*kappa_f);
         p_card->add(*hoff_f);
         p_card->set_material(*_m_card);
         _discipline->set_property_for_subdomain(0, *p_card);

--- a/examples/structural/example_7/example_7.cpp
+++ b/examples/structural/example_7/example_7.cpp
@@ -163,6 +163,8 @@ int main(int argc, const char** argv) {
     MAST::Parameter E("E", 18.5e6); // lbf/in^2
     MAST::Parameter nu("nu", 0.3); // no unit
     MAST::Parameter rho("rho", 0.000142); // lbf*s^2/in^4 (0.055 lb/in^3 * 0.00259)
+    MAST::Parameter kappa_yy("kappa_yy", 5./6.); // shear coefficient yy
+    MAST::Parameter kappa_zz("kappa_zz", 5./6.); // shear coefficient zz
     MAST::Parameter zero("zero", 0.0);
 
     // Create ConstantFieldFunctions used to spread parameters throughout the model.
@@ -173,6 +175,8 @@ int main(int argc, const char** argv) {
     MAST::ConstantFieldFunction rho_f("rho", rho);
     MAST::ConstantFieldFunction hyoff_f("hy_off", zero);
     MAST::ConstantFieldFunction hzoff_f("hz_off", zero);
+    MAST::ConstantFieldFunction kappa_yy_f("Kappayy", kappa_yy);
+    MAST::ConstantFieldFunction kappa_zz_f("Kappazz", kappa_zz);
 
     // Create the material property card ("card" is NASTRAN lingo) and add the relevant field
     // functions to it. An isotropic material in dynamics needs elastic modulus (E),
@@ -191,6 +195,8 @@ int main(int argc, const char** argv) {
     section.add(thz_f);
     section.add(hyoff_f);
     section.add(hzoff_f);
+    section.add(kappa_yy_f);
+    section.add(kappa_zz_f);
 
     // Specify a section orientation point and add it to the section.
     //  -- Currently this orientation is arbitrary and we assume all beam sections are oriented

--- a/examples/structural/example_8/example_8.cpp
+++ b/examples/structural/example_8/example_8.cpp
@@ -373,7 +373,6 @@ public:
         penalty   = _input("rho_penalty", "penalty parameter of volume fraction", 4.),
         rhoval    = _input("rho", "material density", 2700.),
         nu_val    = _input("nu", "Poisson's ratio",  0.33),
-        kappa_val = _input("kappa", "shear correction factor",  5./6.),
         kval      = _input("k", "thermal conductivity",  1.e-2),
         cpval     = _input("cp", "thermal capacitance",  864.);
         
@@ -381,14 +380,12 @@ public:
         MAST::Parameter
         *rho       = new MAST::Parameter("rho",      rhoval),
         *nu        = new MAST::Parameter("nu",       nu_val),
-        *kappa     = new MAST::Parameter("kappa", kappa_val),
         *k         = new MAST::Parameter("k",          kval),
         *cp        = new MAST::Parameter("cp",        cpval);
         
         MAST::ConstantFieldFunction
         *rho_f   = new MAST::ConstantFieldFunction(  "rho",    *rho),
         *nu_f    = new MAST::ConstantFieldFunction(   "nu",     *nu),
-        *kappa_f = new MAST::ConstantFieldFunction("kappa",  *kappa),
         *k_f     = new MAST::ConstantFieldFunction( "k_th",      *k),
         *cp_f    = new MAST::ConstantFieldFunction(   "cp",     *cp);
 
@@ -396,13 +393,11 @@ public:
 
         _parameters[  rho->name()]     = rho;
         _parameters[   nu->name()]     = nu;
-        _parameters[kappa->name()]     = kappa;
         _parameters[    k->name()]     = k;
         _parameters[   cp->name()]     = cp;
         _field_functions.insert(_Ef);
         _field_functions.insert(rho_f);
         _field_functions.insert(nu_f);
-        _field_functions.insert(kappa_f);
         _field_functions.insert(k_f);
         _field_functions.insert(cp_f);
 
@@ -411,7 +406,6 @@ public:
         _m_card1->add(*_Ef);
         _m_card1->add(*rho_f);
         _m_card1->add(*nu_f);
-        _m_card1->add(*kappa_f);
         _m_card1->add(*k_f);
         _m_card1->add(*cp_f);
         
@@ -419,7 +413,6 @@ public:
         _m_card2->add(*_Ef);
         _m_card2->add(*rho_f);
         _m_card2->add(*nu_f);
-        _m_card2->add(*kappa_f);
         _m_card2->add(*k_f);
         _m_card2->add(*cp_f);
     }
@@ -434,20 +427,25 @@ public:
         
         
         Real
+        kappa_val = _input("kappa", "shear correction factor",  5./6.),
         th_v      =  _input("th", "thickness of 2D element",  0.001);
         
         MAST::Parameter
         *th       = new MAST::Parameter("th", th_v),
+        *kappa    = new MAST::Parameter("kappa", kappa_val),
         *zero     = new MAST::Parameter("zero", 0.);
         
         MAST::ConstantFieldFunction
         *th_f     = new MAST::ConstantFieldFunction("h",       *th),
+        *kappa_f = new MAST::ConstantFieldFunction("kappa",  *kappa),
         *hoff_f   = new MAST::ConstantFieldFunction("off",   *zero);
         
         
         _parameters[th->name()]    = th;
+        _parameters[kappa->name()] = kappa;
         _parameters[zero->name()]  = zero;
         _field_functions.insert(th_f);
+        _field_functions.insert(kappa_f);
         _field_functions.insert(hoff_f);
         
         MAST::Solid2DSectionElementPropertyCard
@@ -465,11 +463,13 @@ public:
 
         p_card1->add(*th_f);
         p_card1->add(*hoff_f);
+        p_card1->add(*kappa_f);
         p_card1->set_material(*_m_card1);
 
         // property card for void
         p_card2->add(*th_f);
         p_card2->add(*hoff_f);
+        p_card2->add(*kappa_f);
         p_card2->set_material(*_m_card2);
         
         _discipline->set_property_for_subdomain(0, *p_card1);

--- a/src/property_cards/element_property_card_base.h
+++ b/src/property_cards/element_property_card_base.h
@@ -176,6 +176,11 @@ namespace MAST
         }
         
         
+        virtual bool get_warping_only() const
+        {
+            return _warping_only;
+        }
+        
     protected:
         
         /*!
@@ -187,6 +192,8 @@ namespace MAST
          *    flag to use a diagonal mass matrix. By default, this is false
          */
         bool _diagonal_mass;
+        
+        bool _warping_only = false;
     };
     
 }

--- a/src/property_cards/solid_1d_section_element_property_card.cpp
+++ b/src/property_cards/solid_1d_section_element_property_card.cpp
@@ -546,9 +546,7 @@ namespace MAST {
                 _A(p, t, A);
                 _Kappa(p, t, Kappa);
                 _material_stiffness(p, t, m);
-                libMesh::out << "G =\n" << m << std::endl;
-                libMesh::out << "A = " << A << std::endl;
-                libMesh::out << "K =\n" << Kappa << std::endl;
+
                 m *= A;
                 
                 m(0,0) *= Kappa(0,0);

--- a/src/property_cards/solid_1d_section_element_property_card.cpp
+++ b/src/property_cards/solid_1d_section_element_property_card.cpp
@@ -371,6 +371,78 @@ namespace MAST {
         };
         
         
+        class WarpingConstant: public MAST::FieldFunction<Real> 
+        {
+        public:
+            WarpingConstant():
+            MAST::FieldFunction<Real>("WarpingConstant")
+            {
+            }
+            
+            virtual ~WarpingConstant()
+            {
+            }
+            
+            virtual void operator() (const libMesh::Point& p,
+                                     const Real t,
+                                     Real& m) const
+            {
+                m = 0.0;
+            }
+            
+            virtual void derivative (const MAST::FunctionBase& f,
+                                     const libMesh::Point& p,
+                                     const Real t,
+                                     Real& m) const
+            {
+                m = 0.0;
+            }
+        };
+        
+        
+        class ShearCoefficientMatrix: public MAST::FieldFunction<RealMatrixX> {
+        public:
+            ShearCoefficientMatrix(const MAST::FieldFunction<Real>& Kzz, 
+                                   const MAST::FieldFunction<Real>& Kyy):
+            MAST::FieldFunction<RealMatrixX>("ShearCoefficientMatrix"), 
+            _Kzz(Kzz),
+            _Kyy(Kyy)
+            {
+                _functions.insert(&Kzz);
+                _functions.insert(&Kyy);
+            }
+            
+            virtual ~ShearCoefficientMatrix() { }
+            
+            virtual void operator() (const libMesh::Point& p,
+                                     const Real t,
+                                     RealMatrixX& m) const {
+                Real Kzz;
+                Real Kyy;
+                _Kzz(p, t, Kzz);
+                _Kyy(p, t, Kyy);
+                m = RealMatrixX::Zero(2,2);
+                m(0,0) = Kzz;
+                m(1,1) = Kyy;
+            }
+            
+            virtual void derivative (const MAST::FunctionBase& f,
+                                     const libMesh::Point& p,
+                                     const Real t,
+                                     RealMatrixX& m) const {
+                Real dKzz, dKyy;
+                _Kyy.derivative(f, p, t, dKyy);
+                _Kzz.derivative(f, p, t, dKzz);
+                m = RealMatrixX::Zero(2,2);
+                m(0,0) = dKzz;
+                m(1,1) = dKyy;
+            }
+        protected:
+            const MAST::FieldFunction<Real>& _Kyy;
+            const MAST::FieldFunction<Real>& _Kzz;
+        };
+        
+        
         class ExtensionStiffnessMatrix: public MAST::FieldFunction<RealMatrixX> {
         public:
             ExtensionStiffnessMatrix(const MAST::FieldFunction<RealMatrixX>& mat,
@@ -452,12 +524,16 @@ namespace MAST {
         class TransverseStiffnessMatrix: public MAST::FieldFunction<RealMatrixX> {
         public:
             TransverseStiffnessMatrix(const MAST::FieldFunction<RealMatrixX>& mat,
-                                      const MAST::FieldFunction<Real>&  A):
+                                      const MAST::FieldFunction<Real>&  A,
+                                      const MAST::FieldFunction<RealMatrixX>& Kappa):
             MAST::FieldFunction<RealMatrixX>("TransverseStiffnessMatrix1D"),
             _material_stiffness(mat),
-            _A(A) {
+            _A(A),
+            _Kappa(Kappa)
+            {
                 _functions.insert(&mat);
                 _functions.insert(&A);
+                _functions.insert(&Kappa);
             }
             
             virtual ~TransverseStiffnessMatrix() { }
@@ -466,28 +542,48 @@ namespace MAST {
                                      const Real t,
                                      RealMatrixX& m) const {
                 Real A;
+                RealMatrixX Kappa;
                 _A(p, t, A);
+                _Kappa(p, t, Kappa);
                 _material_stiffness(p, t, m);
+                libMesh::out << "G =\n" << m << std::endl;
+                libMesh::out << "A = " << A << std::endl;
+                libMesh::out << "K =\n" << Kappa << std::endl;
                 m *= A;
+                
+                m(0,0) *= Kappa(0,0);
+                m(1,1) *= Kappa(1,1);
+                m(0,1) *= Kappa(0,1);
+                m(1,0) *= Kappa(1,0);
+                
+                /**
+                 * m = [G*kappa*A,          0,
+                 *              0,   G*kappa*A]
+                 */
             }
             
             virtual void derivative (    const MAST::FunctionBase& f,
                                      const libMesh::Point& p,
                                      const Real t,
                                      RealMatrixX& m) const {
-                RealMatrixX dm;
+                RealMatrixX G, dG, dm, Kappa, dKappa;
                 Real A, dA;
                 _A                  (p, t, A);                  _A.derivative( f, p, t, dA);
-                _material_stiffness (p, t, m); _material_stiffness.derivative( f, p, t, dm);
+                _material_stiffness (p, t, G); _material_stiffness.derivative( f, p, t, dG);
+                _Kappa              (p, t, Kappa);
+                _Kappa.derivative(f, p, t, dKappa);
                 
-                m *= dA;
-                m += A*dm;
+                m(0,0) = (dG(0,0) * Kappa(0,0) * A) + (G(0,0) * dKappa(0,0) * A) + (G(0,0) * Kappa(0,0) * dA);
+                m(1,1) = (dG(1,1) * Kappa(1,1) * A) + (G(1,1) * dKappa(1,1) * A) + (G(1,1) * Kappa(1,1) * dA);
+                m(0,1) = (dG(0,1) * Kappa(0,1) * A) + (G(0,1) * dKappa(0,1) * A) + (G(0,1) * Kappa(0,1) * dA);
+                m(1,0) = (dG(1,0) * Kappa(1,0) * A) + (G(1,0) * dKappa(1,0) * A) + (G(1,0) * Kappa(1,0) * dA);
             }
             
         protected:
             
             const MAST::FieldFunction<RealMatrixX>& _material_stiffness;
             const MAST::FieldFunction<Real>& _A;
+            const MAST::FieldFunction<RealMatrixX>& _Kappa;
         };
         
         
@@ -699,6 +795,9 @@ namespace MAST {
             
             const MAST::FieldFunction<Real>&  _h;
         };
+        
+        
+        
     }
     
     
@@ -1439,6 +1538,20 @@ MAST::Solid1DSectionElementPropertyCard::I() const {
 }
 
 
+const MAST::FieldFunction<RealMatrixX>&
+MAST::Solid1DSectionElementPropertyCard::Kap() const {
+    
+    libmesh_assert(_initialized);
+    return *_Kappa;
+}
+
+
+const MAST::FieldFunction<Real>&
+MAST::Solid1DSectionElementPropertyCard::Gam() const {
+    
+    libmesh_assert(_initialized);
+    return *_Gamma;
+}
 
 
 MAST::FieldFunction<Real>&
@@ -1490,7 +1603,20 @@ MAST::Solid1DSectionElementPropertyCard::I() {
 }
 
 
+MAST::FieldFunction<RealMatrixX>&
+MAST::Solid1DSectionElementPropertyCard::Kap() {
+    
+    libmesh_assert(_initialized);
+    return *_Kappa;
+}
 
+
+MAST::FieldFunction<Real>&
+MAST::Solid1DSectionElementPropertyCard::Gam() {
+    
+    libmesh_assert(_initialized);
+    return *_Gamma;
+}
 
 
 void
@@ -1504,6 +1630,8 @@ MAST::Solid1DSectionElementPropertyCard::clear() {
     _J.reset();
     _Ip.reset();
     _AI.reset();
+    _Gamma.reset();
+    _Kappa.reset();
     
     _initialized = false;
 }
@@ -1516,10 +1644,12 @@ MAST::Solid1DSectionElementPropertyCard::init() {
     libmesh_assert(!_initialized);
     
     MAST::FieldFunction<Real>
-    &hy     =  this->get<MAST::FieldFunction<Real> >("hy"),
-    &hz     =  this->get<MAST::FieldFunction<Real> >("hz"),
-    &hy_off =  this->get<MAST::FieldFunction<Real> >("hy_off"),
-    &hz_off =  this->get<MAST::FieldFunction<Real> >("hz_off");
+    &hy         =  this->get<MAST::FieldFunction<Real> >("hy"),
+    &hz         =  this->get<MAST::FieldFunction<Real> >("hz"),
+    &Kappazz    =  this->get<MAST::FieldFunction<Real> >("Kappazz"),
+    &Kappayy    =  this->get<MAST::FieldFunction<Real> >("Kappayy"),
+    &hy_off     =  this->get<MAST::FieldFunction<Real> >("hy_off"),
+    &hz_off     =  this->get<MAST::FieldFunction<Real> >("hz_off");
     
     _A.reset(new MAST::Solid1DSectionProperty::Area(hy,
                                                     hz));
@@ -1539,6 +1669,10 @@ MAST::Solid1DSectionElementPropertyCard::init() {
                                                                   hz,
                                                                   hy_off,
                                                                   hz_off));
+    
+    _Kappa.reset(new MAST::Solid1DSectionProperty::ShearCoefficientMatrix(Kappazz, Kappayy));
+    
+    _Gamma.reset(new MAST::Solid1DSectionProperty::WarpingConstant());
     
     _initialized = true;
 }
@@ -1669,7 +1803,7 @@ transverse_shear_stiffness_matrix(const MAST::ElementBase& e) const {
     MAST::FieldFunction<RealMatrixX>* rval =
     new MAST::Solid1DSectionProperty::TransverseStiffnessMatrix
     (_material->transverse_shear_stiffness_matrix(),
-     *_A);
+     *_A, *_Kappa);
     
     return std::unique_ptr<MAST::FieldFunction<RealMatrixX> > (rval);
 }

--- a/src/property_cards/solid_1d_section_element_property_card.h
+++ b/src/property_cards/solid_1d_section_element_property_card.h
@@ -179,6 +179,33 @@ namespace MAST {
          *   section area moment of inertia
          */
         virtual MAST::FieldFunction<RealMatrixX>& I();
+        
+        /*!
+         *   @returns constant reference to the function that calculates the 
+         *   shear coeffcients (kappa)
+         */
+        virtual const MAST::FieldFunction<RealMatrixX>& Kap() const;
+        
+        
+        /*!
+         *   @returns constant reference to the function that calculates the 
+         *   warping constant
+         */
+        virtual const MAST::FieldFunction<Real>& Gam() const;
+        
+        
+        /*!
+         *   @returns reference to the function that calculates the 
+         *   shear coeffcients (kappa)
+         */
+        virtual MAST::FieldFunction<RealMatrixX>& Kap();
+        
+        
+        /*!
+         *   @returns reference to the function that calculates the 
+         *   warping constant
+         */
+        virtual MAST::FieldFunction<Real>& Gam();
 
         /*!
          *  returns true if the property card depends on the function \p f
@@ -210,6 +237,10 @@ namespace MAST {
         std::unique_ptr<MAST::FieldFunction<Real> > _Az;
         
         std::unique_ptr<MAST::FieldFunction<RealMatrixX> > _AI;
+        
+        std::unique_ptr<MAST::FieldFunction<RealMatrixX> > _Kappa;
+        
+        std::unique_ptr<MAST::FieldFunction<Real> > _Gamma;
         
         std::unique_ptr<MAST::FieldFunction<RealMatrixX> > _stiff_A;
 

--- a/src/property_cards/solid_2d_section_element_property_card.h
+++ b/src/property_cards/solid_2d_section_element_property_card.h
@@ -88,27 +88,48 @@ namespace MAST {
         
         virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
         stiffness_A_matrix(const MAST::ElementBase& e) const;
+
+        virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+        stiffness_A_matrix() const;
         
         virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
         stiffness_B_matrix(const MAST::ElementBase& e) const;
+
+	virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+        stiffness_B_matrix() const;
         
         virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
         stiffness_D_matrix(const MAST::ElementBase& e) const;
+
+	virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+        stiffness_D_matrix() const;
         
         virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
         damping_matrix(const MAST::ElementBase& e) const;
         
         virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
         inertia_matrix(const MAST::ElementBase& e) const;
+
+	virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+        inertia_matrix() const;
         
         virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
         thermal_expansion_A_matrix(const MAST::ElementBase& e) const;
+
+        virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+        thermal_expansion_A_matrix() const;
         
         virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
         thermal_expansion_B_matrix(const MAST::ElementBase& e) const;
+
+        virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+        thermal_expansion_B_matrix() const;
         
         virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
         transverse_shear_stiffness_matrix(const MAST::ElementBase& e) const;
+
+	virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+        transverse_shear_stiffness_matrix() const;
         
         virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
         prestress_A_matrix( MAST::ElementBase& e) const;
@@ -120,12 +141,27 @@ namespace MAST {
         virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
         thermal_conductance_matrix(const MAST::ElementBase& e) const;
         
+        virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+        thermal_conductance_matrix() const;
         
         virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
         thermal_capacitance_matrix(const MAST::ElementBase& e) const;
+
+        virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
+        thermal_capacitance_matrix() const;
         
         virtual const MAST::FieldFunction<Real>&
         section(const MAST::ElementBase& e) const;
+        
+        void set_warping_only(const bool warping_only)
+        {
+            _warping_only = warping_only;
+        }
+        
+        virtual bool get_warping_only() const 
+        {
+            return _warping_only;
+        }
 
     protected:
         
@@ -133,6 +169,7 @@ namespace MAST {
          *   material property card
          */
         MAST::MaterialPropertyCardBase *_material;
+
     };
     
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ target_link_libraries(mast_catch_tests mast)
 
 add_subdirectory(base)
 #add_subdirectory(boundary_condition)
-#add_subdirectory(material)
+add_subdirectory(material)
 #add_subdirectory(property)
 #add_subdirectory(element)
 

--- a/tests/base/CMakeLists.txt
+++ b/tests/base/CMakeLists.txt
@@ -11,28 +11,28 @@ target_sources(mast_catch_tests
         
 # libMesh mesh generation test
 add_test(NAME libMesh_Mesh_Generation_1d
-    COMMAND $<TARGET_FILE:mast_catch_tests> "libmesh_mesh_generation_1d")
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "libmesh_mesh_generation_1d")
 set_tests_properties(libMesh_Mesh_Generation_1d
     PROPERTIES
         LABELS "SEQ"
         FIXTURES_SETUP libMesh_Mesh_Generation_1d)
         
 add_test(NAME libMesh_Mesh_Generation_1d_mpi
-    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> "libmesh_mesh_generation_1d")
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "libmesh_mesh_generation_1d")
 set_tests_properties(libMesh_Mesh_Generation_1d_mpi
     PROPERTIES
         LABELS "MPI"
         FIXTURES_SETUP libMesh_Mesh_Generation_1d_mpi)
 
 add_test(NAME libMesh_Mesh_Generation_2d
-    COMMAND $<TARGET_FILE:mast_catch_tests> "libmesh_mesh_generation_2d")
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "libmesh_mesh_generation_2d")
 set_tests_properties(libMesh_Mesh_Generation_2d
     PROPERTIES
         LABELS "SEQ"
         FIXTURES_SETUP libMesh_Mesh_Generation_2d)
         
 add_test(NAME libMesh_Mesh_Generation_2d_mpi
-    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> "libmesh_mesh_generation_2d")
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "libmesh_mesh_generation_2d")
 set_tests_properties(libMesh_Mesh_Generation_2d_mpi
     PROPERTIES
         LABELS "MPI"
@@ -40,14 +40,14 @@ set_tests_properties(libMesh_Mesh_Generation_2d_mpi
 
 # Parameter tests
 add_test(NAME Parameter
-    COMMAND $<TARGET_FILE:mast_catch_tests> parameters)
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests parameters)
 set_tests_properties(Parameter
     PROPERTIES
         LABELS "SEQ"
         FIXTURES_SETUP Parameter)
     
 add_test(NAME Parameter_mpi
-    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> parameters)
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests parameters)
 set_tests_properties(Parameter_mpi
     PROPERTIES
         LABELS "MPI"
@@ -55,7 +55,7 @@ set_tests_properties(Parameter_mpi
 
 # Constant Field Function tests that depend on parameter tests being successful
 add_test(NAME ConstantFieldFunction 
-    COMMAND $<TARGET_FILE:mast_catch_tests> constant_field_functions)
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_field_functions)
 set_tests_properties(ConstantFieldFunction 
     PROPERTIES
         LABELS "SEQ"
@@ -63,7 +63,7 @@ set_tests_properties(ConstantFieldFunction
         FIXTURES_SETUP ConstantFieldFunction)
         
 add_test(NAME ConstantFieldFunction_mpi 
-    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_field_functions)
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests constant_field_functions)
 set_tests_properties(ConstantFieldFunction_mpi
     PROPERTIES
         LABELS "MPI"
@@ -72,7 +72,7 @@ set_tests_properties(ConstantFieldFunction_mpi
                      
 # FunctionSetBase tests that depend on constant field function tests being successful
 add_test(NAME FunctionSetBase
-    COMMAND $<TARGET_FILE:mast_catch_tests> "function_set_base")
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "function_set_base")
 set_tests_properties(FunctionSetBase
     PROPERTIES
         LABELS "SEQ"
@@ -80,7 +80,7 @@ set_tests_properties(FunctionSetBase
         FIXTURES_SETUP FunctionSetBase)
 
 add_test(NAME FunctionSetBase_mpi
-COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> "function_set_base")
+COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "function_set_base")
 set_tests_properties(FunctionSetBase_mpi
     PROPERTIES
         LABELS "MPI"

--- a/tests/base/CMakeLists.txt
+++ b/tests/base/CMakeLists.txt
@@ -7,36 +7,68 @@ target_sources(mast_catch_tests
 
 # libMesh mesh generation test
 add_test(NAME libMesh_Mesh_Generation_1d
-    COMMAND mast_catch_tests "libmesh_mesh_generation_1d")
+    COMMAND $<TARGET_FILE:mast_catch_tests> "libmesh_mesh_generation_1d")
 set_tests_properties(libMesh_Mesh_Generation_1d
     PROPERTIES
         FIXTURES_SETUP libMesh_Mesh_Generation_1d)
+        
+add_test(NAME libMesh_Mesh_Generation_1d_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> "libmesh_mesh_generation_1d")
+set_tests_properties(libMesh_Mesh_Generation_1d_mpi
+    PROPERTIES
+        FIXTURES_SETUP libMesh_Mesh_Generation_1d_mpi)
 
 add_test(NAME libMesh_Mesh_Generation_2d
-    COMMAND mast_catch_tests "libmesh_mesh_generation_2d")
+    COMMAND $<TARGET_FILE:mast_catch_tests> "libmesh_mesh_generation_2d")
 set_tests_properties(libMesh_Mesh_Generation_2d
     PROPERTIES
         FIXTURES_SETUP libMesh_Mesh_Generation_2d)
+        
+add_test(NAME libMesh_Mesh_Generation_2d_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> "libmesh_mesh_generation_2d")
+set_tests_properties(libMesh_Mesh_Generation_2d_mpi
+    PROPERTIES
+        FIXTURES_SETUP libMesh_Mesh_Generation_2d_mpi)
 
 # Parameter tests
 add_test(NAME Parameter
-    COMMAND mast_catch_tests parameters)
+    COMMAND $<TARGET_FILE:mast_catch_tests> parameters)
 set_tests_properties(Parameter
     PROPERTIES
         FIXTURES_SETUP Parameter)
+    
+add_test(NAME Parameter_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> parameters)
+set_tests_properties(Parameter_mpi
+    PROPERTIES
+        FIXTURES_SETUP Parameter_mpi)
 
 # Constant Field Function tests that depend on parameter tests being successful
 add_test(NAME ConstantFieldFunction 
-    COMMAND mast_catch_tests constant_field_functions)
+    COMMAND $<TARGET_FILE:mast_catch_tests> constant_field_functions)
 set_tests_properties(ConstantFieldFunction 
     PROPERTIES
         FIXTURES_REQUIRED Parameter
         FIXTURES_SETUP ConstantFieldFunction)
+        
+add_test(NAME ConstantFieldFunction_mpi 
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_field_functions)
+set_tests_properties(ConstantFieldFunction_mpi
+    PROPERTIES
+        FIXTURES_REQUIRED Parameter_mpi
+        FIXTURES_SETUP ConstantFieldFunction_mpi)
                      
 # FunctionSetBase tests that depend on constant field function tests being successful
 add_test(NAME FunctionSetBase
-    COMMAND mast_catch_tests "function_set_base")
+    COMMAND $<TARGET_FILE:mast_catch_tests> "function_set_base")
 set_tests_properties(FunctionSetBase
     PROPERTIES
         FIXTURES_REQUIRED ConstantFieldFunction
         FIXTURES_SETUP FunctionSetBase)
+
+add_test(NAME FunctionSetBase_mpi
+COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> "function_set_base")
+set_tests_properties(FunctionSetBase_mpi
+    PROPERTIES
+        FIXTURES_REQUIRED ConstantFieldFunction_mpi
+        FIXTURES_SETUP FunctionSetBase_mpi)

--- a/tests/base/CMakeLists.txt
+++ b/tests/base/CMakeLists.txt
@@ -5,29 +5,37 @@ target_sources(mast_catch_tests
         ${CMAKE_CURRENT_LIST_DIR}/mast_function_set_base.cpp
         ${CMAKE_CURRENT_LIST_DIR}/mast_mesh.cpp)
 
+# FIXME: MPI tests seem to either run very slow or hang up intermittently
+# This has occured in:
+#   libMesh_Mesh_Generation_1d_mpi  - hung up
+        
 # libMesh mesh generation test
 add_test(NAME libMesh_Mesh_Generation_1d
     COMMAND $<TARGET_FILE:mast_catch_tests> "libmesh_mesh_generation_1d")
 set_tests_properties(libMesh_Mesh_Generation_1d
     PROPERTIES
+        LABELS "SEQ"
         FIXTURES_SETUP libMesh_Mesh_Generation_1d)
         
 add_test(NAME libMesh_Mesh_Generation_1d_mpi
     COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> "libmesh_mesh_generation_1d")
 set_tests_properties(libMesh_Mesh_Generation_1d_mpi
     PROPERTIES
+        LABELS "MPI"
         FIXTURES_SETUP libMesh_Mesh_Generation_1d_mpi)
 
 add_test(NAME libMesh_Mesh_Generation_2d
     COMMAND $<TARGET_FILE:mast_catch_tests> "libmesh_mesh_generation_2d")
 set_tests_properties(libMesh_Mesh_Generation_2d
     PROPERTIES
+        LABELS "SEQ"
         FIXTURES_SETUP libMesh_Mesh_Generation_2d)
         
 add_test(NAME libMesh_Mesh_Generation_2d_mpi
     COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> "libmesh_mesh_generation_2d")
 set_tests_properties(libMesh_Mesh_Generation_2d_mpi
     PROPERTIES
+        LABELS "MPI"
         FIXTURES_SETUP libMesh_Mesh_Generation_2d_mpi)
 
 # Parameter tests
@@ -35,12 +43,14 @@ add_test(NAME Parameter
     COMMAND $<TARGET_FILE:mast_catch_tests> parameters)
 set_tests_properties(Parameter
     PROPERTIES
+        LABELS "SEQ"
         FIXTURES_SETUP Parameter)
     
 add_test(NAME Parameter_mpi
     COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> parameters)
 set_tests_properties(Parameter_mpi
     PROPERTIES
+        LABELS "MPI"
         FIXTURES_SETUP Parameter_mpi)
 
 # Constant Field Function tests that depend on parameter tests being successful
@@ -48,6 +58,7 @@ add_test(NAME ConstantFieldFunction
     COMMAND $<TARGET_FILE:mast_catch_tests> constant_field_functions)
 set_tests_properties(ConstantFieldFunction 
     PROPERTIES
+        LABELS "SEQ"
         FIXTURES_REQUIRED Parameter
         FIXTURES_SETUP ConstantFieldFunction)
         
@@ -55,6 +66,7 @@ add_test(NAME ConstantFieldFunction_mpi
     COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_field_functions)
 set_tests_properties(ConstantFieldFunction_mpi
     PROPERTIES
+        LABELS "MPI"
         FIXTURES_REQUIRED Parameter_mpi
         FIXTURES_SETUP ConstantFieldFunction_mpi)
                      
@@ -63,6 +75,7 @@ add_test(NAME FunctionSetBase
     COMMAND $<TARGET_FILE:mast_catch_tests> "function_set_base")
 set_tests_properties(FunctionSetBase
     PROPERTIES
+        LABELS "SEQ"
         FIXTURES_REQUIRED ConstantFieldFunction
         FIXTURES_SETUP FunctionSetBase)
 
@@ -70,5 +83,6 @@ add_test(NAME FunctionSetBase_mpi
 COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> "function_set_base")
 set_tests_properties(FunctionSetBase_mpi
     PROPERTIES
+        LABELS "MPI"
         FIXTURES_REQUIRED ConstantFieldFunction_mpi
         FIXTURES_SETUP FunctionSetBase_mpi)

--- a/tests/material/CMakeLists.txt
+++ b/tests/material/CMakeLists.txt
@@ -17,7 +17,7 @@ target_sources( mast_catch_tests
 # 1D Isotropic Material Tests
 #-----------------------------------------------------------------------------
 add_test(NAME Isotropic_Material_1D_Thermoelastic
-         COMMAND $<TARGET_FILE:mast_catch_tests> constant_isotropic_thermoelastic_material_1d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_isotropic_thermoelastic_material_1d)
 set_tests_properties(Isotropic_Material_1D_Thermoelastic
                     PROPERTIES 
                     LABELS "SEQ"
@@ -25,7 +25,7 @@ set_tests_properties(Isotropic_Material_1D_Thermoelastic
                     FIXTURES_SETUP      Isotropic_Material_1D_Thermoelastic)
                     
 add_test(NAME Isotropic_Material_1D_Thermoelastic_mpi
-         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_isotropic_thermoelastic_material_1d)
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests constant_isotropic_thermoelastic_material_1d)
 set_tests_properties(Isotropic_Material_1D_Thermoelastic_mpi
                     PROPERTIES 
                     LABELS "MPI"
@@ -33,7 +33,7 @@ set_tests_properties(Isotropic_Material_1D_Thermoelastic_mpi
                     FIXTURES_SETUP      Isotropic_Material_1D_Thermoelastic_mpi)
 
 add_test(NAME Isotropic_Material_1D_Structural
-         COMMAND $<TARGET_FILE:mast_catch_tests> constant_isotropic_structural_material_1d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_isotropic_structural_material_1d)
 set_tests_properties(Isotropic_Material_1D_Structural
                     PROPERTIES 
                     LABELS "SEQ"
@@ -41,7 +41,7 @@ set_tests_properties(Isotropic_Material_1D_Structural
                     FIXTURES_SETUP      Isotropic_Material_1D_Structural)
                     
 add_test(NAME Isotropic_Material_1D_Structural_mpi
-         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_isotropic_structural_material_1d)
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests constant_isotropic_structural_material_1d)
 set_tests_properties(Isotropic_Material_1D_Structural_mpi
                     PROPERTIES 
                     LABELS "MPI"
@@ -49,7 +49,7 @@ set_tests_properties(Isotropic_Material_1D_Structural_mpi
                     FIXTURES_SETUP      Isotropic_Material_1D_Structural_mpi)
 
 add_test(NAME Isotropic_Material_1D_Heat_Transfer
-         COMMAND $<TARGET_FILE:mast_catch_tests> constant_isotropic_heat_transfer_material_1d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_isotropic_heat_transfer_material_1d)
 set_tests_properties(Isotropic_Material_1D_Heat_Transfer
                     PROPERTIES 
                     LABELS "SEQ"
@@ -57,7 +57,7 @@ set_tests_properties(Isotropic_Material_1D_Heat_Transfer
                     FIXTURES_SETUP      Isotropic_Material_1D_Heat_Transfer)
                     
 add_test(NAME Isotropic_Material_1D_Heat_Transfer_mpi
-         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_isotropic_heat_transfer_material_1d)
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests constant_isotropic_heat_transfer_material_1d)
 set_tests_properties(Isotropic_Material_1D_Heat_Transfer_mpi
                     PROPERTIES 
                     LABELS "MPI"
@@ -65,7 +65,7 @@ set_tests_properties(Isotropic_Material_1D_Heat_Transfer_mpi
                     FIXTURES_SETUP      Isotropic_Material_1D_Heat_Transfer_mpi)
                     
 add_test(NAME Isotropic_Material_1D_Transient_Heat_Transfer
-         COMMAND $<TARGET_FILE:mast_catch_tests> constant_isotropic_transient_heat_transfer_material_1d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_isotropic_transient_heat_transfer_material_1d)
 set_tests_properties(Isotropic_Material_1D_Transient_Heat_Transfer
                     PROPERTIES 
                     LABELS "SEQ"
@@ -73,7 +73,7 @@ set_tests_properties(Isotropic_Material_1D_Transient_Heat_Transfer
                     FIXTURES_SETUP      Isotropic_Material_1D_Transient_Heat_Transfer)
                     
 add_test(NAME Isotropic_Material_1D_Transient_Heat_Transfer_mpi
-         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_isotropic_transient_heat_transfer_material_1d)
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests constant_isotropic_transient_heat_transfer_material_1d)
 set_tests_properties(Isotropic_Material_1D_Transient_Heat_Transfer_mpi
                     PROPERTIES 
                     LABELS "MPI"
@@ -84,7 +84,7 @@ set_tests_properties(Isotropic_Material_1D_Transient_Heat_Transfer_mpi
 # 2D Isotropic Material Tests
 #-----------------------------------------------------------------------------
 add_test(NAME Isotropic_Material_2D_Thermoelastic
-         COMMAND $<TARGET_FILE:mast_catch_tests> constant_isotropic_thermoelastic_material_2d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_isotropic_thermoelastic_material_2d)
 set_tests_properties(Isotropic_Material_2D_Thermoelastic
                     PROPERTIES 
                     LABELS "SEQ"
@@ -92,7 +92,7 @@ set_tests_properties(Isotropic_Material_2D_Thermoelastic
                     FIXTURES_SETUP      Isotropic_Material_2D_Thermoelastic)
 
 add_test(NAME Isotropic_Material_2D_Thermoelastic_mpi
-         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_isotropic_thermoelastic_material_2d)
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests constant_isotropic_thermoelastic_material_2d)
 set_tests_properties(Isotropic_Material_2D_Thermoelastic_mpi
                     PROPERTIES 
                     LABELS "MPI"
@@ -100,7 +100,7 @@ set_tests_properties(Isotropic_Material_2D_Thermoelastic_mpi
                     FIXTURES_SETUP      Isotropic_Material_2D_Thermoelastic_mpi)
                     
 add_test(NAME Isotropic_Material_2D_Structural
-         COMMAND $<TARGET_FILE:mast_catch_tests> constant_isotropic_structural_material_2d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_isotropic_structural_material_2d)
 set_tests_properties(Isotropic_Material_2D_Structural
                     PROPERTIES 
                     LABELS "SEQ"
@@ -108,7 +108,7 @@ set_tests_properties(Isotropic_Material_2D_Structural
                     FIXTURES_SETUP      Isotropic_Material_2D_Structural)
                     
 add_test(NAME Isotropic_Material_2D_Structural_mpi
-         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_isotropic_structural_material_2d)
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests constant_isotropic_structural_material_2d)
 set_tests_properties(Isotropic_Material_2D_Structural_mpi
                     PROPERTIES 
                     LABELS "MPI"
@@ -116,7 +116,7 @@ set_tests_properties(Isotropic_Material_2D_Structural_mpi
                     FIXTURES_SETUP      Isotropic_Material_2D_Structural_mpi)
 
 add_test(NAME Isotropic_Material_2D_Heat_Transfer
-         COMMAND $<TARGET_FILE:mast_catch_tests> constant_isotropic_heat_transfer_material_2d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_isotropic_heat_transfer_material_2d)
 set_tests_properties(Isotropic_Material_2D_Heat_Transfer
                      PROPERTIES 
                      LABELS "SEQ"
@@ -124,7 +124,7 @@ set_tests_properties(Isotropic_Material_2D_Heat_Transfer
                      FIXTURES_SETUP      Isotropic_Material_2D_Heat_Transfer)
                      
 add_test(NAME Isotropic_Material_2D_Heat_Transfer_mpi
-         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_isotropic_heat_transfer_material_2d)
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests constant_isotropic_heat_transfer_material_2d)
 set_tests_properties(Isotropic_Material_2D_Heat_Transfer_mpi
                      PROPERTIES 
                      LABELS "MPI"
@@ -132,7 +132,7 @@ set_tests_properties(Isotropic_Material_2D_Heat_Transfer_mpi
                      FIXTURES_SETUP      Isotropic_Material_2D_Heat_Transfer_mpi)
                     
 add_test(NAME Isotropic_Material_2D_Transient_Heat_Transfer
-         COMMAND $<TARGET_FILE:mast_catch_tests> constant_isotropic_transient_heat_transfer_material_2d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_isotropic_transient_heat_transfer_material_2d)
 set_tests_properties(Isotropic_Material_2D_Transient_Heat_Transfer
                      PROPERTIES 
                      LABELS "SEQ"
@@ -140,7 +140,7 @@ set_tests_properties(Isotropic_Material_2D_Transient_Heat_Transfer
                      FIXTURES_SETUP      Isotropic_Material_2D_Transient_Heat_Transfer)
                     
 add_test(NAME Isotropic_Material_2D_Transient_Heat_Transfer_mpi
-         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_isotropic_transient_heat_transfer_material_2d)
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests constant_isotropic_transient_heat_transfer_material_2d)
 set_tests_properties(Isotropic_Material_2D_Transient_Heat_Transfer_mpi
                      PROPERTIES 
                      LABELS "MPI"
@@ -150,70 +150,70 @@ set_tests_properties(Isotropic_Material_2D_Transient_Heat_Transfer_mpi
 # 3D Isotropic Material Tests
 #-----------------------------------------------------------------------------
 add_test(NAME Isotropic_Material_3D_Thermoelastic
-         COMMAND $<TARGET_FILE:mast_catch_tests> constant_isotropic_thermoelastic_material_3d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_isotropic_thermoelastic_material_3d)
 set_tests_properties(Isotropic_Material_3D_Thermoelastic
                     PROPERTIES 
                     LABELS "SEQ"
                     FIXTURES_REQUIRED   ConstantFieldFunction)
 
 add_test(NAME Isotropic_Material_3D_Thermoelastic_mpi
-         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_isotropic_thermoelastic_material_3d)
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests constant_isotropic_thermoelastic_material_3d)
 set_tests_properties(Isotropic_Material_3D_Thermoelastic_mpi
                     PROPERTIES 
                     LABELS "MPI"
                     FIXTURES_REQUIRED   ConstantFieldFunction_mpi)
                     
 add_test(NAME Isotropic_Material_3D_Structural
-         COMMAND $<TARGET_FILE:mast_catch_tests> constant_isotropic_structural_material_3d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_isotropic_structural_material_3d)
 set_tests_properties(Isotropic_Material_3D_Structural
                      PROPERTIES 
                      LABELS "SEQ"
                      FIXTURES_REQUIRED  ConstantFieldFunction)
 
 add_test(NAME Isotropic_Material_3D_Structural_mpi
-         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_isotropic_structural_material_3d)
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests constant_isotropic_structural_material_3d)
 set_tests_properties(Isotropic_Material_3D_Structural_mpi
                      PROPERTIES 
                      LABELS "MPI"
                      FIXTURES_REQUIRED  ConstantFieldFunction_mpi)
                      
 add_test(NAME Isotropic_Material_3D_Heat_Transfer
-         COMMAND $<TARGET_FILE:mast_catch_tests> constant_isotropic_heat_transfer_material_3d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_isotropic_heat_transfer_material_3d)
 set_tests_properties(Isotropic_Material_3D_Heat_Transfer
                      PROPERTIES 
                      LABELS "SEQ"
                      FIXTURES_REQUIRED  ConstantFieldFunction)
                      
 add_test(NAME Isotropic_Material_3D_Heat_Transfer_mpi
-         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_isotropic_heat_transfer_material_3d)
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests constant_isotropic_heat_transfer_material_3d)
 set_tests_properties(Isotropic_Material_3D_Heat_Transfer_mpi
                      PROPERTIES 
                      LABELS "MPI"
                      FIXTURES_REQUIRED  ConstantFieldFunction_mpi)
                      
 add_test(NAME Isotropic_Material_3D_Transient_Heat_Transfer
-         COMMAND $<TARGET_FILE:mast_catch_tests> constant_isotropic_transient_heat_transfer_material_3d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_isotropic_transient_heat_transfer_material_3d)
 set_tests_properties(Isotropic_Material_3D_Transient_Heat_Transfer
                      PROPERTIES 
                      LABELS "SEQ"
                      FIXTURES_REQUIRED   ConstantFieldFunction)
 
 add_test(NAME Isotropic_Material_3D_Transient_Heat_Transfer_mpi
-         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_isotropic_transient_heat_transfer_material_3d)
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests constant_isotropic_transient_heat_transfer_material_3d)
 set_tests_properties(Isotropic_Material_3D_Transient_Heat_Transfer_mpi
                      PROPERTIES 
                      LABELS "MPI"
                      FIXTURES_REQUIRED   ConstantFieldFunction_mpi)
                      
 add_test(NAME Isotropic_Material_3D_Dynamic
-         COMMAND $<TARGET_FILE:mast_catch_tests> constant_isotropic_dynamic_material_3d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_isotropic_dynamic_material_3d)
 set_tests_properties(Isotropic_Material_3D_Dynamic
                      PROPERTIES 
                      LABELS "SEQ"
                      FIXTURES_REQUIRED  ConstantFieldFunction)
                      
 add_test(NAME Isotropic_Material_3D_Dynamic_mpi
-         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_isotropic_dynamic_material_3d)
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests constant_isotropic_dynamic_material_3d)
 set_tests_properties(Isotropic_Material_3D_Dynamic_mpi
                      PROPERTIES 
                      LABELS "MPI"
@@ -227,56 +227,56 @@ set_tests_properties(Isotropic_Material_3D_Dynamic_mpi
 # 1D Orthotropic Material Tests
 #-----------------------------------------------------------------------------
 add_test(NAME Orthotropic_Material_1D_Thermoelastic
-         COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_thermoelastic_material_1d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_orthotropic_thermoelastic_material_1d)
 set_tests_properties(Orthotropic_Material_1D_Thermoelastic
                     PROPERTIES 
                     LABELS "SEQ"
                     FIXTURES_REQUIRED   ConstantFieldFunction)
                     
 add_test(NAME Orthotropic_Material_1D_Thermoelastic_mpi
-         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_orthotropic_thermoelastic_material_1d)
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests constant_orthotropic_thermoelastic_material_1d)
 set_tests_properties(Orthotropic_Material_1D_Thermoelastic_mpi
                     PROPERTIES 
                     LABELS "MPI"
                     FIXTURES_REQUIRED   ConstantFieldFunction_mpi)
                     
 add_test(NAME Orthotropic_Material_1D_Structural
-         COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_structural_material_1d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_orthotropic_structural_material_1d)
 set_tests_properties(Orthotropic_Material_1D_Structural
                      PROPERTIES 
                      LABELS "SEQ"
                      FIXTURES_REQUIRED   ConstantFieldFunction)
 
 add_test(NAME Orthotropic_Material_1D_Structural_mpi
-         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_orthotropic_structural_material_1d)
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests constant_orthotropic_structural_material_1d)
 set_tests_properties(Orthotropic_Material_1D_Structural_mpi
                      PROPERTIES 
                      LABELS "MPI"
                      FIXTURES_REQUIRED   ConstantFieldFunction_mpi)
                      
 add_test(NAME Orthotropic_Material_1D_Heat_Transfer
-         COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_heat_transfer_material_1d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_orthotropic_heat_transfer_material_1d)
 set_tests_properties(Orthotropic_Material_1D_Heat_Transfer
                      PROPERTIES 
                      LABELS "SEQ"
                      FIXTURES_REQUIRED   ConstantFieldFunction)
                      
 add_test(NAME Orthotropic_Material_1D_Heat_Transfer_mpi
-         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_orthotropic_heat_transfer_material_1d)
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests constant_orthotropic_heat_transfer_material_1d)
 set_tests_properties(Orthotropic_Material_1D_Heat_Transfer_mpi
                      PROPERTIES 
                      LABELS "MPI"
                      FIXTURES_REQUIRED   ConstantFieldFunction_mpi)
                     
 add_test(NAME Orthotropic_Material_1D_Transient_Heat_Transfer
-         COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_transient_heat_transfer_material_1d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_orthotropic_transient_heat_transfer_material_1d)
 set_tests_properties(Orthotropic_Material_1D_Transient_Heat_Transfer
                      PROPERTIES 
                      LABELS "SEQ"
                      FIXTURES_REQUIRED   ConstantFieldFunction)
 
 add_test(NAME Orthotropic_Material_1D_Transient_Heat_Transfer_mpi
-         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_orthotropic_transient_heat_transfer_material_1d)
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests constant_orthotropic_transient_heat_transfer_material_1d)
 set_tests_properties(Orthotropic_Material_1D_Transient_Heat_Transfer_mpi
                      PROPERTIES 
                      LABELS "MPI"
@@ -285,56 +285,56 @@ set_tests_properties(Orthotropic_Material_1D_Transient_Heat_Transfer_mpi
 # 2D Orthotropic Material Tests
 #-----------------------------------------------------------------------------
 add_test(NAME Orthotropic_Material_2D_Thermoelastic
-         COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_thermoelastic_material_2d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_orthotropic_thermoelastic_material_2d)
 set_tests_properties(Orthotropic_Material_2D_Thermoelastic
                     PROPERTIES 
                     LABELS "SEQ"
                     FIXTURES_REQUIRED   ConstantFieldFunction)
                     
 add_test(NAME Orthotropic_Material_2D_Thermoelastic_mpi
-         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_orthotropic_thermoelastic_material_2d)
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests constant_orthotropic_thermoelastic_material_2d)
 set_tests_properties(Orthotropic_Material_2D_Thermoelastic_mpi
                     PROPERTIES 
                     LABELS "MPI"
                     FIXTURES_REQUIRED   ConstantFieldFunction_mpi)
                     
 add_test(NAME Orthotropic_Material_2D_Structural
-         COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_structural_material_2d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_orthotropic_structural_material_2d)
 set_tests_properties(Orthotropic_Material_2D_Structural
                      PROPERTIES 
                      LABELS "SEQ"
                      FIXTURES_REQUIRED   ConstantFieldFunction)
 
 add_test(NAME Orthotropic_Material_2D_Structural_mpi
-         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_orthotropic_structural_material_2d)
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests constant_orthotropic_structural_material_2d)
 set_tests_properties(Orthotropic_Material_2D_Structural_mpi
                      PROPERTIES 
                      LABELS "MPI"
                      FIXTURES_REQUIRED   ConstantFieldFunction_mpi)
                      
 add_test(NAME Orthotropic_Material_2D_Heat_Transfer
-         COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_heat_transfer_material_2d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_orthotropic_heat_transfer_material_2d)
 set_tests_properties(Orthotropic_Material_2D_Heat_Transfer
                      PROPERTIES 
                      LABELS "SEQ"
                      FIXTURES_REQUIRED   ConstantFieldFunction)
 
 add_test(NAME Orthotropic_Material_2D_Heat_Transfer_mpi
-         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_orthotropic_heat_transfer_material_2d)
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests constant_orthotropic_heat_transfer_material_2d)
 set_tests_properties(Orthotropic_Material_2D_Heat_Transfer_mpi
                      PROPERTIES 
                      LABELS "MPI"
                      FIXTURES_REQUIRED   ConstantFieldFunction_mpi)
                     
 add_test(NAME Orthotropic_Material_2D_Transient_Heat_Transfer
-         COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_transient_heat_transfer_material_2d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_orthotropic_transient_heat_transfer_material_2d)
 set_tests_properties(Orthotropic_Material_2D_Transient_Heat_Transfer
                      PROPERTIES 
                      LABELS "SEQ"
                      FIXTURES_REQUIRED   ConstantFieldFunction)
 
 add_test(NAME Orthotropic_Material_2D_Transient_Heat_Transfer_mpi
-         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_orthotropic_transient_heat_transfer_material_2d)
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests constant_orthotropic_transient_heat_transfer_material_2d)
 set_tests_properties(Orthotropic_Material_2D_Transient_Heat_Transfer_mpi
                      PROPERTIES 
                      LABELS "MPI"
@@ -344,70 +344,70 @@ set_tests_properties(Orthotropic_Material_2D_Transient_Heat_Transfer_mpi
 # 3D Orthotropic Material Tests
 #-----------------------------------------------------------------------------
 add_test(NAME Orthotropic_Material_3D_Thermoelastic
-         COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_thermoelastic_material_3d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_orthotropic_thermoelastic_material_3d)
 set_tests_properties(Orthotropic_Material_3D_Thermoelastic
                     PROPERTIES 
                     LABELS "SEQ"
                     FIXTURES_REQUIRED   ConstantFieldFunction)
 
 add_test(NAME Orthotropic_Material_3D_Thermoelastic_mpi
-         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_orthotropic_thermoelastic_material_3d)
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests constant_orthotropic_thermoelastic_material_3d)
 set_tests_properties(Orthotropic_Material_3D_Thermoelastic_mpi
                     PROPERTIES 
                     LABELS "MPI"
                     FIXTURES_REQUIRED   ConstantFieldFunction_mpi)
                     
 add_test(NAME Orthotropic_Material_3D_Structural
-         COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_structural_material_3d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_orthotropic_structural_material_3d)
 set_tests_properties(Orthotropic_Material_3D_Structural
                      PROPERTIES 
                      LABELS "SEQ"
                      FIXTURES_REQUIRED  ConstantFieldFunction)
 
 add_test(NAME Orthotropic_Material_3D_Structural_mpi
-         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_orthotropic_structural_material_3d)
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests constant_orthotropic_structural_material_3d)
 set_tests_properties(Orthotropic_Material_3D_Structural_mpi
                      PROPERTIES 
                      LABELS "MPI"
                      FIXTURES_REQUIRED  ConstantFieldFunction_mpi)
                      
 add_test(NAME Orthotropic_Material_3D_Heat_Transfer
-         COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_heat_transfer_material_3d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_orthotropic_heat_transfer_material_3d)
 set_tests_properties(Orthotropic_Material_3D_Heat_Transfer
                      PROPERTIES 
                      LABELS "SEQ"
                      FIXTURES_REQUIRED  ConstantFieldFunction)
                      
 add_test(NAME Orthotropic_Material_3D_Heat_Transfer_mpi
-         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_orthotropic_heat_transfer_material_3d)
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests constant_orthotropic_heat_transfer_material_3d)
 set_tests_properties(Orthotropic_Material_3D_Heat_Transfer_mpi
                      PROPERTIES 
                      LABELS "MPI"
                      FIXTURES_REQUIRED  ConstantFieldFunction_mpi)
                      
 add_test(NAME Orthotropic_Material_3D_Transient_Heat_Transfer
-         COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_transient_heat_transfer_material_3d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_orthotropic_transient_heat_transfer_material_3d)
 set_tests_properties(Orthotropic_Material_3D_Transient_Heat_Transfer
                      PROPERTIES 
                      LABELS "SEQ"
                      FIXTURES_REQUIRED   ConstantFieldFunction)
 
 add_test(NAME Orthotropic_Material_3D_Transient_Heat_Transfer_mpi
-         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_orthotropic_transient_heat_transfer_material_3d)
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests constant_orthotropic_transient_heat_transfer_material_3d)
 set_tests_properties(Orthotropic_Material_3D_Transient_Heat_Transfer_mpi
                      PROPERTIES 
                      LABELS "MPI"
                      FIXTURES_REQUIRED   ConstantFieldFunction_mpi)
                      
 add_test(NAME Orthotropic_Material_3D_Dynamic
-         COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_dynamic_material_3d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_orthotropic_dynamic_material_3d)
 set_tests_properties(Orthotropic_Material_3D_Dynamic
                      PROPERTIES 
                      LABELS "SEQ"
                      FIXTURES_REQUIRED  ConstantFieldFunction)
 
 add_test(NAME Orthotropic_Material_3D_Dynamic_mpi
-         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_orthotropic_dynamic_material_3d)
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests constant_orthotropic_dynamic_material_3d)
 set_tests_properties(Orthotropic_Material_3D_Dynamic_mpi
                      PROPERTIES 
                      LABELS "MPI"
@@ -421,25 +421,25 @@ set_tests_properties(Orthotropic_Material_3D_Dynamic_mpi
 # # 1D Anisotropic Material Tests
 # #-----------------------------------------------------------------------------
 # add_test(NAME Anisotropic_Material_1D_Thermoelastic
-#          COMMAND $<TARGET_FILE:mast_catch_tests> constant_anisotropic_thermoelastic_material_1d)
+#          COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_anisotropic_thermoelastic_material_1d)
 # set_tests_properties(Anisotropic_Material_1D_Thermoelastic
 #                     PROPERTIES 
 #                     FIXTURES_REQUIRED   ConstantFieldFunction)
 #                     
 # add_test(NAME Anisotropic_Material_1D_Structural
-#          COMMAND $<TARGET_FILE:mast_catch_tests> constant_anisotropic_structural_material_1d)
+#          COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_anisotropic_structural_material_1d)
 # set_tests_properties(Anisotropic_Material_1D_Structural
 #                      PROPERTIES 
 #                      FIXTURES_REQUIRED   ConstantFieldFunction)
 # 
 # add_test(NAME Anisotropic_Material_1D_Heat_Transfer
-#          COMMAND $<TARGET_FILE:mast_catch_tests> constant_anisotropic_heat_transfer_material_1d)
+#          COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_anisotropic_heat_transfer_material_1d)
 # set_tests_properties(Anisotropic_Material_1D_Heat_Transfer
 #                      PROPERTIES 
 #                      FIXTURES_REQUIRED   ConstantFieldFunction)
 #                      
 # add_test(NAME Anisotropic_Material_1D_Transient_Heat_Transfer
-#          COMMAND $<TARGET_FILE:mast_catch_tests> constant_anisotropic_transient_heat_transfer_material_1d)
+#          COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_anisotropic_transient_heat_transfer_material_1d)
 # set_tests_properties(Anisotropic_Material_1D_Transient_Heat_Transfer
 #                      PROPERTIES 
 #                      FIXTURES_REQUIRED   ConstantFieldFunction)
@@ -448,25 +448,25 @@ set_tests_properties(Orthotropic_Material_3D_Dynamic_mpi
 # # 2D Anisotropic Material Tests
 # #-----------------------------------------------------------------------------
 # add_test(NAME Anisotropic_Material_2D_Thermoelastic
-#          COMMAND $<TARGET_FILE:mast_catch_tests> constant_anisotropic_thermoelastic_material_2d)
+#          COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_anisotropic_thermoelastic_material_2d)
 # set_tests_properties(Anisotropic_Material_2D_Thermoelastic
 #                     PROPERTIES 
 #                     FIXTURES_REQUIRED   ConstantFieldFunction)
 #                     
 # add_test(NAME Anisotropic_Material_2D_Structural
-#          COMMAND $<TARGET_FILE:mast_catch_tests> constant_anisotropic_structural_material_2d)
+#          COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_anisotropic_structural_material_2d)
 # set_tests_properties(Anisotropic_Material_2D_Structural
 #                      PROPERTIES 
 #                      FIXTURES_REQUIRED   ConstantFieldFunction)
 # 
 # add_test(NAME Anisotropic_Material_2D_Heat_Transfer
-#          COMMAND $<TARGET_FILE:mast_catch_tests> constant_anisotropic_heat_transfer_material_2d)
+#          COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_anisotropic_heat_transfer_material_2d)
 # set_tests_properties(Anisotropic_Material_2D_Heat_Transfer
 #                      PROPERTIES 
 #                      FIXTURES_REQUIRED   ConstantFieldFunction)
 #                     
 # add_test(NAME Anisotropic_Material_2D_Transient_Heat_Transfer
-#          COMMAND $<TARGET_FILE:mast_catch_tests> constant_anisotropic_transient_heat_transfer_material_2d)
+#          COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_anisotropic_transient_heat_transfer_material_2d)
 # set_tests_properties(Anisotropic_Material_2D_Transient_Heat_Transfer
 #                      PROPERTIES 
 #                      FIXTURES_REQUIRED   ConstantFieldFunction)
@@ -475,31 +475,31 @@ set_tests_properties(Orthotropic_Material_3D_Dynamic_mpi
 # # 3D Anisotropic Material Tests
 # #-----------------------------------------------------------------------------
 # add_test(NAME Anisotropic_Material_3D_Thermoelastic
-#          COMMAND $<TARGET_FILE:mast_catch_tests> constant_anisotropic_thermoelastic_material_3d)
+#          COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_anisotropic_thermoelastic_material_3d)
 # set_tests_properties(Anisotropic_Material_3D_Thermoelastic
 #                     PROPERTIES 
 #                     FIXTURES_REQUIRED   ConstantFieldFunction)
 # 
 # add_test(NAME Anisotropic_Material_3D_Structural
-#          COMMAND $<TARGET_FILE:mast_catch_tests> constant_anisotropic_structural_material_3d)
+#          COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_anisotropic_structural_material_3d)
 # set_tests_properties(Anisotropic_Material_3D_Structural
 #                      PROPERTIES 
 #                      FIXTURES_REQUIRED  ConstantFieldFunction)
 # 
 # add_test(NAME Anisotropic_Material_3D_Heat_Transfer
-#          COMMAND $<TARGET_FILE:mast_catch_tests> constant_anisotropic_heat_transfer_material_3d)
+#          COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_anisotropic_heat_transfer_material_3d)
 # set_tests_properties(Anisotropic_Material_3D_Heat_Transfer
 #                      PROPERTIES 
 #                      FIXTURES_REQUIRED  ConstantFieldFunction)
 #                      
 # add_test(NAME Anisotropic_Material_3D_Transient_Heat_Transfer
-#          COMMAND $<TARGET_FILE:mast_catch_tests> constant_anisotropic_transient_heat_transfer_material_3d)
+#          COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_anisotropic_transient_heat_transfer_material_3d)
 # set_tests_properties(Anisotropic_Material_3D_Transient_Heat_Transfer
 #                      PROPERTIES 
 #                      FIXTURES_REQUIRED   ConstantFieldFunction)
 # 
 # add_test(NAME Anisotropic_Material_3D_Dynamic
-#          COMMAND $<TARGET_FILE:mast_catch_tests> constant_anisotropic_dynamic_material_3d)
+#          COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests constant_anisotropic_dynamic_material_3d)
 # set_tests_properties(Anisotropic_Material_3D_Dynamic
 #                      PROPERTIES 
 #                      FIXTURES_REQUIRED  ConstantFieldFunction)

--- a/tests/material/CMakeLists.txt
+++ b/tests/material/CMakeLists.txt
@@ -1,0 +1,287 @@
+target_sources( mast_catch_tests
+                PRIVATE
+                ${CMAKE_CURRENT_LIST_DIR}/mast_isotropic_material.cpp
+                ${CMAKE_CURRENT_LIST_DIR}/mast_orthotropic_material.cpp
+                ${CMAKE_CURRENT_LIST_DIR}/mast_isotropic_material_sensitivity.cpp)
+
+                
+# ============================================================================
+#                          ISOTROPIC MATERIAL TESTS
+# ============================================================================
+                
+# 1D Isotropic Material Tests
+#-----------------------------------------------------------------------------
+add_test(NAME Isotropic_Material_1D_Thermoelastic
+         COMMAND mast_catch_tests constant_isotropic_thermoelastic_material_1d)
+set_tests_properties(Isotropic_Material_1D_Thermoelastic
+                    PROPERTIES 
+                    FIXTURES_REQUIRED   ConstantFieldFunction
+                    FIXTURES_SETUP      Isotropic_Material_1D_Thermoelastic)
+
+add_test(NAME Isotropic_Material_1D_Structural
+         COMMAND mast_catch_tests constant_isotropic_structural_material_1d)
+set_tests_properties(Isotropic_Material_1D_Structural
+                    PROPERTIES 
+                    FIXTURES_REQUIRED   ConstantFieldFunction
+                    FIXTURES_SETUP      Isotropic_Material_1D_Structural)
+
+add_test(NAME Isotropic_Material_1D_Heat_Transfer
+         COMMAND mast_catch_tests constant_isotropic_heat_transfer_material_1d)
+set_tests_properties(Isotropic_Material_1D_Heat_Transfer
+                    PROPERTIES 
+                    FIXTURES_REQUIRED   ConstantFieldFunction
+                    FIXTURES_SETUP      Isotropic_Material_1D_Heat_Transfer)
+                    
+add_test(NAME Isotropic_Material_1D_Transient_Heat_Transfer
+         COMMAND mast_catch_tests constant_isotropic_transient_heat_transfer_material_1d)
+set_tests_properties(Isotropic_Material_1D_Transient_Heat_Transfer
+                    PROPERTIES 
+                    FIXTURES_REQUIRED   ConstantFieldFunction
+                    FIXTURES_SETUP      Isotropic_Material_1D_Transient_Heat_Transfer)
+                    
+                    
+# 2D Isotropic Material Tests
+#-----------------------------------------------------------------------------
+add_test(NAME Isotropic_Material_2D_Thermoelastic
+         COMMAND mast_catch_tests constant_isotropic_thermoelastic_material_2d)
+set_tests_properties(Isotropic_Material_2D_Thermoelastic
+                    PROPERTIES 
+                    FIXTURES_REQUIRED   ConstantFieldFunction
+                    FIXTURES_SETUP      Isotropic_Material_2D_Thermoelastic)
+
+add_test(NAME Isotropic_Material_2D_Structural
+         COMMAND mast_catch_tests constant_isotropic_structural_material_2d)
+set_tests_properties(Isotropic_Material_2D_Structural
+                    PROPERTIES 
+                    FIXTURES_REQUIRED   ConstantFieldFunction
+                    FIXTURES_SETUP      Isotropic_Material_2D_Structural)
+
+add_test(NAME Isotropic_Material_2D_Heat_Transfer
+         COMMAND mast_catch_tests constant_isotropic_heat_transfer_material_2d)
+set_tests_properties(Isotropic_Material_2D_Heat_Transfer
+                     PROPERTIES 
+                     FIXTURES_REQUIRED   ConstantFieldFunction
+                     FIXTURES_SETUP      Isotropic_Material_2D_Heat_Transfer)
+                    
+add_test(NAME Isotropic_Material_2D_Transient_Heat_Transfer
+         COMMAND mast_catch_tests constant_isotropic_transient_heat_transfer_material_2d)
+set_tests_properties(Isotropic_Material_2D_Transient_Heat_Transfer
+                     PROPERTIES 
+                     FIXTURES_REQUIRED   ConstantFieldFunction
+                     FIXTURES_SETUP      Isotropic_Material_2D_Transient_Heat_Transfer)
+                    
+                    
+# 3D Isotropic Material Tests
+#-----------------------------------------------------------------------------
+add_test(NAME Isotropic_Material_3D_Thermoelastic
+         COMMAND mast_catch_tests constant_isotropic_thermoelastic_material_3d)
+set_tests_properties(Isotropic_Material_3D_Thermoelastic
+                    PROPERTIES 
+                    FIXTURES_REQUIRED   ConstantFieldFunction)
+
+add_test(NAME Isotropic_Material_3D_Structural
+         COMMAND mast_catch_tests constant_isotropic_structural_material_3d)
+set_tests_properties(Isotropic_Material_3D_Structural
+                     PROPERTIES 
+                     FIXTURES_REQUIRED  ConstantFieldFunction)
+
+add_test(NAME Isotropic_Material_3D_Heat_Transfer
+         COMMAND mast_catch_tests constant_isotropic_heat_transfer_material_3d)
+set_tests_properties(Isotropic_Material_3D_Heat_Transfer
+                     PROPERTIES 
+                     FIXTURES_REQUIRED  ConstantFieldFunction)
+                     
+add_test(NAME Isotropic_Material_3D_Transient_Heat_Transfer
+         COMMAND mast_catch_tests constant_isotropic_transient_heat_transfer_material_3d)
+set_tests_properties(Isotropic_Material_3D_Transient_Heat_Transfer
+                     PROPERTIES 
+                     FIXTURES_REQUIRED   ConstantFieldFunction)
+
+add_test(NAME Isotropic_Material_3D_Dynamic
+         COMMAND mast_catch_tests constant_isotropic_dynamic_material_3d)
+set_tests_properties(Isotropic_Material_3D_Dynamic
+                     PROPERTIES 
+                     FIXTURES_REQUIRED  ConstantFieldFunction)
+                    
+                    
+# ============================================================================
+#                          ORTHOTROPIC MATERIAL TESTS
+# ============================================================================
+
+# 1D Orthotropic Material Tests
+#-----------------------------------------------------------------------------
+add_test(NAME Orthotropic_Material_1D_Thermoelastic
+         COMMAND mast_catch_tests constant_orthotropic_thermoelastic_material_1d)
+set_tests_properties(Orthotropic_Material_1D_Thermoelastic
+                    PROPERTIES 
+                    FIXTURES_REQUIRED   ConstantFieldFunction)
+                    
+add_test(NAME Orthotropic_Material_1D_Structural
+         COMMAND mast_catch_tests constant_orthotropic_structural_material_1d)
+set_tests_properties(Orthotropic_Material_1D_Structural
+                     PROPERTIES 
+                     FIXTURES_REQUIRED   ConstantFieldFunction)
+
+add_test(NAME Orthotropic_Material_1D_Heat_Transfer
+         COMMAND mast_catch_tests constant_orthotropic_heat_transfer_material_1d)
+set_tests_properties(Orthotropic_Material_1D_Heat_Transfer
+                     PROPERTIES 
+                     FIXTURES_REQUIRED   ConstantFieldFunction)
+                    
+add_test(NAME Orthotropic_Material_1D_Transient_Heat_Transfer
+         COMMAND mast_catch_tests constant_orthotropic_transient_heat_transfer_material_1d)
+set_tests_properties(Orthotropic_Material_1D_Transient_Heat_Transfer
+                     PROPERTIES 
+                     FIXTURES_REQUIRED   ConstantFieldFunction)
+
+                     
+# 2D Orthotropic Material Tests
+#-----------------------------------------------------------------------------
+add_test(NAME Orthotropic_Material_2D_Thermoelastic
+         COMMAND mast_catch_tests constant_orthotropic_thermoelastic_material_2d)
+set_tests_properties(Orthotropic_Material_2D_Thermoelastic
+                    PROPERTIES 
+                    FIXTURES_REQUIRED   ConstantFieldFunction)
+                    
+add_test(NAME Orthotropic_Material_2D_Structural
+         COMMAND mast_catch_tests constant_orthotropic_structural_material_2d)
+set_tests_properties(Orthotropic_Material_2D_Structural
+                     PROPERTIES 
+                     FIXTURES_REQUIRED   ConstantFieldFunction)
+
+add_test(NAME Orthotropic_Material_2D_Heat_Transfer
+         COMMAND mast_catch_tests constant_orthotropic_heat_transfer_material_2d)
+set_tests_properties(Orthotropic_Material_2D_Heat_Transfer
+                     PROPERTIES 
+                     FIXTURES_REQUIRED   ConstantFieldFunction)
+                    
+add_test(NAME Orthotropic_Material_2D_Transient_Heat_Transfer
+         COMMAND mast_catch_tests constant_orthotropic_transient_heat_transfer_material_2d)
+set_tests_properties(Orthotropic_Material_2D_Transient_Heat_Transfer
+                     PROPERTIES 
+                     FIXTURES_REQUIRED   ConstantFieldFunction)
+
+                     
+# 3D Orthotropic Material Tests
+#-----------------------------------------------------------------------------
+add_test(NAME Orthotropic_Material_3D_Thermoelastic
+         COMMAND mast_catch_tests constant_orthotropic_thermoelastic_material_3d)
+set_tests_properties(Orthotropic_Material_3D_Thermoelastic
+                    PROPERTIES 
+                    FIXTURES_REQUIRED   ConstantFieldFunction)
+
+add_test(NAME Orthotropic_Material_3D_Structural
+         COMMAND mast_catch_tests constant_orthotropic_structural_material_3d)
+set_tests_properties(Orthotropic_Material_3D_Structural
+                     PROPERTIES 
+                     FIXTURES_REQUIRED  ConstantFieldFunction)
+
+add_test(NAME Orthotropic_Material_3D_Heat_Transfer
+         COMMAND mast_catch_tests constant_orthotropic_heat_transfer_material_3d)
+set_tests_properties(Orthotropic_Material_3D_Heat_Transfer
+                     PROPERTIES 
+                     FIXTURES_REQUIRED  ConstantFieldFunction)
+                     
+add_test(NAME Orthotropic_Material_3D_Transient_Heat_Transfer
+         COMMAND mast_catch_tests constant_orthotropic_transient_heat_transfer_material_3d)
+set_tests_properties(Orthotropic_Material_3D_Transient_Heat_Transfer
+                     PROPERTIES 
+                     FIXTURES_REQUIRED   ConstantFieldFunction)
+
+add_test(NAME Orthotropic_Material_3D_Dynamic
+         COMMAND mast_catch_tests constant_orthotropic_dynamic_material_3d)
+set_tests_properties(Orthotropic_Material_3D_Dynamic
+                     PROPERTIES 
+                     FIXTURES_REQUIRED  ConstantFieldFunction)
+
+         
+# # ============================================================================
+# #                          ANISOTROPIC MATERIAL TESTS
+# # ============================================================================
+# 
+# # 1D Anisotropic Material Tests
+# #-----------------------------------------------------------------------------
+# add_test(NAME Anisotropic_Material_1D_Thermoelastic
+#          COMMAND mast_catch_tests constant_anisotropic_thermoelastic_material_1d)
+# set_tests_properties(Anisotropic_Material_1D_Thermoelastic
+#                     PROPERTIES 
+#                     FIXTURES_REQUIRED   ConstantFieldFunction)
+#                     
+# add_test(NAME Anisotropic_Material_1D_Structural
+#          COMMAND mast_catch_tests constant_anisotropic_structural_material_1d)
+# set_tests_properties(Anisotropic_Material_1D_Structural
+#                      PROPERTIES 
+#                      FIXTURES_REQUIRED   ConstantFieldFunction)
+# 
+# add_test(NAME Anisotropic_Material_1D_Heat_Transfer
+#          COMMAND mast_catch_tests constant_anisotropic_heat_transfer_material_1d)
+# set_tests_properties(Anisotropic_Material_1D_Heat_Transfer
+#                      PROPERTIES 
+#                      FIXTURES_REQUIRED   ConstantFieldFunction)
+#                      
+# add_test(NAME Anisotropic_Material_1D_Transient_Heat_Transfer
+#          COMMAND mast_catch_tests constant_anisotropic_transient_heat_transfer_material_1d)
+# set_tests_properties(Anisotropic_Material_1D_Transient_Heat_Transfer
+#                      PROPERTIES 
+#                      FIXTURES_REQUIRED   ConstantFieldFunction)
+#          
+#          
+# # 2D Anisotropic Material Tests
+# #-----------------------------------------------------------------------------
+# add_test(NAME Anisotropic_Material_2D_Thermoelastic
+#          COMMAND mast_catch_tests constant_anisotropic_thermoelastic_material_2d)
+# set_tests_properties(Anisotropic_Material_2D_Thermoelastic
+#                     PROPERTIES 
+#                     FIXTURES_REQUIRED   ConstantFieldFunction)
+#                     
+# add_test(NAME Anisotropic_Material_2D_Structural
+#          COMMAND mast_catch_tests constant_anisotropic_structural_material_2d)
+# set_tests_properties(Anisotropic_Material_2D_Structural
+#                      PROPERTIES 
+#                      FIXTURES_REQUIRED   ConstantFieldFunction)
+# 
+# add_test(NAME Anisotropic_Material_2D_Heat_Transfer
+#          COMMAND mast_catch_tests constant_anisotropic_heat_transfer_material_2d)
+# set_tests_properties(Anisotropic_Material_2D_Heat_Transfer
+#                      PROPERTIES 
+#                      FIXTURES_REQUIRED   ConstantFieldFunction)
+#                     
+# add_test(NAME Anisotropic_Material_2D_Transient_Heat_Transfer
+#          COMMAND mast_catch_tests constant_anisotropic_transient_heat_transfer_material_2d)
+# set_tests_properties(Anisotropic_Material_2D_Transient_Heat_Transfer
+#                      PROPERTIES 
+#                      FIXTURES_REQUIRED   ConstantFieldFunction)
+#                     
+#                     
+# # 3D Anisotropic Material Tests
+# #-----------------------------------------------------------------------------
+# add_test(NAME Anisotropic_Material_3D_Thermoelastic
+#          COMMAND mast_catch_tests constant_anisotropic_thermoelastic_material_3d)
+# set_tests_properties(Anisotropic_Material_3D_Thermoelastic
+#                     PROPERTIES 
+#                     FIXTURES_REQUIRED   ConstantFieldFunction)
+# 
+# add_test(NAME Anisotropic_Material_3D_Structural
+#          COMMAND mast_catch_tests constant_anisotropic_structural_material_3d)
+# set_tests_properties(Anisotropic_Material_3D_Structural
+#                      PROPERTIES 
+#                      FIXTURES_REQUIRED  ConstantFieldFunction)
+# 
+# add_test(NAME Anisotropic_Material_3D_Heat_Transfer
+#          COMMAND mast_catch_tests constant_anisotropic_heat_transfer_material_3d)
+# set_tests_properties(Anisotropic_Material_3D_Heat_Transfer
+#                      PROPERTIES 
+#                      FIXTURES_REQUIRED  ConstantFieldFunction)
+#                      
+# add_test(NAME Anisotropic_Material_3D_Transient_Heat_Transfer
+#          COMMAND mast_catch_tests constant_anisotropic_transient_heat_transfer_material_3d)
+# set_tests_properties(Anisotropic_Material_3D_Transient_Heat_Transfer
+#                      PROPERTIES 
+#                      FIXTURES_REQUIRED   ConstantFieldFunction)
+# 
+# add_test(NAME Anisotropic_Material_3D_Dynamic
+#          COMMAND mast_catch_tests constant_anisotropic_dynamic_material_3d)
+# set_tests_properties(Anisotropic_Material_3D_Dynamic
+#                      PROPERTIES 
+#                      FIXTURES_REQUIRED  ConstantFieldFunction)
+#                      

--- a/tests/material/CMakeLists.txt
+++ b/tests/material/CMakeLists.txt
@@ -4,6 +4,11 @@ target_sources( mast_catch_tests
                 ${CMAKE_CURRENT_LIST_DIR}/mast_orthotropic_material.cpp
                 ${CMAKE_CURRENT_LIST_DIR}/mast_isotropic_material_sensitivity.cpp)
 
+# FIXME: MPI tests seem to either run very slow or hang up intermittently
+# This has occured in:
+#   FunctionSetBase_mpi - Slow
+#   Isotropic_Material_2D_Thermoelastic_mpi - Hung Up 
+#   Isotropic_Material_3D_Thermoelastic_mpi - Hung Up
                 
 # ============================================================================
 #                          ISOTROPIC MATERIAL TESTS
@@ -12,96 +17,207 @@ target_sources( mast_catch_tests
 # 1D Isotropic Material Tests
 #-----------------------------------------------------------------------------
 add_test(NAME Isotropic_Material_1D_Thermoelastic
-         COMMAND mast_catch_tests constant_isotropic_thermoelastic_material_1d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> constant_isotropic_thermoelastic_material_1d)
 set_tests_properties(Isotropic_Material_1D_Thermoelastic
                     PROPERTIES 
+                    LABELS "SEQ"
                     FIXTURES_REQUIRED   ConstantFieldFunction
                     FIXTURES_SETUP      Isotropic_Material_1D_Thermoelastic)
+                    
+add_test(NAME Isotropic_Material_1D_Thermoelastic_mpi
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_isotropic_thermoelastic_material_1d)
+set_tests_properties(Isotropic_Material_1D_Thermoelastic_mpi
+                    PROPERTIES 
+                    LABELS "MPI"
+                    FIXTURES_REQUIRED   ConstantFieldFunction_mpi
+                    FIXTURES_SETUP      Isotropic_Material_1D_Thermoelastic_mpi)
 
 add_test(NAME Isotropic_Material_1D_Structural
-         COMMAND mast_catch_tests constant_isotropic_structural_material_1d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> constant_isotropic_structural_material_1d)
 set_tests_properties(Isotropic_Material_1D_Structural
                     PROPERTIES 
+                    LABELS "SEQ"
                     FIXTURES_REQUIRED   ConstantFieldFunction
                     FIXTURES_SETUP      Isotropic_Material_1D_Structural)
+                    
+add_test(NAME Isotropic_Material_1D_Structural_mpi
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_isotropic_structural_material_1d)
+set_tests_properties(Isotropic_Material_1D_Structural_mpi
+                    PROPERTIES 
+                    LABELS "MPI"
+                    FIXTURES_REQUIRED   ConstantFieldFunction_mpi
+                    FIXTURES_SETUP      Isotropic_Material_1D_Structural_mpi)
 
 add_test(NAME Isotropic_Material_1D_Heat_Transfer
-         COMMAND mast_catch_tests constant_isotropic_heat_transfer_material_1d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> constant_isotropic_heat_transfer_material_1d)
 set_tests_properties(Isotropic_Material_1D_Heat_Transfer
                     PROPERTIES 
+                    LABELS "SEQ"
                     FIXTURES_REQUIRED   ConstantFieldFunction
                     FIXTURES_SETUP      Isotropic_Material_1D_Heat_Transfer)
                     
+add_test(NAME Isotropic_Material_1D_Heat_Transfer_mpi
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_isotropic_heat_transfer_material_1d)
+set_tests_properties(Isotropic_Material_1D_Heat_Transfer_mpi
+                    PROPERTIES 
+                    LABELS "MPI"
+                    FIXTURES_REQUIRED   ConstantFieldFunction_mpi
+                    FIXTURES_SETUP      Isotropic_Material_1D_Heat_Transfer_mpi)
+                    
 add_test(NAME Isotropic_Material_1D_Transient_Heat_Transfer
-         COMMAND mast_catch_tests constant_isotropic_transient_heat_transfer_material_1d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> constant_isotropic_transient_heat_transfer_material_1d)
 set_tests_properties(Isotropic_Material_1D_Transient_Heat_Transfer
                     PROPERTIES 
+                    LABELS "SEQ"
                     FIXTURES_REQUIRED   ConstantFieldFunction
                     FIXTURES_SETUP      Isotropic_Material_1D_Transient_Heat_Transfer)
+                    
+add_test(NAME Isotropic_Material_1D_Transient_Heat_Transfer_mpi
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_isotropic_transient_heat_transfer_material_1d)
+set_tests_properties(Isotropic_Material_1D_Transient_Heat_Transfer_mpi
+                    PROPERTIES 
+                    LABELS "MPI"
+                    FIXTURES_REQUIRED   ConstantFieldFunction_mpi
+                    FIXTURES_SETUP      Isotropic_Material_1D_Transient_Heat_Transfer_mpi)
                     
                     
 # 2D Isotropic Material Tests
 #-----------------------------------------------------------------------------
 add_test(NAME Isotropic_Material_2D_Thermoelastic
-         COMMAND mast_catch_tests constant_isotropic_thermoelastic_material_2d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> constant_isotropic_thermoelastic_material_2d)
 set_tests_properties(Isotropic_Material_2D_Thermoelastic
                     PROPERTIES 
+                    LABELS "SEQ"
                     FIXTURES_REQUIRED   ConstantFieldFunction
                     FIXTURES_SETUP      Isotropic_Material_2D_Thermoelastic)
 
+add_test(NAME Isotropic_Material_2D_Thermoelastic_mpi
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_isotropic_thermoelastic_material_2d)
+set_tests_properties(Isotropic_Material_2D_Thermoelastic_mpi
+                    PROPERTIES 
+                    LABELS "MPI"
+                    FIXTURES_REQUIRED   ConstantFieldFunction_mpi
+                    FIXTURES_SETUP      Isotropic_Material_2D_Thermoelastic_mpi)
+                    
 add_test(NAME Isotropic_Material_2D_Structural
-         COMMAND mast_catch_tests constant_isotropic_structural_material_2d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> constant_isotropic_structural_material_2d)
 set_tests_properties(Isotropic_Material_2D_Structural
                     PROPERTIES 
+                    LABELS "SEQ"
                     FIXTURES_REQUIRED   ConstantFieldFunction
                     FIXTURES_SETUP      Isotropic_Material_2D_Structural)
+                    
+add_test(NAME Isotropic_Material_2D_Structural_mpi
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_isotropic_structural_material_2d)
+set_tests_properties(Isotropic_Material_2D_Structural_mpi
+                    PROPERTIES 
+                    LABELS "MPI"
+                    FIXTURES_REQUIRED   ConstantFieldFunction_mpi
+                    FIXTURES_SETUP      Isotropic_Material_2D_Structural_mpi)
 
 add_test(NAME Isotropic_Material_2D_Heat_Transfer
-         COMMAND mast_catch_tests constant_isotropic_heat_transfer_material_2d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> constant_isotropic_heat_transfer_material_2d)
 set_tests_properties(Isotropic_Material_2D_Heat_Transfer
                      PROPERTIES 
+                     LABELS "SEQ"
                      FIXTURES_REQUIRED   ConstantFieldFunction
                      FIXTURES_SETUP      Isotropic_Material_2D_Heat_Transfer)
+                     
+add_test(NAME Isotropic_Material_2D_Heat_Transfer_mpi
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_isotropic_heat_transfer_material_2d)
+set_tests_properties(Isotropic_Material_2D_Heat_Transfer_mpi
+                     PROPERTIES 
+                     LABELS "MPI"
+                     FIXTURES_REQUIRED   ConstantFieldFunction_mpi
+                     FIXTURES_SETUP      Isotropic_Material_2D_Heat_Transfer_mpi)
                     
 add_test(NAME Isotropic_Material_2D_Transient_Heat_Transfer
-         COMMAND mast_catch_tests constant_isotropic_transient_heat_transfer_material_2d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> constant_isotropic_transient_heat_transfer_material_2d)
 set_tests_properties(Isotropic_Material_2D_Transient_Heat_Transfer
                      PROPERTIES 
+                     LABELS "SEQ"
                      FIXTURES_REQUIRED   ConstantFieldFunction
                      FIXTURES_SETUP      Isotropic_Material_2D_Transient_Heat_Transfer)
                     
+add_test(NAME Isotropic_Material_2D_Transient_Heat_Transfer_mpi
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_isotropic_transient_heat_transfer_material_2d)
+set_tests_properties(Isotropic_Material_2D_Transient_Heat_Transfer_mpi
+                     PROPERTIES 
+                     LABELS "MPI"
+                     FIXTURES_REQUIRED   ConstantFieldFunction_mpi
+                     FIXTURES_SETUP      Isotropic_Material_2D_Transient_Heat_Transfer_mpi)
                     
 # 3D Isotropic Material Tests
 #-----------------------------------------------------------------------------
 add_test(NAME Isotropic_Material_3D_Thermoelastic
-         COMMAND mast_catch_tests constant_isotropic_thermoelastic_material_3d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> constant_isotropic_thermoelastic_material_3d)
 set_tests_properties(Isotropic_Material_3D_Thermoelastic
                     PROPERTIES 
+                    LABELS "SEQ"
                     FIXTURES_REQUIRED   ConstantFieldFunction)
 
+add_test(NAME Isotropic_Material_3D_Thermoelastic_mpi
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_isotropic_thermoelastic_material_3d)
+set_tests_properties(Isotropic_Material_3D_Thermoelastic_mpi
+                    PROPERTIES 
+                    LABELS "MPI"
+                    FIXTURES_REQUIRED   ConstantFieldFunction_mpi)
+                    
 add_test(NAME Isotropic_Material_3D_Structural
-         COMMAND mast_catch_tests constant_isotropic_structural_material_3d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> constant_isotropic_structural_material_3d)
 set_tests_properties(Isotropic_Material_3D_Structural
                      PROPERTIES 
+                     LABELS "SEQ"
                      FIXTURES_REQUIRED  ConstantFieldFunction)
 
+add_test(NAME Isotropic_Material_3D_Structural_mpi
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_isotropic_structural_material_3d)
+set_tests_properties(Isotropic_Material_3D_Structural_mpi
+                     PROPERTIES 
+                     LABELS "MPI"
+                     FIXTURES_REQUIRED  ConstantFieldFunction_mpi)
+                     
 add_test(NAME Isotropic_Material_3D_Heat_Transfer
-         COMMAND mast_catch_tests constant_isotropic_heat_transfer_material_3d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> constant_isotropic_heat_transfer_material_3d)
 set_tests_properties(Isotropic_Material_3D_Heat_Transfer
                      PROPERTIES 
+                     LABELS "SEQ"
                      FIXTURES_REQUIRED  ConstantFieldFunction)
                      
+add_test(NAME Isotropic_Material_3D_Heat_Transfer_mpi
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_isotropic_heat_transfer_material_3d)
+set_tests_properties(Isotropic_Material_3D_Heat_Transfer_mpi
+                     PROPERTIES 
+                     LABELS "MPI"
+                     FIXTURES_REQUIRED  ConstantFieldFunction_mpi)
+                     
 add_test(NAME Isotropic_Material_3D_Transient_Heat_Transfer
-         COMMAND mast_catch_tests constant_isotropic_transient_heat_transfer_material_3d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> constant_isotropic_transient_heat_transfer_material_3d)
 set_tests_properties(Isotropic_Material_3D_Transient_Heat_Transfer
                      PROPERTIES 
+                     LABELS "SEQ"
                      FIXTURES_REQUIRED   ConstantFieldFunction)
 
+add_test(NAME Isotropic_Material_3D_Transient_Heat_Transfer_mpi
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_isotropic_transient_heat_transfer_material_3d)
+set_tests_properties(Isotropic_Material_3D_Transient_Heat_Transfer_mpi
+                     PROPERTIES 
+                     LABELS "MPI"
+                     FIXTURES_REQUIRED   ConstantFieldFunction_mpi)
+                     
 add_test(NAME Isotropic_Material_3D_Dynamic
-         COMMAND mast_catch_tests constant_isotropic_dynamic_material_3d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> constant_isotropic_dynamic_material_3d)
 set_tests_properties(Isotropic_Material_3D_Dynamic
                      PROPERTIES 
+                     LABELS "SEQ"
                      FIXTURES_REQUIRED  ConstantFieldFunction)
+                     
+add_test(NAME Isotropic_Material_3D_Dynamic_mpi
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_isotropic_dynamic_material_3d)
+set_tests_properties(Isotropic_Material_3D_Dynamic_mpi
+                     PROPERTIES 
+                     LABELS "MPI"
+                     FIXTURES_REQUIRED  ConstantFieldFunction_mpi)
                     
                     
 # ============================================================================
@@ -111,25 +227,25 @@ set_tests_properties(Isotropic_Material_3D_Dynamic
 # 1D Orthotropic Material Tests
 #-----------------------------------------------------------------------------
 add_test(NAME Orthotropic_Material_1D_Thermoelastic
-         COMMAND mast_catch_tests constant_orthotropic_thermoelastic_material_1d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_thermoelastic_material_1d)
 set_tests_properties(Orthotropic_Material_1D_Thermoelastic
                     PROPERTIES 
                     FIXTURES_REQUIRED   ConstantFieldFunction)
                     
 add_test(NAME Orthotropic_Material_1D_Structural
-         COMMAND mast_catch_tests constant_orthotropic_structural_material_1d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_structural_material_1d)
 set_tests_properties(Orthotropic_Material_1D_Structural
                      PROPERTIES 
                      FIXTURES_REQUIRED   ConstantFieldFunction)
 
 add_test(NAME Orthotropic_Material_1D_Heat_Transfer
-         COMMAND mast_catch_tests constant_orthotropic_heat_transfer_material_1d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_heat_transfer_material_1d)
 set_tests_properties(Orthotropic_Material_1D_Heat_Transfer
                      PROPERTIES 
                      FIXTURES_REQUIRED   ConstantFieldFunction)
                     
 add_test(NAME Orthotropic_Material_1D_Transient_Heat_Transfer
-         COMMAND mast_catch_tests constant_orthotropic_transient_heat_transfer_material_1d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_transient_heat_transfer_material_1d)
 set_tests_properties(Orthotropic_Material_1D_Transient_Heat_Transfer
                      PROPERTIES 
                      FIXTURES_REQUIRED   ConstantFieldFunction)
@@ -138,25 +254,25 @@ set_tests_properties(Orthotropic_Material_1D_Transient_Heat_Transfer
 # 2D Orthotropic Material Tests
 #-----------------------------------------------------------------------------
 add_test(NAME Orthotropic_Material_2D_Thermoelastic
-         COMMAND mast_catch_tests constant_orthotropic_thermoelastic_material_2d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_thermoelastic_material_2d)
 set_tests_properties(Orthotropic_Material_2D_Thermoelastic
                     PROPERTIES 
                     FIXTURES_REQUIRED   ConstantFieldFunction)
                     
 add_test(NAME Orthotropic_Material_2D_Structural
-         COMMAND mast_catch_tests constant_orthotropic_structural_material_2d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_structural_material_2d)
 set_tests_properties(Orthotropic_Material_2D_Structural
                      PROPERTIES 
                      FIXTURES_REQUIRED   ConstantFieldFunction)
 
 add_test(NAME Orthotropic_Material_2D_Heat_Transfer
-         COMMAND mast_catch_tests constant_orthotropic_heat_transfer_material_2d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_heat_transfer_material_2d)
 set_tests_properties(Orthotropic_Material_2D_Heat_Transfer
                      PROPERTIES 
                      FIXTURES_REQUIRED   ConstantFieldFunction)
                     
 add_test(NAME Orthotropic_Material_2D_Transient_Heat_Transfer
-         COMMAND mast_catch_tests constant_orthotropic_transient_heat_transfer_material_2d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_transient_heat_transfer_material_2d)
 set_tests_properties(Orthotropic_Material_2D_Transient_Heat_Transfer
                      PROPERTIES 
                      FIXTURES_REQUIRED   ConstantFieldFunction)
@@ -165,31 +281,31 @@ set_tests_properties(Orthotropic_Material_2D_Transient_Heat_Transfer
 # 3D Orthotropic Material Tests
 #-----------------------------------------------------------------------------
 add_test(NAME Orthotropic_Material_3D_Thermoelastic
-         COMMAND mast_catch_tests constant_orthotropic_thermoelastic_material_3d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_thermoelastic_material_3d)
 set_tests_properties(Orthotropic_Material_3D_Thermoelastic
                     PROPERTIES 
                     FIXTURES_REQUIRED   ConstantFieldFunction)
 
 add_test(NAME Orthotropic_Material_3D_Structural
-         COMMAND mast_catch_tests constant_orthotropic_structural_material_3d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_structural_material_3d)
 set_tests_properties(Orthotropic_Material_3D_Structural
                      PROPERTIES 
                      FIXTURES_REQUIRED  ConstantFieldFunction)
 
 add_test(NAME Orthotropic_Material_3D_Heat_Transfer
-         COMMAND mast_catch_tests constant_orthotropic_heat_transfer_material_3d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_heat_transfer_material_3d)
 set_tests_properties(Orthotropic_Material_3D_Heat_Transfer
                      PROPERTIES 
                      FIXTURES_REQUIRED  ConstantFieldFunction)
                      
 add_test(NAME Orthotropic_Material_3D_Transient_Heat_Transfer
-         COMMAND mast_catch_tests constant_orthotropic_transient_heat_transfer_material_3d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_transient_heat_transfer_material_3d)
 set_tests_properties(Orthotropic_Material_3D_Transient_Heat_Transfer
                      PROPERTIES 
                      FIXTURES_REQUIRED   ConstantFieldFunction)
 
 add_test(NAME Orthotropic_Material_3D_Dynamic
-         COMMAND mast_catch_tests constant_orthotropic_dynamic_material_3d)
+         COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_dynamic_material_3d)
 set_tests_properties(Orthotropic_Material_3D_Dynamic
                      PROPERTIES 
                      FIXTURES_REQUIRED  ConstantFieldFunction)
@@ -202,25 +318,25 @@ set_tests_properties(Orthotropic_Material_3D_Dynamic
 # # 1D Anisotropic Material Tests
 # #-----------------------------------------------------------------------------
 # add_test(NAME Anisotropic_Material_1D_Thermoelastic
-#          COMMAND mast_catch_tests constant_anisotropic_thermoelastic_material_1d)
+#          COMMAND $<TARGET_FILE:mast_catch_tests> constant_anisotropic_thermoelastic_material_1d)
 # set_tests_properties(Anisotropic_Material_1D_Thermoelastic
 #                     PROPERTIES 
 #                     FIXTURES_REQUIRED   ConstantFieldFunction)
 #                     
 # add_test(NAME Anisotropic_Material_1D_Structural
-#          COMMAND mast_catch_tests constant_anisotropic_structural_material_1d)
+#          COMMAND $<TARGET_FILE:mast_catch_tests> constant_anisotropic_structural_material_1d)
 # set_tests_properties(Anisotropic_Material_1D_Structural
 #                      PROPERTIES 
 #                      FIXTURES_REQUIRED   ConstantFieldFunction)
 # 
 # add_test(NAME Anisotropic_Material_1D_Heat_Transfer
-#          COMMAND mast_catch_tests constant_anisotropic_heat_transfer_material_1d)
+#          COMMAND $<TARGET_FILE:mast_catch_tests> constant_anisotropic_heat_transfer_material_1d)
 # set_tests_properties(Anisotropic_Material_1D_Heat_Transfer
 #                      PROPERTIES 
 #                      FIXTURES_REQUIRED   ConstantFieldFunction)
 #                      
 # add_test(NAME Anisotropic_Material_1D_Transient_Heat_Transfer
-#          COMMAND mast_catch_tests constant_anisotropic_transient_heat_transfer_material_1d)
+#          COMMAND $<TARGET_FILE:mast_catch_tests> constant_anisotropic_transient_heat_transfer_material_1d)
 # set_tests_properties(Anisotropic_Material_1D_Transient_Heat_Transfer
 #                      PROPERTIES 
 #                      FIXTURES_REQUIRED   ConstantFieldFunction)
@@ -229,25 +345,25 @@ set_tests_properties(Orthotropic_Material_3D_Dynamic
 # # 2D Anisotropic Material Tests
 # #-----------------------------------------------------------------------------
 # add_test(NAME Anisotropic_Material_2D_Thermoelastic
-#          COMMAND mast_catch_tests constant_anisotropic_thermoelastic_material_2d)
+#          COMMAND $<TARGET_FILE:mast_catch_tests> constant_anisotropic_thermoelastic_material_2d)
 # set_tests_properties(Anisotropic_Material_2D_Thermoelastic
 #                     PROPERTIES 
 #                     FIXTURES_REQUIRED   ConstantFieldFunction)
 #                     
 # add_test(NAME Anisotropic_Material_2D_Structural
-#          COMMAND mast_catch_tests constant_anisotropic_structural_material_2d)
+#          COMMAND $<TARGET_FILE:mast_catch_tests> constant_anisotropic_structural_material_2d)
 # set_tests_properties(Anisotropic_Material_2D_Structural
 #                      PROPERTIES 
 #                      FIXTURES_REQUIRED   ConstantFieldFunction)
 # 
 # add_test(NAME Anisotropic_Material_2D_Heat_Transfer
-#          COMMAND mast_catch_tests constant_anisotropic_heat_transfer_material_2d)
+#          COMMAND $<TARGET_FILE:mast_catch_tests> constant_anisotropic_heat_transfer_material_2d)
 # set_tests_properties(Anisotropic_Material_2D_Heat_Transfer
 #                      PROPERTIES 
 #                      FIXTURES_REQUIRED   ConstantFieldFunction)
 #                     
 # add_test(NAME Anisotropic_Material_2D_Transient_Heat_Transfer
-#          COMMAND mast_catch_tests constant_anisotropic_transient_heat_transfer_material_2d)
+#          COMMAND $<TARGET_FILE:mast_catch_tests> constant_anisotropic_transient_heat_transfer_material_2d)
 # set_tests_properties(Anisotropic_Material_2D_Transient_Heat_Transfer
 #                      PROPERTIES 
 #                      FIXTURES_REQUIRED   ConstantFieldFunction)
@@ -256,31 +372,31 @@ set_tests_properties(Orthotropic_Material_3D_Dynamic
 # # 3D Anisotropic Material Tests
 # #-----------------------------------------------------------------------------
 # add_test(NAME Anisotropic_Material_3D_Thermoelastic
-#          COMMAND mast_catch_tests constant_anisotropic_thermoelastic_material_3d)
+#          COMMAND $<TARGET_FILE:mast_catch_tests> constant_anisotropic_thermoelastic_material_3d)
 # set_tests_properties(Anisotropic_Material_3D_Thermoelastic
 #                     PROPERTIES 
 #                     FIXTURES_REQUIRED   ConstantFieldFunction)
 # 
 # add_test(NAME Anisotropic_Material_3D_Structural
-#          COMMAND mast_catch_tests constant_anisotropic_structural_material_3d)
+#          COMMAND $<TARGET_FILE:mast_catch_tests> constant_anisotropic_structural_material_3d)
 # set_tests_properties(Anisotropic_Material_3D_Structural
 #                      PROPERTIES 
 #                      FIXTURES_REQUIRED  ConstantFieldFunction)
 # 
 # add_test(NAME Anisotropic_Material_3D_Heat_Transfer
-#          COMMAND mast_catch_tests constant_anisotropic_heat_transfer_material_3d)
+#          COMMAND $<TARGET_FILE:mast_catch_tests> constant_anisotropic_heat_transfer_material_3d)
 # set_tests_properties(Anisotropic_Material_3D_Heat_Transfer
 #                      PROPERTIES 
 #                      FIXTURES_REQUIRED  ConstantFieldFunction)
 #                      
 # add_test(NAME Anisotropic_Material_3D_Transient_Heat_Transfer
-#          COMMAND mast_catch_tests constant_anisotropic_transient_heat_transfer_material_3d)
+#          COMMAND $<TARGET_FILE:mast_catch_tests> constant_anisotropic_transient_heat_transfer_material_3d)
 # set_tests_properties(Anisotropic_Material_3D_Transient_Heat_Transfer
 #                      PROPERTIES 
 #                      FIXTURES_REQUIRED   ConstantFieldFunction)
 # 
 # add_test(NAME Anisotropic_Material_3D_Dynamic
-#          COMMAND mast_catch_tests constant_anisotropic_dynamic_material_3d)
+#          COMMAND $<TARGET_FILE:mast_catch_tests> constant_anisotropic_dynamic_material_3d)
 # set_tests_properties(Anisotropic_Material_3D_Dynamic
 #                      PROPERTIES 
 #                      FIXTURES_REQUIRED  ConstantFieldFunction)

--- a/tests/material/CMakeLists.txt
+++ b/tests/material/CMakeLists.txt
@@ -230,26 +230,57 @@ add_test(NAME Orthotropic_Material_1D_Thermoelastic
          COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_thermoelastic_material_1d)
 set_tests_properties(Orthotropic_Material_1D_Thermoelastic
                     PROPERTIES 
+                    LABELS "SEQ"
                     FIXTURES_REQUIRED   ConstantFieldFunction)
+                    
+add_test(NAME Orthotropic_Material_1D_Thermoelastic_mpi
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_orthotropic_thermoelastic_material_1d)
+set_tests_properties(Orthotropic_Material_1D_Thermoelastic_mpi
+                    PROPERTIES 
+                    LABELS "MPI"
+                    FIXTURES_REQUIRED   ConstantFieldFunction_mpi)
                     
 add_test(NAME Orthotropic_Material_1D_Structural
          COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_structural_material_1d)
 set_tests_properties(Orthotropic_Material_1D_Structural
                      PROPERTIES 
+                     LABELS "SEQ"
                      FIXTURES_REQUIRED   ConstantFieldFunction)
 
+add_test(NAME Orthotropic_Material_1D_Structural_mpi
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_orthotropic_structural_material_1d)
+set_tests_properties(Orthotropic_Material_1D_Structural_mpi
+                     PROPERTIES 
+                     LABELS "MPI"
+                     FIXTURES_REQUIRED   ConstantFieldFunction_mpi)
+                     
 add_test(NAME Orthotropic_Material_1D_Heat_Transfer
          COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_heat_transfer_material_1d)
 set_tests_properties(Orthotropic_Material_1D_Heat_Transfer
                      PROPERTIES 
+                     LABELS "SEQ"
                      FIXTURES_REQUIRED   ConstantFieldFunction)
+                     
+add_test(NAME Orthotropic_Material_1D_Heat_Transfer_mpi
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_orthotropic_heat_transfer_material_1d)
+set_tests_properties(Orthotropic_Material_1D_Heat_Transfer_mpi
+                     PROPERTIES 
+                     LABELS "MPI"
+                     FIXTURES_REQUIRED   ConstantFieldFunction_mpi)
                     
 add_test(NAME Orthotropic_Material_1D_Transient_Heat_Transfer
          COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_transient_heat_transfer_material_1d)
 set_tests_properties(Orthotropic_Material_1D_Transient_Heat_Transfer
                      PROPERTIES 
+                     LABELS "SEQ"
                      FIXTURES_REQUIRED   ConstantFieldFunction)
 
+add_test(NAME Orthotropic_Material_1D_Transient_Heat_Transfer_mpi
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_orthotropic_transient_heat_transfer_material_1d)
+set_tests_properties(Orthotropic_Material_1D_Transient_Heat_Transfer_mpi
+                     PROPERTIES 
+                     LABELS "MPI"
+                     FIXTURES_REQUIRED   ConstantFieldFunction_mpi)
                      
 # 2D Orthotropic Material Tests
 #-----------------------------------------------------------------------------
@@ -257,26 +288,58 @@ add_test(NAME Orthotropic_Material_2D_Thermoelastic
          COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_thermoelastic_material_2d)
 set_tests_properties(Orthotropic_Material_2D_Thermoelastic
                     PROPERTIES 
+                    LABELS "SEQ"
                     FIXTURES_REQUIRED   ConstantFieldFunction)
+                    
+add_test(NAME Orthotropic_Material_2D_Thermoelastic_mpi
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_orthotropic_thermoelastic_material_2d)
+set_tests_properties(Orthotropic_Material_2D_Thermoelastic_mpi
+                    PROPERTIES 
+                    LABELS "MPI"
+                    FIXTURES_REQUIRED   ConstantFieldFunction_mpi)
                     
 add_test(NAME Orthotropic_Material_2D_Structural
          COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_structural_material_2d)
 set_tests_properties(Orthotropic_Material_2D_Structural
                      PROPERTIES 
+                     LABELS "SEQ"
                      FIXTURES_REQUIRED   ConstantFieldFunction)
 
+add_test(NAME Orthotropic_Material_2D_Structural_mpi
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_orthotropic_structural_material_2d)
+set_tests_properties(Orthotropic_Material_2D_Structural_mpi
+                     PROPERTIES 
+                     LABELS "MPI"
+                     FIXTURES_REQUIRED   ConstantFieldFunction_mpi)
+                     
 add_test(NAME Orthotropic_Material_2D_Heat_Transfer
          COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_heat_transfer_material_2d)
 set_tests_properties(Orthotropic_Material_2D_Heat_Transfer
                      PROPERTIES 
+                     LABELS "SEQ"
                      FIXTURES_REQUIRED   ConstantFieldFunction)
+
+add_test(NAME Orthotropic_Material_2D_Heat_Transfer_mpi
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_orthotropic_heat_transfer_material_2d)
+set_tests_properties(Orthotropic_Material_2D_Heat_Transfer_mpi
+                     PROPERTIES 
+                     LABELS "MPI"
+                     FIXTURES_REQUIRED   ConstantFieldFunction_mpi)
                     
 add_test(NAME Orthotropic_Material_2D_Transient_Heat_Transfer
          COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_transient_heat_transfer_material_2d)
 set_tests_properties(Orthotropic_Material_2D_Transient_Heat_Transfer
                      PROPERTIES 
+                     LABELS "SEQ"
                      FIXTURES_REQUIRED   ConstantFieldFunction)
 
+add_test(NAME Orthotropic_Material_2D_Transient_Heat_Transfer_mpi
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_orthotropic_transient_heat_transfer_material_2d)
+set_tests_properties(Orthotropic_Material_2D_Transient_Heat_Transfer_mpi
+                     PROPERTIES 
+                     LABELS "MPI"
+                     FIXTURES_REQUIRED   ConstantFieldFunction_mpi)
+                     
                      
 # 3D Orthotropic Material Tests
 #-----------------------------------------------------------------------------
@@ -284,32 +347,72 @@ add_test(NAME Orthotropic_Material_3D_Thermoelastic
          COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_thermoelastic_material_3d)
 set_tests_properties(Orthotropic_Material_3D_Thermoelastic
                     PROPERTIES 
+                    LABELS "SEQ"
                     FIXTURES_REQUIRED   ConstantFieldFunction)
 
+add_test(NAME Orthotropic_Material_3D_Thermoelastic_mpi
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_orthotropic_thermoelastic_material_3d)
+set_tests_properties(Orthotropic_Material_3D_Thermoelastic_mpi
+                    PROPERTIES 
+                    LABELS "MPI"
+                    FIXTURES_REQUIRED   ConstantFieldFunction_mpi)
+                    
 add_test(NAME Orthotropic_Material_3D_Structural
          COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_structural_material_3d)
 set_tests_properties(Orthotropic_Material_3D_Structural
                      PROPERTIES 
+                     LABELS "SEQ"
                      FIXTURES_REQUIRED  ConstantFieldFunction)
 
+add_test(NAME Orthotropic_Material_3D_Structural_mpi
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_orthotropic_structural_material_3d)
+set_tests_properties(Orthotropic_Material_3D_Structural_mpi
+                     PROPERTIES 
+                     LABELS "MPI"
+                     FIXTURES_REQUIRED  ConstantFieldFunction_mpi)
+                     
 add_test(NAME Orthotropic_Material_3D_Heat_Transfer
          COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_heat_transfer_material_3d)
 set_tests_properties(Orthotropic_Material_3D_Heat_Transfer
                      PROPERTIES 
+                     LABELS "SEQ"
                      FIXTURES_REQUIRED  ConstantFieldFunction)
+                     
+add_test(NAME Orthotropic_Material_3D_Heat_Transfer_mpi
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_orthotropic_heat_transfer_material_3d)
+set_tests_properties(Orthotropic_Material_3D_Heat_Transfer_mpi
+                     PROPERTIES 
+                     LABELS "MPI"
+                     FIXTURES_REQUIRED  ConstantFieldFunction_mpi)
                      
 add_test(NAME Orthotropic_Material_3D_Transient_Heat_Transfer
          COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_transient_heat_transfer_material_3d)
 set_tests_properties(Orthotropic_Material_3D_Transient_Heat_Transfer
                      PROPERTIES 
+                     LABELS "SEQ"
                      FIXTURES_REQUIRED   ConstantFieldFunction)
 
+add_test(NAME Orthotropic_Material_3D_Transient_Heat_Transfer_mpi
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_orthotropic_transient_heat_transfer_material_3d)
+set_tests_properties(Orthotropic_Material_3D_Transient_Heat_Transfer_mpi
+                     PROPERTIES 
+                     LABELS "MPI"
+                     FIXTURES_REQUIRED   ConstantFieldFunction_mpi)
+                     
 add_test(NAME Orthotropic_Material_3D_Dynamic
          COMMAND $<TARGET_FILE:mast_catch_tests> constant_orthotropic_dynamic_material_3d)
 set_tests_properties(Orthotropic_Material_3D_Dynamic
                      PROPERTIES 
+                     LABELS "SEQ"
                      FIXTURES_REQUIRED  ConstantFieldFunction)
 
+add_test(NAME Orthotropic_Material_3D_Dynamic_mpi
+         COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> constant_orthotropic_dynamic_material_3d)
+set_tests_properties(Orthotropic_Material_3D_Dynamic_mpi
+                     PROPERTIES 
+                     LABELS "MPI"
+                     FIXTURES_REQUIRED  ConstantFieldFunction_mpi)
+    
          
 # # ============================================================================
 # #                          ANISOTROPIC MATERIAL TESTS

--- a/tests/material/mast_isotropic_material.cpp
+++ b/tests/material/mast_isotropic_material.cpp
@@ -1,0 +1,880 @@
+// Catch2 includes
+#include "catch.hpp"
+
+// libMesh includes
+#include "libmesh/point.h"
+
+// MAST includes
+#include "base/parameter.h"
+#include "base/constant_field_function.h"
+#include "property_cards/isotropic_material_property_card.h"
+
+// Custom includes
+#include "test_helpers.h"
+
+// TODO: Need to test temperature dependent material property
+// TODO: Need to test stress dependent material property (plasticity)
+
+TEST_CASE("constant_isotropic_thermoelastic_material_1d",
+          "[isotropic],[material],[constant],[1D],[thermoelastic]")
+{
+    MAST::Parameter alpha("alpha_param", 5.43e-05);   // Coefficient of thermal expansion
+    MAST::ConstantFieldFunction alpha_f("alpha_expansion", alpha);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;      
+    
+    material.add(alpha_f);
+    
+    REQUIRE( material.contains("alpha_expansion") );
+    
+    SECTION("1D material thermal expansion matrix")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_texp =
+            material.thermal_expansion_matrix(1);
+            
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_texp;
+        mat_texp(point, time, D_texp);
+        
+        // Hard-coded in the true value of material thermal expansion matrix
+        RealMatrixX D_texp_true = RealMatrixX::Zero(2,1);
+        D_texp_true(0,0) = 5.43e-05;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_texp);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_texp_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("constant_isotropic_structural_material_1d", 
+          "[isotropic],[material],[constant],[1D],[structural]")
+{
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
+    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction E_f("E", E);
+    MAST::ConstantFieldFunction nu_f("nu", nu);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(E_f);                                             
+    material.add(nu_f);
+    
+    // Ensure that the material properties were added before doing other checks
+    REQUIRE( material.contains("E") );
+    REQUIRE( material.contains("nu") );
+    
+    SECTION("1D material constitutive matrix")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_stiffness = 
+            material.stiffness_matrix(1);
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D;
+        mat_stiffness(point, time, D);
+        
+        // Hard-code in the true value of the material stiffness
+        RealMatrixX D_true = RealMatrixX::Zero(2,2);
+        D_true(0,0) = 72.0e9;
+        D_true(1,1) = 2.706766917293233e+10;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("constant_isotropic_heat_transfer_material_1d", 
+          "[isotropic],[material],[1D],[heat_transfer][constant]")
+{
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter k("k_param",     237.0);             // Thermal Conductivity
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction k_f("k_th", k);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;
+    
+    // Add the material property constant field functions to the material card
+    material.add(k_f);
+    
+    // Ensure that the material properties were added before doing other checks
+    REQUIRE( material.contains("k_th") );
+    
+    SECTION("material depends on the parameters that it should")
+    {
+        CHECK( material.depends_on(k) );
+    }
+    
+    SECTION("material does not depend on other parameters")
+    {
+        MAST::Parameter dummy("dummy", 1.0);
+        CHECK_FALSE( material.depends_on(dummy) );
+    }
+    
+    SECTION("1D thermal conductivity matrix")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_conduct = 
+            material.conductance_matrix(1);
+            
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_k;
+        mat_conduct(point, time, D_k);
+        
+        // Hard-coded values for thermal conductivity matrix
+        RealMatrixX D_k_true = RealMatrixX::Identity(1,1);
+        D_k_true *= 237.0;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test = eigen_matrix_to_std_vector(D_k);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_k_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("constant_isotropic_transient_heat_transfer_material_1d", 
+          "[isotropic],[material],[1D],[heat_transfer],[constant],[transient]")
+{
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter rho("rho_param", 1234.5);            // Density
+    MAST::Parameter cp("cp_param",   908.0);             // Specific Heat Capacity
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction rho_f("rho", rho);
+    MAST::ConstantFieldFunction cp_f("cp", cp);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;
+    
+    // Add the material property constant field functions to the material card
+    material.add(rho_f);                                             
+    material.add(cp_f);
+    
+    // Ensure that the material properties were added before doing other checks
+    REQUIRE( material.contains("rho") );
+    REQUIRE( material.contains("cp") );
+    
+    SECTION("material depends on the parameters that it should")
+    {
+        CHECK( material.depends_on(rho) );
+        CHECK( material.depends_on(cp) );
+    }
+    
+    SECTION("material does not depend on other parameters")
+    {
+        MAST::Parameter dummy("dummy", 1.0);
+        CHECK_FALSE( material.depends_on(dummy) );
+    }
+    
+    SECTION("1D thermal capacitance matrix")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_capacit =
+            material.capacitance_matrix(1);
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_cp;
+        mat_capacit(point, time, D_cp);
+        
+        // Hard-coded values for thermal conductivity matrix
+        RealMatrixX D_cp_true = RealMatrixX::Identity(1,1);
+        D_cp_true *= (908.0 * 1234.5);
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test = eigen_matrix_to_std_vector(D_cp);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_cp_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("constant_isotropic_thermoelastic_material_2d", 
+          "[isotropic],[material],[2D],[thermoelastic][constant]")
+{
+    MAST::Parameter alpha("alpha_param", 5.43e-05);   // Coefficient of thermal expansion
+    MAST::ConstantFieldFunction alpha_f("alpha_expansion", alpha);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;      
+    
+    material.add(alpha_f);
+    
+    REQUIRE( material.contains("alpha_expansion") );
+    
+    SECTION("material does not depend on other parameters")
+    {
+        MAST::Parameter dummy("dummy", 1.0);
+        CHECK_FALSE( material.depends_on(dummy) );
+    }
+    
+    SECTION("2D material thermal expansion matrix")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_texp =
+            material.thermal_expansion_matrix(2);
+            
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_texp;
+        mat_texp(point, time, D_texp);
+        
+        // Hard-coded in the true value of material thermal expansion matrix
+        RealMatrixX D_texp_true = RealMatrixX::Zero(3,1);
+        D_texp_true(0,0) = 5.43e-05;
+        D_texp_true(1,0) = 5.43e-05;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_texp);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_texp_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("constant_isotropic_structural_material_2d", 
+          "[isotropic],[material],[2D],[structural],[constant]")
+{
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
+    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
+    
+    const Real G = E() / (2.0 * (1.0+nu()));
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction E_f("E", E);
+    MAST::ConstantFieldFunction nu_f("nu", nu);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(E_f);                                             
+    material.add(nu_f);
+    
+    // Ensure that the material properties were added before doing other checks
+    REQUIRE( material.contains("E") );
+    REQUIRE( material.contains("nu") );
+    
+    SECTION("material depends on the parameters that it should")
+    {
+        CHECK( material.depends_on(E) );
+        CHECK( material.depends_on(nu) );
+    }
+    
+    SECTION("material does not depend on other parameters")
+    {
+        MAST::Parameter dummy("dummy", 1.0);
+        CHECK_FALSE( material.depends_on(dummy) );
+    }
+    
+    SECTION("2D plane stress material constitutive matrix is correct")
+    {
+        const bool is_plane_stress = true;
+        const MAST::FieldFunction<RealMatrixX>& mat_stiffness = 
+            material.stiffness_matrix(2, is_plane_stress);
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX K_mat;
+        mat_stiffness(point, time, K_mat);
+        
+        // Check for symmetry
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(K_mat.transpose());
+        std::vector<double> truth = eigen_matrix_to_std_vector(K_mat);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+        
+        // Check for positive definiteness
+        SelfAdjointEigenSolver<RealMatrixX> eigensolver(K_mat);
+        if (eigensolver.info() != Success)
+        {
+            std::cout << "eigensolver failed to converge!" << std::endl;
+            REQUIRE(false); // Force test failure.
+        }
+        RealVectorX eigenvalues = eigensolver.eigenvalues();
+        for (uint i=0; i<K_mat.cols(); i++)
+        {
+            REQUIRE( eigenvalues(i) > 0.0 );
+        }
+        
+        // Hard-code in the true value of the material stiffness
+        RealMatrixX K_mat_true = RealMatrixX::Zero(3,3);
+        K_mat_true(0,0) = 8.079901245651442e+10;
+        K_mat_true(1,1) = 8.079901245651442e+10;
+        K_mat_true(0,1) = 2.666367411064976e+10;
+        K_mat_true(1,0) = 2.666367411064976e+10;
+        K_mat_true(2,2) = 2.706766917293233e+10;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        test =  eigen_matrix_to_std_vector(K_mat);
+        truth = eigen_matrix_to_std_vector(K_mat_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    SECTION("2D plane strain material constitutive matrix is correct")
+    {
+        const bool is_plane_stress = false;
+        const MAST::FieldFunction<RealMatrixX>& mat_stiffness = 
+            material.stiffness_matrix(2, is_plane_stress);
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX K_mat;
+        mat_stiffness(point, time, K_mat);
+        
+        // Check for symmetry
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(K_mat.transpose());
+        std::vector<double> truth = eigen_matrix_to_std_vector(K_mat);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+        
+        // Check for positive definiteness
+        SelfAdjointEigenSolver<RealMatrixX> eigensolver(K_mat);
+        if (eigensolver.info() != Success)
+        {
+            std::cout << "eigensolver failed to converge!" << std::endl;
+            REQUIRE(false); // Force test failure.
+        }
+        RealVectorX eigenvalues = eigensolver.eigenvalues();
+        for (uint i=0; i<K_mat.cols(); i++)
+        {
+            REQUIRE( eigenvalues(i) > 0.0 );
+        }
+        
+        // Hard-code in the true value of the material stiffness
+        RealMatrixX K_mat_true = RealMatrixX::Zero(3,3);
+        K_mat_true(0,0) = 1.066784608580274e+11;
+        K_mat_true(1,1) = 1.066784608580274e+11;
+        K_mat_true(0,1) = 0.525431225121628e+11;
+        K_mat_true(1,0) = 0.525431225121628e+11;
+        K_mat_true(2,2) = 0.270676691729323e+11;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        test =  eigen_matrix_to_std_vector(K_mat);
+        truth = eigen_matrix_to_std_vector(K_mat_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    SECTION("transverse shear material stiffness matrix")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_trans_shear =
+            material.transverse_shear_stiffness_matrix();
+            
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_trans_shear;
+        mat_trans_shear(point, time, D_trans_shear);
+        
+        // Hard-coded in the true value of the material transverse shear stiffness
+        RealMatrixX D_trans_shear_true = RealMatrixX::Zero(2,2);
+        D_trans_shear_true(0,0) = G;//2.255639097744361e+10;
+        D_trans_shear_true(1,1) = G;//2.255639097744361e+10;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test(D_trans_shear.data(), D_trans_shear.data()+D_trans_shear.rows()*D_trans_shear.cols());
+        std::vector<double> truth(D_trans_shear_true.data(), D_trans_shear_true.data()+D_trans_shear_true.rows()*D_trans_shear_true.cols());
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("constant_isotropic_heat_transfer_material_2d", 
+          "[isotropic],[material],[2D],[heat_transfer][constant]")
+{
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter k("k_param",     237.0);             // Thermal Conductivity
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction k_f("k_th", k);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;
+    
+    // Add the material property constant field functions to the material card
+    material.add(k_f);
+    
+    // Ensure that the material properties were added before doing other checks
+    REQUIRE( material.contains("k_th") );
+    
+    SECTION("material depends on the parameters that it should")
+    {
+        CHECK( material.depends_on(k) );
+    }
+    
+    SECTION("material does not depend on other parameters")
+    {
+        MAST::Parameter dummy("dummy", 1.0);
+        CHECK_FALSE( material.depends_on(dummy) );
+    }
+    
+    SECTION("2D thermal conductivity matrix")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_conduct = 
+            material.conductance_matrix(2);
+            
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_k;
+        mat_conduct(point, time, D_k);
+        
+        // Hard-coded values for thermal conductivity matrix
+        RealMatrixX D_k_true = RealMatrixX::Identity(2,2);
+        D_k_true *= 237.0;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test = eigen_matrix_to_std_vector(D_k);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_k_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("constant_isotropic_transient_heat_transfer_material_2d", 
+          "[isotropic],[material],[2D],[heat_transfer],[constant],[transient]")
+{
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter rho("rho_param", 1234.5);            // Density
+    MAST::Parameter cp("cp_param",   908.0);             // Specific Heat Capacity
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction rho_f("rho", rho);
+    MAST::ConstantFieldFunction cp_f("cp", cp);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;
+    
+    // Add the material property constant field functions to the material card
+    material.add(rho_f);                                             
+    material.add(cp_f);
+    
+    // Ensure that the material properties were added before doing other checks
+    REQUIRE( material.contains("rho") );
+    REQUIRE( material.contains("cp") );
+    
+    SECTION("material depends on the parameters that it should")
+    {
+        CHECK( material.depends_on(rho) );
+        CHECK( material.depends_on(cp) );
+    }
+    
+    SECTION("material does not depend on other parameters")
+    {
+        MAST::Parameter dummy("dummy", 1.0);
+        CHECK_FALSE( material.depends_on(dummy) );
+    }
+    
+    SECTION("2D thermal capacitance matrix")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_capacit =
+            material.capacitance_matrix(2);
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_cp;
+        mat_capacit(point, time, D_cp);
+        
+        // Hard-coded values for thermal conductivity matrix
+        RealMatrixX D_cp_true = RealMatrixX::Identity(1,1);
+        D_cp_true *= (908.0 * 1234.5);
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test = eigen_matrix_to_std_vector(D_cp);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_cp_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("constant_isotropic_thermoelastic_material_3d", 
+          "[isotropic],[material],[3D],[thermoelastic][constant]")
+{
+    MAST::Parameter alpha("alpha_param", 5.43e-05);   // Coefficient of thermal expansion
+    MAST::ConstantFieldFunction alpha_f("alpha_expansion", alpha);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;      
+    
+    material.add(alpha_f);
+    
+    REQUIRE( material.contains("alpha_expansion") );
+    
+    SECTION("material does not depend on other parameters")
+    {
+        MAST::Parameter dummy("dummy", 1.0);
+        CHECK_FALSE( material.depends_on(dummy) );
+    }
+    
+    SECTION("3D material thermal expansion matrix")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_texp =
+            material.thermal_expansion_matrix(3);
+            
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_texp;
+        mat_texp(point, time, D_texp);
+        
+        // Hard-coded in the true value of material thermal expansion matrix
+        RealMatrixX D_texp_true = RealMatrixX::Zero(6,1);
+        D_texp_true(0,0) = 5.43e-05;
+        D_texp_true(1,0) = 5.43e-05;
+        D_texp_true(2,0) = 5.43e-05;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_texp);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_texp_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("constant_isotropic_structural_material_3d", 
+          "[isotropic],[material],[3D],[structural],[constant]")
+{
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
+    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
+    
+    const Real G = E() / (2.0 * (1.0+nu()));
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction E_f("E", E);
+    MAST::ConstantFieldFunction nu_f("nu", nu);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(E_f);                                             
+    material.add(nu_f);
+    
+    // Ensure that the material properties were added before doing other checks
+    REQUIRE( material.contains("E") );
+    REQUIRE( material.contains("nu") );
+    
+    SECTION("material depends on the parameters that it should")
+    {
+        CHECK( material.depends_on(E) );
+        CHECK( material.depends_on(nu) );
+    }
+    
+    SECTION("material does not depend on other parameters")
+    {
+        MAST::Parameter dummy("dummy", 1.0);
+        CHECK_FALSE( material.depends_on(dummy) );
+    }
+    
+    SECTION("3D material constitutive matrix is correct")
+    {
+        const bool is_plane_stress = true;
+        const MAST::FieldFunction<RealMatrixX>& mat_stiffness = 
+            material.stiffness_matrix(3);
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX K_mat;
+        mat_stiffness(point, time, K_mat);
+        
+        // Check for symmetry
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(K_mat.transpose());
+        std::vector<double> truth = eigen_matrix_to_std_vector(K_mat);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+        
+        // Check for positive definiteness
+        SelfAdjointEigenSolver<RealMatrixX> eigensolver(K_mat);
+        if (eigensolver.info() != Success)
+        {
+            std::cout << "eigensolver failed to converge!" << std::endl;
+            REQUIRE(false); // Force test failure.
+        }
+        RealVectorX eigenvalues = eigensolver.eigenvalues();
+        for (uint i=0; i<K_mat.cols(); i++)
+        {
+            REQUIRE( eigenvalues(i) > 0.0 );
+        }
+        
+        // Hard-code in the true value of the material stiffness
+        RealMatrixX K_mat_true = RealMatrixX::Zero(6,6);
+        K_mat_true(0,0) = 1.066784608580274e+11;
+        K_mat_true(1,1) = 1.066784608580274e+11;
+        K_mat_true(2,2) = 1.066784608580274e+11;
+        K_mat_true(3,3) = 0.541353383458647e+11/2.;
+        K_mat_true(4,4) = 0.541353383458647e+11/2.;
+        K_mat_true(5,5) = 0.541353383458647e+11/2.;
+        
+        K_mat_true(0,1) = K_mat_true(1,0) = 0.525431225121628e+11;
+        K_mat_true(0,2) = K_mat_true(2,0) = 0.525431225121628e+11;
+        K_mat_true(1,2) = K_mat_true(2,1) = 0.525431225121628e+11;
+        
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        test =  eigen_matrix_to_std_vector(K_mat);
+        truth = eigen_matrix_to_std_vector(K_mat_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("constant_isotropic_heat_transfer_material_3d", 
+          "[isotropic],[material],[3D],[heat_transfer][constant]")
+{
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter k("k_param",     237.0);             // Thermal Conductivity
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction k_f("k_th", k);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;
+    
+    // Add the material property constant field functions to the material card
+    material.add(k_f);
+    
+    // Ensure that the material properties were added before doing other checks
+    REQUIRE( material.contains("k_th") );
+    
+    SECTION("material depends on the parameters that it should")
+    {
+        CHECK( material.depends_on(k) );
+    }
+    
+    SECTION("material does not depend on other parameters")
+    {
+        MAST::Parameter dummy("dummy", 1.0);
+        CHECK_FALSE( material.depends_on(dummy) );
+    }
+    
+    SECTION("2D thermal conductivity matrix")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_conduct = 
+            material.conductance_matrix(3);
+            
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_k;
+        mat_conduct(point, time, D_k);
+        
+        // Hard-coded values for thermal conductivity matrix
+        RealMatrixX D_k_true = RealMatrixX::Identity(3,3);
+        D_k_true *= 237.0;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test = eigen_matrix_to_std_vector(D_k);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_k_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("constant_isotropic_transient_heat_transfer_material_3d", 
+          "[isotropic],[material],[3D],[heat_transfer],[constant],[transient]")
+{
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter rho("rho_param", 1234.5);            // Density
+    MAST::Parameter cp("cp_param",   908.0);             // Specific Heat Capacity
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction rho_f("rho", rho);
+    MAST::ConstantFieldFunction cp_f("cp", cp);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;
+    
+    // Add the material property constant field functions to the material card
+    material.add(rho_f);                                             
+    material.add(cp_f);
+    
+    // Ensure that the material properties were added before doing other checks
+    REQUIRE( material.contains("rho") );
+    REQUIRE( material.contains("cp") );
+    
+    SECTION("material depends on the parameters that it should")
+    {
+        CHECK( material.depends_on(rho) );
+        CHECK( material.depends_on(cp) );
+    }
+    
+    SECTION("material does not depend on other parameters")
+    {
+        MAST::Parameter dummy("dummy", 1.0);
+        CHECK_FALSE( material.depends_on(dummy) );
+    }
+    
+    SECTION("2D thermal capacitance matrix")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_capacit =
+            material.capacitance_matrix(3);
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_cp;
+        mat_capacit(point, time, D_cp);
+        
+        // Hard-coded values for thermal conductivity matrix
+        RealMatrixX D_cp_true = RealMatrixX::Identity(1,1);
+        D_cp_true *= (908.0 * 1234.5);
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test = eigen_matrix_to_std_vector(D_cp);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_cp_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("constant_isotropic_dynamic_material_3d", 
+          "[isotropic],[material],[3D],[dynamic],[constant]")
+{
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter rho("rho_param", 1234.5);            // Density
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction rho_f("rho", rho);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;
+    
+    // Add the material property constant field functions to the material card
+    material.add(rho_f);                                             
+    
+    // Ensure that the material properties were added before doing other checks
+    REQUIRE( material.contains("rho") );
+    
+    SECTION("material depends on the parameters that it should")
+    {
+        CHECK( material.depends_on(rho) );
+    }
+    
+    SECTION("material does not depend on other parameters")
+    {
+        MAST::Parameter dummy("dummy", 1.0);
+        CHECK_FALSE( material.depends_on(dummy) );
+    }
+    
+    SECTION("3D inertia matrix")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_capacit =
+            material.inertia_matrix(3);
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_inertia;
+        mat_capacit(point, time, D_inertia);
+        
+        // Hard-coded values for thermal conductivity matrix
+        RealMatrixX D_inertia_true = RealMatrixX::Identity(3,3);
+        D_inertia_true *= 1234.5;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test = eigen_matrix_to_std_vector(D_inertia);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_inertia_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}

--- a/tests/material/mast_isotropic_material_sensitivity.cpp
+++ b/tests/material/mast_isotropic_material_sensitivity.cpp
@@ -1,0 +1,719 @@
+// Catch2 includes
+#include "catch.hpp"
+
+// libMesh includes
+#include "libmesh/point.h"
+
+// MAST includes
+#include "base/parameter.h"
+#include "base/constant_field_function.h"
+#include "property_cards/isotropic_material_property_card.h"
+
+// Custom includes
+#include "test_helpers.h"
+
+// TODO: Need to test temperature dependent material property
+// TODO: Need to test stress dependent material property (plasticity)
+// TODO: Need to test material property where field functions are not constant
+// TODO: Need to implement tests for 3D elements
+
+// TODO: Check this. May need to remove the effect of Kappa from the calculations.
+
+TEST_CASE("constant_isotropic_thermoelastic_material_1d_sensitivity",
+          "[isotropic],[material],[constant],[1D],[thermoelastic],[sensitivity]")
+{
+    MAST::Parameter alpha("alpha_param", 5.43e-05);   // Coefficient of thermal expansion
+    MAST::ConstantFieldFunction alpha_f("alpha_expansion", alpha);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;      
+    
+    material.add(alpha_f);
+    
+    REQUIRE( material.contains("alpha_expansion") );
+    
+    SECTION("1D material thermal expansion matrix derivative w.r.t. coefficient of thermal expansion")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_texp =
+            material.thermal_expansion_matrix(1);
+            
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX dD_texp;
+        mat_texp.derivative(alpha, point, time, dD_texp);
+        
+        // Hard-coded in the true value of material thermal expansion matrix
+        RealMatrixX dD_texp_true = RealMatrixX::Zero(2,1);
+        dD_texp_true(0,0) = 1.0;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(dD_texp);
+        std::vector<double> truth = eigen_matrix_to_std_vector(dD_texp_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("constant_isotropic_structural_material_1d_sensitivity", 
+          "[isotropic],[material],[constant],[1D],[structural],[sensitivity]")
+{
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
+    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
+    MAST::Parameter kappa("kappa_param", 5.0/6.0);    // Shear coefficient
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction E_f("E", E);
+    MAST::ConstantFieldFunction nu_f("nu", nu);
+    MAST::ConstantFieldFunction kappa_f("kappa", kappa);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(E_f);                                             
+    material.add(nu_f);
+    material.add(kappa_f);
+    
+    // Ensure that the material properties were added before doing other checks
+    REQUIRE( material.contains("E") );
+    REQUIRE( material.contains("nu") );
+    REQUIRE( material.contains("kappa") );
+    
+    SECTION("1D material constitutive matrix derivative w.r.t. elastic modulus")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_stiffness = 
+            material.stiffness_matrix(1);
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX dD;
+        mat_stiffness.derivative(E, point, time, dD);
+        
+        // Hard-code in the true value of the material stiffness
+        RealMatrixX dD_true = RealMatrixX::Zero(2,2);
+        dD_true(0,0) = 1.0;
+        dD_true(1,1) = 0.375939849624060;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(dD);
+        std::vector<double> truth = eigen_matrix_to_std_vector(dD_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    SECTION("1D material constitutive matrix derivative w.r.t. poisson's ratio")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_stiffness = 
+            material.stiffness_matrix(1);
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX dD;
+        mat_stiffness.derivative(nu, point, time, dD);
+        
+        // Hard-code in the true value of the material stiffness
+        RealMatrixX dD_true = RealMatrixX::Zero(2,2);
+        dD_true(0,0) = 0.0;
+        dD_true(1,1) = -0.203516309570920e+11;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(dD);
+        std::vector<double> truth = eigen_matrix_to_std_vector(dD_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("constant_isotropic_heat_transfer_material_1d_sensitivity", 
+          "[isotropic],[material],[1D],[heat_transfer],[constant],[sensitivity]")
+{
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter k("k_param",     237.0);             // Thermal Conductivity
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction k_f("k_th", k);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;
+    
+    // Add the material property constant field functions to the material card
+    material.add(k_f);
+    
+    // Ensure that the material properties were added before doing other checks
+    REQUIRE( material.contains("k_th") );
+    
+    SECTION("material depends on the parameters that it should")
+    {
+        CHECK( material.depends_on(k) );
+    }
+    
+    SECTION("material does not depend on other parameters")
+    {
+        MAST::Parameter dummy("dummy", 1.0);
+        CHECK_FALSE( material.depends_on(dummy) );
+    }
+    
+    SECTION("1D thermal conductivity matrix derivative w.r.t. thermal conductivity")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_conduct = 
+            material.conductance_matrix(1);
+            
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX dD_k;
+        mat_conduct.derivative(k, point, time, dD_k);
+        
+        // Hard-coded values for thermal conductivity matrix
+        RealMatrixX dD_k_true = RealMatrixX::Identity(1,1);
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test = eigen_matrix_to_std_vector(dD_k);
+        std::vector<double> truth = eigen_matrix_to_std_vector(dD_k_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("constant_isotropic_transient_heat_transfer_material_1d_sensitivity", 
+          "[isotropic],[material],[1D],[heat_transfer],[constant],[transient],[sensitivity]")
+{
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter rho("rho_param", 1234.5);            // Density
+    MAST::Parameter cp("cp_param",   908.0);             // Specific Heat Capacity
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction rho_f("rho", rho);
+    MAST::ConstantFieldFunction cp_f("cp", cp);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;
+    
+    // Add the material property constant field functions to the material card
+    material.add(rho_f);                                             
+    material.add(cp_f);
+    
+    // Ensure that the material properties were added before doing other checks
+    REQUIRE( material.contains("rho") );
+    REQUIRE( material.contains("cp") );
+    
+    SECTION("material depends on the parameters that it should")
+    {
+        CHECK( material.depends_on(rho) );
+        CHECK( material.depends_on(cp) );
+    }
+    
+    SECTION("material does not depend on other parameters")
+    {
+        MAST::Parameter dummy("dummy", 1.0);
+        CHECK_FALSE( material.depends_on(dummy) );
+    }
+    
+    SECTION("1D thermal capacitance matrix derivative w.r.t. specifc heat capacity")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_capacit =
+            material.capacitance_matrix(1);
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX dD_cp;
+        mat_capacit.derivative(cp, point, time, dD_cp);
+        
+        // Hard-coded values for thermal conductivity matrix
+        RealMatrixX dD_cp_true = RealMatrixX::Identity(1,1);
+        dD_cp_true *= 1234.5;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test = eigen_matrix_to_std_vector(dD_cp);
+        std::vector<double> truth = eigen_matrix_to_std_vector(dD_cp_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("constant_isotropic_thermoelastic_material_2d_sensitivity", 
+          "[isotropic],[material],[2D],[thermoelastic],[constant],[sensitivity]")
+{
+    MAST::Parameter alpha("alpha_param", 5.43e-05);   // Coefficient of thermal expansion
+    MAST::ConstantFieldFunction alpha_f("alpha_expansion", alpha);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;      
+    
+    material.add(alpha_f);
+    
+    REQUIRE( material.contains("alpha_expansion") );
+    
+    SECTION("material does not depend on other parameters")
+    {
+        MAST::Parameter dummy("dummy", 1.0);
+        CHECK_FALSE( material.depends_on(dummy) );
+    }
+    
+    SECTION("2D material thermal expansion matrix derivative w.r.t. coefficient of thermal expansion")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_texp =
+            material.thermal_expansion_matrix(2);
+            
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX dD_texp;
+        mat_texp.derivative(alpha, point, time, dD_texp);
+        
+        // Hard-coded in the true value of material thermal expansion matrix
+        RealMatrixX dD_texp_true = RealMatrixX::Zero(3,1);
+        dD_texp_true(0,0) = 1.0;
+        dD_texp_true(1,0) = 1.0;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(dD_texp);
+        std::vector<double> truth = eigen_matrix_to_std_vector(dD_texp_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("constant_isotropic_structural_material_2d_sensitivity", 
+          "[isotropic],[material],[2D],[structural],[constant],[sensitivity]")
+{
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
+    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
+    MAST::Parameter kappa("kappa_param", 5.0/6.0);    // Shear coefficient
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction E_f("E", E);
+    MAST::ConstantFieldFunction nu_f("nu", nu);
+    MAST::ConstantFieldFunction kappa_f("kappa", kappa);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(E_f);                                             
+    material.add(nu_f);
+    material.add(kappa_f);
+    
+    // Ensure that the material properties were added before doing other checks
+    REQUIRE( material.contains("E") );
+    REQUIRE( material.contains("nu") );
+    REQUIRE( material.contains("kappa") );
+    
+    SECTION("material depends on the parameters that it should")
+    {
+        CHECK( material.depends_on(E) );
+        CHECK( material.depends_on(nu) );
+        CHECK( material.depends_on(kappa) );
+    }
+    
+    SECTION("material does not depend on other parameters")
+    {
+        MAST::Parameter dummy("dummy", 1.0);
+        CHECK_FALSE( material.depends_on(dummy) );
+    }
+    
+    SECTION("2D plane stress material constitutive matrix derivative w.r.t. elastic modulus is correct")
+    {
+        const bool is_plane_stress = true;
+        const MAST::FieldFunction<RealMatrixX>& mat_stiffness = 
+            material.stiffness_matrix(2, is_plane_stress);
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX dK_mat;
+        mat_stiffness.derivative(E, point, time, dK_mat);
+        
+        // Hard-code in the true value of the material stiffness
+        RealMatrixX dK_mat_true = RealMatrixX::Zero(3,3);
+        dK_mat_true(0,0) = 1.122208506340478;
+        dK_mat_true(1,1) = 1.122208506340478;
+        dK_mat_true(0,1) = 0.370328807092358;
+        dK_mat_true(1,0) = 0.370328807092358;
+        dK_mat_true(2,2) = 0.375939849624060;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test(dK_mat.data(), dK_mat.data()+dK_mat.rows()*dK_mat.cols());
+        std::vector<double> truth(dK_mat_true.data(), dK_mat_true.data()+dK_mat_true.rows()*dK_mat_true.cols());
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    
+    SECTION("2D plane stress material constitutive matrix derivative w.r.t. poisson's ratio is correct")
+    {
+        const bool is_plane_stress = true;
+        const MAST::FieldFunction<RealMatrixX>& mat_stiffness = 
+            material.stiffness_matrix(2, is_plane_stress);
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX dK_mat;
+        mat_stiffness.derivative(nu, point, time, dK_mat);
+        
+        // Hard-code in the true value of the material stiffness
+        RealMatrixX dK_mat_true = RealMatrixX::Zero(3,3);
+        dK_mat_true(0,0) = 0.598444037945231e+11;
+        dK_mat_true(1,1) = 0.598444037945231e+11;
+        dK_mat_true(0,1) = 1.005476657087070e+11;
+        dK_mat_true(1,0) = 1.005476657087070e+11;
+        dK_mat_true(2,2) = -0.203516309570920e+11;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test(dK_mat.data(), dK_mat.data()+dK_mat.rows()*dK_mat.cols());
+        std::vector<double> truth(dK_mat_true.data(), dK_mat_true.data()+dK_mat_true.rows()*dK_mat_true.cols());
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    SECTION("2D plane strain material constitutive matrix derivative w.r.t. elastic modulus is correct")
+    {
+        const bool is_plane_stress = false;
+        const MAST::FieldFunction<RealMatrixX>& mat_stiffness = 
+            material.stiffness_matrix(2, is_plane_stress);
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX dK_mat;
+        mat_stiffness.derivative(E, point, time, dK_mat);
+        
+//         // 4th order central finite difference approximation
+//         RealMatrixX K_mat_h, K_mat_h2, K_mat_n, K_mat_n2;
+//         Real delta = 1e9;
+//         const Real E0 = E();
+//         
+//         E = E0 + delta;
+//         mat_stiffness.derivative(E, point, time, K_mat_h);
+//         
+//         E = E0 + 2.0*delta;
+//         mat_stiffness.derivative(E, point, time, K_mat_h2);
+//         
+//         E = E0 - delta;
+//         mat_stiffness.derivative(E, point, time, K_mat_n);
+//         
+//         E = E0 - 2.0*delta;
+//         mat_stiffness.derivative(E, point, time, K_mat_n2);
+//         
+//         E = E0;
+//         
+//         RealMatrixX dK_mat_true = (K_mat_n2 - 8.0*K_mat_n + 8.0*K_mat_h - K_mat_h2)/(12.0*delta);
+        
+        // Hard-code in the true value of the material stiffness
+        RealMatrixX dK_mat_true = RealMatrixX::Zero(3,3);
+        dK_mat_true(0,0) = 1.481645289694825;
+        dK_mat_true(1,1) = 1.481645289694825;
+        dK_mat_true(0,1) = 0.729765590446705;
+        dK_mat_true(1,0) = 0.729765590446705;
+        dK_mat_true(2,2) = 0.375939849624060;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test(dK_mat.data(), dK_mat.data()+dK_mat.rows()*dK_mat.cols());
+        std::vector<double> truth(dK_mat_true.data(), dK_mat_true.data()+dK_mat_true.rows()*dK_mat_true.cols());
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    SECTION("2D plane strain material constitutive matrix derivative w.r.t. poisson's ratio is correct")
+    {
+        const bool is_plane_stress = false;
+        const MAST::FieldFunction<RealMatrixX>& mat_stiffness = 
+            material.stiffness_matrix(2, is_plane_stress);
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX dK_mat;
+        mat_stiffness.derivative(nu, point, time, dK_mat);
+        
+        // Hard-code in the true value of the material stiffness
+        RealMatrixX dK_mat_true = RealMatrixX::Zero(3,3);
+        dK_mat_true(0,0) = 3.880894055520205e+11;
+        dK_mat_true(1,1) = 3.880894055520205e+11;
+        dK_mat_true(0,1) = 4.287926674662045e+11;
+        dK_mat_true(1,0) = 4.287926674662045e+11;
+        dK_mat_true(2,2) = -0.203516309570920e+11;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test(dK_mat.data(), dK_mat.data()+dK_mat.rows()*dK_mat.cols());
+        std::vector<double> truth(dK_mat_true.data(), dK_mat_true.data()+dK_mat_true.rows()*dK_mat_true.cols());
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    SECTION("transverse shear material stiffness matrix derivative w.r.t. elastic modulus")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_trans_shear =
+            material.transverse_shear_stiffness_matrix();
+            
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX dD_trans_shear;
+        mat_trans_shear.derivative(E, point, time, dD_trans_shear);
+        
+        // Hard-coded in the true value of the material transverse shear stiffness
+        RealMatrixX dD_trans_shear_true = RealMatrixX::Zero(2,2);
+        dD_trans_shear_true(0,0) = 0.313283208020050;
+        dD_trans_shear_true(1,1) = 0.313283208020050;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test(dD_trans_shear.data(), dD_trans_shear.data()+dD_trans_shear.rows()*dD_trans_shear.cols());
+        std::vector<double> truth(dD_trans_shear_true.data(), dD_trans_shear_true.data()+dD_trans_shear_true.rows()*dD_trans_shear_true.cols());
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    SECTION("transverse shear material stiffness matrix derivative w.r.t. poisson's ratio")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_trans_shear =
+            material.transverse_shear_stiffness_matrix();
+            
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX dD_trans_shear;
+        mat_trans_shear.derivative(nu, point, time, dD_trans_shear);
+        
+        // Hard-coded in the true value of the material transverse shear stiffness
+        RealMatrixX dD_trans_shear_true = RealMatrixX::Zero(2,2);
+        dD_trans_shear_true(0,0) = -1.695969246424331e+10;
+        dD_trans_shear_true(1,1) = -1.695969246424331e+10;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test(dD_trans_shear.data(), dD_trans_shear.data()+dD_trans_shear.rows()*dD_trans_shear.cols());
+        std::vector<double> truth(dD_trans_shear_true.data(), dD_trans_shear_true.data()+dD_trans_shear_true.rows()*dD_trans_shear_true.cols());
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    SECTION("transverse shear material stiffness matrix derivative w.r.t. shear coefficient")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_trans_shear =
+            material.transverse_shear_stiffness_matrix();
+            
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX dD_trans_shear;
+        mat_trans_shear.derivative(kappa, point, time, dD_trans_shear);
+        
+        // Hard-coded in the true value of the material transverse shear stiffness
+        RealMatrixX dD_trans_shear_true = RealMatrixX::Zero(2,2);
+        dD_trans_shear_true(0,0) = 2.706766917293233e+10;
+        dD_trans_shear_true(1,1) = 2.706766917293233e+10;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(dD_trans_shear);
+        std::vector<double> truth = eigen_matrix_to_std_vector(dD_trans_shear_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("constant_isotropic_transient_heat_transfer_material_2d_sensitivity",
+          "[isotropic],[material],[2D],[heat_transfer],[constant],[sensitivity],[transient]")
+{
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter rho("rho_param", 1234.5);            // Density
+    MAST::Parameter cp("cp_param",   908.0);             // Specific Heat Capacity
+    MAST::Parameter k("k_param",     237.0);             // Thermal Conductivity
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction rho_f("rho", rho);
+    MAST::ConstantFieldFunction cp_f("cp", cp);
+    MAST::ConstantFieldFunction k_f("k_th", k);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;
+    
+    // Add the material property constant field functions to the material card
+    material.add(rho_f);                                             
+    material.add(cp_f);
+    material.add(k_f);
+    
+    // Ensure that the material properties were added before doing other checks
+    REQUIRE( material.contains("rho") );
+    REQUIRE( material.contains("cp") );
+    REQUIRE( material.contains("k_th") );
+    
+    SECTION("material depends on the parameters that it should")
+    {
+        CHECK( material.depends_on(rho) );
+        CHECK( material.depends_on(cp) );
+        CHECK( material.depends_on(k) );
+    }
+    
+    SECTION("material does not depend on other parameters")
+    {
+        MAST::Parameter dummy("dummy", 1.0);
+        CHECK_FALSE( material.depends_on(dummy) );
+    }
+    
+    SECTION("2D thermal capacitance matrix derivative w.r.t. specifc heat capacity")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_capacit =
+            material.capacitance_matrix(2);
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX dD_cp;
+        mat_capacit.derivative(cp, point, time, dD_cp);
+        
+        // Hard-coded values for thermal conductivity matrix
+        RealMatrixX dD_cp_true = RealMatrixX::Identity(1,1);
+        dD_cp_true *= 1234.5;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test = eigen_matrix_to_std_vector(dD_cp);
+        std::vector<double> truth = eigen_matrix_to_std_vector(dD_cp_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    SECTION("2D thermal capacitance matrix derivative w.r.t. density")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_capacit =
+            material.capacitance_matrix(2);
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX dD_cp;
+        mat_capacit.derivative(rho, point, time, dD_cp);
+        
+        // Hard-coded values for thermal conductivity matrix
+        RealMatrixX dD_cp_true = RealMatrixX::Identity(1,1);
+        dD_cp_true *= 908.0;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test = eigen_matrix_to_std_vector(dD_cp);
+        std::vector<double> truth = eigen_matrix_to_std_vector(dD_cp_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("constant_isotropic_heat_transfer_material_2d_sensitivity", 
+          "[isotropic],[material],[2D],[heat_transfer][constant],[sensitivity]")
+{
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter rho("rho_param", 1234.5);            // Density
+    MAST::Parameter cp("cp_param",   908.0);             // Specific Heat Capacity
+    MAST::Parameter k("k_param",     237.0);             // Thermal Conductivity
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction rho_f("rho", rho);
+    MAST::ConstantFieldFunction cp_f("cp", cp);
+    MAST::ConstantFieldFunction k_f("k_th", k);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;
+    
+    // Add the material property constant field functions to the material card
+    material.add(rho_f);                                             
+    material.add(cp_f);
+    material.add(k_f);
+    
+    // Ensure that the material properties were added before doing other checks
+    REQUIRE( material.contains("rho") );
+    REQUIRE( material.contains("cp") );
+    REQUIRE( material.contains("k_th") );
+    
+    SECTION("material depends on the parameters that it should")
+    {
+        CHECK( material.depends_on(rho) );
+        CHECK( material.depends_on(cp) );
+        CHECK( material.depends_on(k) );
+    }
+    
+    SECTION("material does not depend on other parameters")
+    {
+        MAST::Parameter dummy("dummy", 1.0);
+        CHECK_FALSE( material.depends_on(dummy) );
+    }
+    
+    SECTION("2D thermal conductivity matrix derivative w.r.t. thermal conductivity")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_conduct = 
+            material.conductance_matrix(2);
+            
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX dD_k;
+        mat_conduct.derivative(k, point, time, dD_k);
+        
+        // Hard-coded values for thermal conductivity matrix
+        RealMatrixX dD_k_true = RealMatrixX::Identity(2,2);
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test = eigen_matrix_to_std_vector(dD_k);
+        std::vector<double> truth = eigen_matrix_to_std_vector(dD_k_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}

--- a/tests/material/mast_orthotropic_material.cpp
+++ b/tests/material/mast_orthotropic_material.cpp
@@ -1,0 +1,969 @@
+// Catch2 includes
+#include "catch.hpp"
+
+// libMesh includes
+#include "libmesh/point.h"
+
+// MAST includes
+#include "base/parameter.h"
+#include "base/constant_field_function.h"
+#include "property_cards/orthotropic_material_property_card.h"
+
+// Custom includes
+#include "test_helpers.h"
+
+// TODO: Need to test temperature dependent material property
+// TODO: Need to test stress dependent material property (plasticity)
+// TODO: Need to test material property where field functions are not constant
+// TODO: Need to implement tests for 3D elements
+
+
+TEST_CASE("constant_orthotropic_thermoelastic_material_1d",
+          "[orthotropic],[material],[constant],[1D],[thermoelastic]")
+{
+    MAST::Parameter alpha11("alpha11_param", 5.43e-05);   // Coefficient of thermal expansion
+    MAST::ConstantFieldFunction alpha11_f("alpha11_expansion", alpha11);
+    
+    // Initialize the material
+    MAST::OrthotropicMaterialPropertyCard material;      
+    
+    material.add(alpha11_f);
+    
+    REQUIRE( material.contains("alpha11_expansion") );
+    
+    SECTION("1D material thermal expansion matrix")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_texp =
+            material.thermal_expansion_matrix(1);
+            
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_texp;
+        mat_texp(point, time, D_texp);
+        
+        // Hard-coded in the true value of material thermal expansion matrix
+        RealMatrixX D_texp_true = RealMatrixX::Zero(2,1);
+        D_texp_true(0,0) = 5.43e-05;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_texp);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_texp_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("constant_orthotropic_structural_material_1d", 
+          "[orthotropic],[material],[constant],[1D],[structural]")
+{
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter E11("E11_param", 72.0e9);   // Modulus of Elasticity
+    MAST::Parameter G12("G12_param", 68.3e9);   // Shear Modulus
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction E11_f("E11", E11);
+    MAST::ConstantFieldFunction G12_f("G12", G12);
+    
+    // Initialize the material
+    MAST::OrthotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(E11_f);    
+    material.add(G12_f);    
+
+    
+    // Ensure that the material properties were added before doing other checks
+    REQUIRE( material.contains("E11") );
+    REQUIRE( material.contains("G12") );
+    
+    SECTION("1D material constitutive matrix")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_stiffness = 
+            material.stiffness_matrix(1);
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D;
+        mat_stiffness(point, time, D);
+        
+        // Hard-code in the true value of the material stiffness
+        RealMatrixX D_true = RealMatrixX::Zero(2,2);
+        D_true(0,0) = 72.0e9;
+        D_true(1,1) = 68.3e9;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("constant_orthotropic_heat_transfer_material_1d", 
+          "[orthotropic],[material],[1D],[heat_transfer][constant]")
+{
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter k11("k11_param",     237.0);     // Thermal Conductivity
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction k11_f("k11_th", k11);
+    
+    // Initialize the material
+    MAST::OrthotropicMaterialPropertyCard material;
+    
+    // Add the material property constant field functions to the material card
+    material.add(k11_f);
+    
+    // Ensure that the material properties were added before doing other checks
+    REQUIRE( material.contains("k11_th") );
+    
+    SECTION("material depends on the parameters that it should")
+    {
+        CHECK( material.depends_on(k11) );
+    }
+    
+    SECTION("material does not depend on other parameters")
+    {
+        MAST::Parameter dummy("dummy", 1.0);
+        CHECK_FALSE( material.depends_on(dummy) );
+    }
+    
+    SECTION("1D thermal conductivity matrix")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_conduct = 
+            material.conductance_matrix(1);
+            
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_k;
+        mat_conduct(point, time, D_k);
+        
+        // Hard-coded values for thermal conductivity matrix
+        RealMatrixX D_k_true = RealMatrixX::Identity(1,1);
+        D_k_true *= 237.0;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test = eigen_matrix_to_std_vector(D_k);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_k_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("constant_orthotropic_transient_heat_transfer_material_1d", 
+          "[orthotropic],[material],[1D],[heat_transfer],[constant],[transient]")
+{
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter rho("rho_param", 1234.5);            // Density
+    MAST::Parameter cp("cp_param",   908.0);             // Specific Heat Capacity
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction rho_f("rho", rho);
+    MAST::ConstantFieldFunction cp_f("cp", cp);
+    
+    // Initialize the material
+    MAST::OrthotropicMaterialPropertyCard material;
+    
+    // Add the material property constant field functions to the material card
+    material.add(rho_f);                                             
+    material.add(cp_f);
+    
+    // Ensure that the material properties were added before doing other checks
+    REQUIRE( material.contains("rho") );
+    REQUIRE( material.contains("cp") );
+    
+    SECTION("material depends on the parameters that it should")
+    {
+        CHECK( material.depends_on(rho) );
+        CHECK( material.depends_on(cp) );
+    }
+    
+    SECTION("material does not depend on other parameters")
+    {
+        MAST::Parameter dummy("dummy", 1.0);
+        CHECK_FALSE( material.depends_on(dummy) );
+    }
+    
+    SECTION("1D thermal capacitance matrix")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_capacit =
+            material.capacitance_matrix(1);
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_cp;
+        mat_capacit(point, time, D_cp);
+        
+        // Hard-coded values for thermal conductivity matrix
+        RealMatrixX D_cp_true = RealMatrixX::Identity(1,1);
+        D_cp_true *= (908.0 * 1234.5);
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test = eigen_matrix_to_std_vector(D_cp);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_cp_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("constant_orthotropic_thermoelastic_material_2d", 
+          "[orthotropic],[material],[2D],[thermoelastic][constant]")
+{
+    MAST::Parameter alpha11("alpha11_param", 5.43e-05);   // Coefficient of thermal expansion
+    MAST::Parameter alpha22("alpha22_param", 8.79e-06);   // Coefficient of thermal expansion
+    
+    MAST::ConstantFieldFunction alpha11_f("alpha11_expansion", alpha11);
+    MAST::ConstantFieldFunction alpha22_f("alpha22_expansion", alpha22);
+    
+    // Initialize the material
+    MAST::OrthotropicMaterialPropertyCard material;      
+    
+    material.add(alpha11_f);
+    material.add(alpha22_f);
+    
+    REQUIRE( material.contains("alpha11_expansion") );
+    REQUIRE( material.contains("alpha22_expansion") );
+    
+    SECTION("material does not depend on other parameters")
+    {
+        MAST::Parameter dummy("dummy", 1.0);
+        CHECK_FALSE( material.depends_on(dummy) );
+    }
+    
+    SECTION("2D material thermal expansion matrix")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_texp =
+            material.thermal_expansion_matrix(2);
+            
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_texp;
+        mat_texp(point, time, D_texp);
+        
+        // Hard-coded in the true value of material thermal expansion matrix
+        RealMatrixX D_texp_true = RealMatrixX::Zero(3,1);
+        D_texp_true(0,0) = 5.43e-05;
+        D_texp_true(1,0) = 8.79e-06;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_texp);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_texp_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("constant_orthotropic_structural_material_2d", 
+          "[orthotropic],[material],[2D],[structural],[constant]")
+{
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter E11("E11", 72.0e9);             // Modulus of Elasticity
+    MAST::Parameter E22("E22", 55.0e9);           
+    MAST::Parameter E33("E33", 33.4e9);
+    MAST::Parameter nu12("nu12", 0.33);             // Poisson's ratio
+    MAST::Parameter nu23("nu23", 0.25);
+    MAST::Parameter nu31("nu31", 0.45);
+    MAST::Parameter G12("G12", 68.3e9);
+        
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction E11_f("E11", E11);
+    MAST::ConstantFieldFunction E22_f("E22", E22);
+    MAST::ConstantFieldFunction E33_f("E33", E33);
+    MAST::ConstantFieldFunction nu12_f("nu12", nu12);
+    MAST::ConstantFieldFunction nu23_f("nu23", nu23);
+    MAST::ConstantFieldFunction nu31_f("nu31", nu31);
+    MAST::ConstantFieldFunction G12_f("G12", G12);
+    
+    // Initialize the material
+    MAST::OrthotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(E11_f);         
+    material.add(E22_f);
+    material.add(E33_f);
+    material.add(nu12_f);
+    material.add(nu23_f);
+    material.add(nu31_f);
+    material.add(G12_f);
+    
+    // Ensure that the material properties were added before doing other checks
+    REQUIRE( material.contains("E11") );
+    REQUIRE( material.contains("E22") );
+    REQUIRE( material.contains("E33") );
+    REQUIRE( material.contains("nu12") );
+    REQUIRE( material.contains("nu23") );
+    REQUIRE( material.contains("nu31") );
+    REQUIRE( material.contains("G12") );
+    
+    SECTION("material depends on the parameters that it should")
+    {
+        CHECK( material.depends_on(E11) );
+        CHECK( material.depends_on(E22) );
+        CHECK( material.depends_on(E33) );
+        CHECK( material.depends_on(nu12) );
+        CHECK( material.depends_on(nu23) );
+        CHECK( material.depends_on(nu31) );
+        CHECK( material.depends_on(G12) );
+    }
+    
+    SECTION("material does not depend on other parameters")
+    {
+        MAST::Parameter dummy("dummy", 1.0);
+        CHECK_FALSE( material.depends_on(dummy) );
+    }
+    
+    SECTION("2D plane stress material constitutive matrix")
+    {
+        const bool is_plane_stress = true;
+        const MAST::FieldFunction<RealMatrixX>& mat_stiffness = 
+            material.stiffness_matrix(2, is_plane_stress);
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX K_mat;
+        mat_stiffness(point, time, K_mat);
+        
+        // Check for symmetry
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(K_mat.transpose());
+        std::vector<double> truth = eigen_matrix_to_std_vector(K_mat);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+        
+        // Check for positive definiteness
+        SelfAdjointEigenSolver<RealMatrixX> eigensolver(K_mat);
+        if (eigensolver.info() != Success)
+        {
+            std::cout << "eigensolver failed to converge!" << std::endl;
+            REQUIRE(false); // Force test failure.
+        }
+        RealVectorX eigenvalues = eigensolver.eigenvalues();
+        for (uint i=0; i<K_mat.cols(); i++)
+        {
+            REQUIRE( eigenvalues(i) > 0.0 );
+        }
+        
+        // Hard-code in the true value of the material stiffness
+        RealMatrixX K_mat_true = RealMatrixX::Zero(3,3);
+        K_mat_true(0,0) = 7.853296066534869e+10;
+        K_mat_true(1,1) = 5.999045606380803e+10;
+        K_mat_true(2,2) = 6.830000000000000e+10;
+        K_mat_true(0,1) = K_mat_true(1,0) =1.979685050105665e+10;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        test =  eigen_matrix_to_std_vector(K_mat);
+        truth = eigen_matrix_to_std_vector(K_mat_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    SECTION("2D plane strain material constitutive matrix")
+    {
+        const bool is_plane_stress = false;
+        const MAST::FieldFunction<RealMatrixX>& mat_stiffness = 
+            material.stiffness_matrix(2, is_plane_stress);
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX K_mat;
+        mat_stiffness(point, time, K_mat);
+        
+        // Check for symmetry
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(K_mat.transpose());
+        std::vector<double> truth = eigen_matrix_to_std_vector(K_mat);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+        
+        // Check for positive definiteness
+        SelfAdjointEigenSolver<RealMatrixX> eigensolver(K_mat);
+        if (eigensolver.info() != Success)
+        {
+            std::cout << "eigensolver failed to converge!" << std::endl;
+            REQUIRE(false); // Force test failure.
+        }
+        RealVectorX eigenvalues = eigensolver.eigenvalues();
+        for (uint i=0; i<K_mat.cols(); i++)
+        {
+            REQUIRE( eigenvalues(i) > 0.0 );
+        }
+        
+        // Hard-code in the true value of the material stiffness
+        RealMatrixX K_mat_true = RealMatrixX::Zero(3,3);
+        K_mat_true(0,0) = 1.881848591463047e11;
+        K_mat_true(1,1) = 0.841961884847417e11;
+        K_mat_true(2,2) = 0.683000000000000e11;
+        K_mat_true(0,1) = K_mat_true(1,0) = 0.713158228712175e11;        
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        test =  eigen_matrix_to_std_vector(K_mat);
+        truth = eigen_matrix_to_std_vector(K_mat_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    SECTION("transverse shear material stiffness matrix")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_trans_shear =
+            material.transverse_shear_stiffness_matrix();
+            
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_trans_shear;
+        mat_trans_shear(point, time, D_trans_shear);
+        
+        // Hard-coded in the true value of the material transverse shear stiffness
+        RealMatrixX D_trans_shear_true = RealMatrixX::Zero(2,2);
+        D_trans_shear_true(0,0) = 6.830000000000000e+10;
+        D_trans_shear_true(1,1) = 6.830000000000000e+10;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test(D_trans_shear.data(), D_trans_shear.data()+D_trans_shear.rows()*D_trans_shear.cols());
+        std::vector<double> truth(D_trans_shear_true.data(), D_trans_shear_true.data()+D_trans_shear_true.rows()*D_trans_shear_true.cols());
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("constant_orthotropic_heat_transfer_material_2d", 
+          "[orthotropic],[material],[2D],[heat_transfer][constant]")
+{
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter k11("k11_param",     237.0);   // Thermal Conductivity
+    MAST::Parameter k22("k22_param",     542.0);   // Thermal Conductivity
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction k11_f("k11_th", k11);
+    MAST::ConstantFieldFunction k22_f("k22_th", k22);
+    
+    // Initialize the material
+    MAST::OrthotropicMaterialPropertyCard material;
+    
+    // Add the material property constant field functions to the material card
+    material.add(k11_f);
+    material.add(k22_f);
+    
+    // Ensure that the material properties were added before doing other checks
+    REQUIRE( material.contains("k11_th") );
+    REQUIRE( material.contains("k22_th") );
+    
+    SECTION("material depends on the parameters that it should")
+    {
+        CHECK( material.depends_on(k11) );
+        CHECK( material.depends_on(k22) );
+    }
+    
+    SECTION("material does not depend on other parameters")
+    {
+        MAST::Parameter dummy("dummy", 1.0);
+        CHECK_FALSE( material.depends_on(dummy) );
+    }
+    
+    SECTION("2D thermal conductivity matrix")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_conduct = 
+            material.conductance_matrix(2);
+            
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_k;
+        mat_conduct(point, time, D_k);
+        
+        // Hard-coded values for thermal conductivity matrix
+        RealMatrixX D_k_true = RealMatrixX::Identity(2,2);
+        D_k_true(0,0) = 237.0;
+        D_k_true(1,1) = 542.0;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test = eigen_matrix_to_std_vector(D_k);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_k_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("constant_orthotropic_transient_heat_transfer_material_2d", 
+          "[orthotropic],[material],[2D],[heat_transfer],[constant],[transient]")
+{
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter rho("rho_param", 1234.5);            // Density
+    MAST::Parameter cp("cp_param",   908.0);             // Specific Heat Capacity
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction rho_f("rho", rho);
+    MAST::ConstantFieldFunction cp_f("cp", cp);
+    
+    // Initialize the material
+    MAST::OrthotropicMaterialPropertyCard material;
+    
+    // Add the material property constant field functions to the material card
+    material.add(rho_f);                                             
+    material.add(cp_f);
+    
+    // Ensure that the material properties were added before doing other checks
+    REQUIRE( material.contains("rho") );
+    REQUIRE( material.contains("cp") );
+    
+    SECTION("material depends on the parameters that it should")
+    {
+        CHECK( material.depends_on(rho) );
+        CHECK( material.depends_on(cp) );
+    }
+    
+    SECTION("material does not depend on other parameters")
+    {
+        MAST::Parameter dummy("dummy", 1.0);
+        CHECK_FALSE( material.depends_on(dummy) );
+    }
+    
+    SECTION("2D thermal capacitance matrix")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_capacit =
+            material.capacitance_matrix(2);
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_cp;
+        mat_capacit(point, time, D_cp);
+        
+        // Hard-coded values for thermal conductivity matrix
+        RealMatrixX D_cp_true = RealMatrixX::Identity(1,1);
+        D_cp_true *= (908.0 * 1234.5);
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test = eigen_matrix_to_std_vector(D_cp);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_cp_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("constant_orthotropic_thermoelastic_material_3d", 
+          "[orthotropic],[material],[3D],[thermoelastic][constant]")
+{
+    MAST::Parameter alpha11("alpha11_param", 5.43e-05);
+    MAST::Parameter alpha22("alpha22_param", 8.79e-06);
+    MAST::Parameter alpha33("alpha33_param", 2.14e-05);
+    
+    MAST::ConstantFieldFunction alpha11_f("alpha11_expansion", alpha11);
+    MAST::ConstantFieldFunction alpha22_f("alpha22_expansion", alpha22);
+    MAST::ConstantFieldFunction alpha33_f("alpha33_expansion", alpha33);
+    
+    // Initialize the material
+    MAST::OrthotropicMaterialPropertyCard material;      
+    
+    material.add(alpha11_f);
+    material.add(alpha22_f);
+    material.add(alpha33_f);
+    
+    REQUIRE( material.contains("alpha11_expansion") );
+    REQUIRE( material.contains("alpha22_expansion") );
+    REQUIRE( material.contains("alpha33_expansion") );
+    
+    SECTION("material does not depend on other parameters")
+    {
+        MAST::Parameter dummy("dummy", 1.0);
+        CHECK_FALSE( material.depends_on(dummy) );
+    }
+    
+    SECTION("3D material thermal expansion matrix")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_texp =
+            material.thermal_expansion_matrix(3);
+            
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_texp;
+        mat_texp(point, time, D_texp);
+        
+        // Hard-coded in the true value of material thermal expansion matrix
+        RealMatrixX D_texp_true = RealMatrixX::Zero(6,1);
+        D_texp_true(0,0) = 5.43e-05;
+        D_texp_true(1,0) = 8.79e-06;
+        D_texp_true(2,0) = 2.14e-05;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(D_texp);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_texp_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("constant_orthotropic_structural_material_3d", 
+          "[orthotropic],[material],[3D],[structural],[constant]")
+{
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter E11("E11", 72.0e9);             // Modulus of Elasticity
+    MAST::Parameter E22("E22", 55.0e9);           
+    MAST::Parameter E33("E33", 33.4e9);
+    MAST::Parameter nu12("nu12", 0.33);             // Poisson's ratio
+    MAST::Parameter nu23("nu23", 0.25);
+    MAST::Parameter nu31("nu31", 0.45);
+    MAST::Parameter G12("G12", 68.3e9);             // Shear Modulus
+    MAST::Parameter G23("G23", 74.5e9);
+    MAST::Parameter G13("G13", 55.1e9);
+        
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction E11_f("E11", E11);
+    MAST::ConstantFieldFunction E22_f("E22", E22);
+    MAST::ConstantFieldFunction E33_f("E33", E33);
+    MAST::ConstantFieldFunction nu12_f("nu12", nu12);
+    MAST::ConstantFieldFunction nu23_f("nu23", nu23);
+    MAST::ConstantFieldFunction nu31_f("nu31", nu31);
+    MAST::ConstantFieldFunction G12_f("G12", G12);
+    MAST::ConstantFieldFunction G23_f("G23", G23);
+    MAST::ConstantFieldFunction G13_f("G13", G13);
+    
+    // Initialize the material
+    MAST::OrthotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(E11_f);         
+    material.add(E22_f);
+    material.add(E33_f);
+    material.add(nu12_f);
+    material.add(nu23_f);
+    material.add(nu31_f);
+    material.add(G12_f);
+    material.add(G23_f);
+    material.add(G13_f);
+    
+    // Ensure that the material properties were added before doing other checks
+    REQUIRE( material.contains("E11") );
+    REQUIRE( material.contains("E22") );
+    REQUIRE( material.contains("E33") );
+    REQUIRE( material.contains("nu12") );
+    REQUIRE( material.contains("nu23") );
+    REQUIRE( material.contains("nu31") );
+    REQUIRE( material.contains("G12") );
+    REQUIRE( material.contains("G23") );
+    REQUIRE( material.contains("G13") );
+    
+    SECTION("material depends on the parameters that it should")
+    {
+        CHECK( material.depends_on(E11) );
+        CHECK( material.depends_on(E22) );
+        CHECK( material.depends_on(E33) );
+        CHECK( material.depends_on(nu12) );
+        CHECK( material.depends_on(nu23) );
+        CHECK( material.depends_on(nu31) );
+        CHECK( material.depends_on(G12) );
+        CHECK( material.depends_on(G23) );
+        CHECK( material.depends_on(G13) );
+    }
+    
+    SECTION("material does not depend on other parameters")
+    {
+        MAST::Parameter dummy("dummy", 1.0);
+        CHECK_FALSE( material.depends_on(dummy) );
+    }
+    
+    SECTION("3D material constitutive matrix")
+    {
+        const bool is_plane_stress = true;
+        const MAST::FieldFunction<RealMatrixX>& mat_stiffness = 
+            material.stiffness_matrix(3);
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX K_mat;
+        mat_stiffness(point, time, K_mat);
+        
+        // Check for symmetry
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(K_mat.transpose());
+        std::vector<double> truth = eigen_matrix_to_std_vector(K_mat);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+        
+        // Check for positive definiteness
+        SelfAdjointEigenSolver<RealMatrixX> eigensolver(K_mat);
+        if (eigensolver.info() != Success)
+        {
+            std::cout << "eigensolver failed to converge!" << std::endl;
+            REQUIRE(false); // Force test failure.
+        }
+        RealVectorX eigenvalues = eigensolver.eigenvalues();
+        for (uint i=0; i<K_mat.cols(); i++)
+        {
+            REQUIRE( eigenvalues(i) > 0.0 );
+        }
+        
+        // Hard-code in the true value of the material stiffness
+        RealMatrixX K_mat_true = RealMatrixX::Zero(6,6);
+        K_mat_true(0,0) = 1.881848591463047e+11;
+        K_mat_true(1,1) = 0.841961884847417e+11;
+        K_mat_true(2,2) = 0.831923864531179e+11;
+        K_mat_true(3,3) = 0.683000000000000e+11;
+        K_mat_true(4,4) = 0.745000000000000e+11;
+        K_mat_true(5,5) = 0.551000000000000e+11;
+    
+        K_mat_true(0,1) = K_mat_true(1,0) = 0.713158228712175e+11;
+        K_mat_true(0,2) = K_mat_true(2,0) = 0.955102251790129e+11;
+        K_mat_true(1,2) = K_mat_true(2,1) = 0.448746325438223e+11;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        test =  eigen_matrix_to_std_vector(K_mat);
+        truth = eigen_matrix_to_std_vector(K_mat_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("constant_orthotropic_heat_transfer_material_3d", 
+          "[orthotropic],[material],[3D],[heat_transfer][constant]")
+{
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter k11("k11_param",     237.0);   // Thermal Conductivity
+    MAST::Parameter k22("k22_param",     542.0);   // Thermal Conductivity
+    MAST::Parameter k33("k33_param",     444.4);   // Thermal Conductivity
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction k11_f("k11_th", k11);
+    MAST::ConstantFieldFunction k22_f("k22_th", k22);
+    MAST::ConstantFieldFunction k33_f("k33_th", k33);
+    
+    // Initialize the material
+    MAST::OrthotropicMaterialPropertyCard material;
+    
+    // Add the material property constant field functions to the material card
+    material.add(k11_f);
+    material.add(k22_f);
+    material.add(k33_f);
+    
+    // Ensure that the material properties were added before doing other checks
+    REQUIRE( material.contains("k11_th") );
+    REQUIRE( material.contains("k22_th") );
+    REQUIRE( material.contains("k33_th") );
+    
+    SECTION("material depends on the parameters that it should")
+    {
+        CHECK( material.depends_on(k11) );
+        CHECK( material.depends_on(k22) );
+        CHECK( material.depends_on(k33) );
+    }
+    
+    SECTION("material does not depend on other parameters")
+    {
+        MAST::Parameter dummy("dummy", 1.0);
+        CHECK_FALSE( material.depends_on(dummy) );
+    }
+    
+    SECTION("3D thermal conductivity matrix")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_conduct = 
+            material.conductance_matrix(3);
+            
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_k;
+        mat_conduct(point, time, D_k);
+        
+        // Hard-coded values for thermal conductivity matrix
+        RealMatrixX D_k_true = RealMatrixX::Identity(3,3);
+        D_k_true(0,0) = 237.0;
+        D_k_true(1,1) = 542.0;
+        D_k_true(2,2) = 444.4;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test = eigen_matrix_to_std_vector(D_k);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_k_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("constant_orthotropic_transient_heat_transfer_material_3d", 
+          "[orthotropic],[material],[3D],[heat_transfer],[constant],[transient]")
+{
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter rho("rho_param", 1234.5);            // Density
+    MAST::Parameter cp("cp_param",   908.0);             // Specific Heat Capacity
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction rho_f("rho", rho);
+    MAST::ConstantFieldFunction cp_f("cp", cp);
+    
+    // Initialize the material
+    MAST::OrthotropicMaterialPropertyCard material;
+    
+    // Add the material property constant field functions to the material card
+    material.add(rho_f);                                             
+    material.add(cp_f);
+    
+    // Ensure that the material properties were added before doing other checks
+    REQUIRE( material.contains("rho") );
+    REQUIRE( material.contains("cp") );
+    
+    SECTION("material depends on the parameters that it should")
+    {
+        CHECK( material.depends_on(rho) );
+        CHECK( material.depends_on(cp) );
+    }
+    
+    SECTION("material does not depend on other parameters")
+    {
+        MAST::Parameter dummy("dummy", 1.0);
+        CHECK_FALSE( material.depends_on(dummy) );
+    }
+    
+    SECTION("2D thermal capacitance matrix")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_capacit =
+            material.capacitance_matrix(3);
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_cp;
+        mat_capacit(point, time, D_cp);
+        
+        // Hard-coded values for thermal conductivity matrix
+        RealMatrixX D_cp_true = RealMatrixX::Identity(1,1);
+        D_cp_true *= (908.0 * 1234.5);
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test = eigen_matrix_to_std_vector(D_cp);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_cp_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}
+
+
+TEST_CASE("constant_orthotropic_dynamic_material_3d", 
+          "[orthotropic],[material],[3D],[dynamic],[constant]")
+{
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter rho("rho_param", 1234.5);            // Density
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction rho_f("rho", rho);
+    
+    // Initialize the material
+    MAST::OrthotropicMaterialPropertyCard material;
+    
+    // Add the material property constant field functions to the material card
+    material.add(rho_f);                                             
+    
+    // Ensure that the material properties were added before doing other checks
+    REQUIRE( material.contains("rho") );
+    
+    SECTION("material depends on the parameters that it should")
+    {
+        CHECK( material.depends_on(rho) );
+    }
+    
+    SECTION("material does not depend on other parameters")
+    {
+        MAST::Parameter dummy("dummy", 1.0);
+        CHECK_FALSE( material.depends_on(dummy) );
+    }
+    
+    SECTION("3D inertia matrix")
+    {
+        const MAST::FieldFunction<RealMatrixX>& mat_capacit =
+            material.inertia_matrix(3);
+        
+        const libMesh::Point point(2.3, 3.1, 5.2);
+        const Real time = 2.34;
+        RealMatrixX D_inertia;
+        mat_capacit(point, time, D_inertia);
+        
+        // Hard-coded values for thermal conductivity matrix
+        RealMatrixX D_inertia_true = RealMatrixX::Identity(3,3);
+        D_inertia_true *= 1234.5;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test = eigen_matrix_to_std_vector(D_inertia);
+        std::vector<double> truth = eigen_matrix_to_std_vector(D_inertia_true);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        CHECK_THAT( test, Catch::Approx<double>(truth) );
+    }
+}


### PR DESCRIPTION
This pull request added plane strain support for 2D isotropic and orthotropic materials and moved the shear coefficient, `kappa`, from the material card to the section card.  

In addition, for 1D materials `kappa` was split into `Kappazz` and `Kappayy` since in general the value is not the same in the y- and z- directions.  

Examples were updated to account for this change.

Catch2 tests were added for isotropic and orthotropic material cards.