### PR TITLE
First Catch2 tests for structural 1D elements

### DIFF
--- a/src/property_cards/element_property_card_1D.cpp
+++ b/src/property_cards/element_property_card_1D.cpp
@@ -23,6 +23,12 @@
 
 MAST::BendingOperatorType
 MAST::ElementPropertyCard1D::bending_model(const MAST::GeomElem& elem) const {
+    
+    // Ensure a valid bending_model is chosen, raise error if not
+    if ((_bending_model == MAST::DKT) or (_bending_model == MAST::MINDLIN)){
+        libmesh_error_msg("Invalid bending model for 1D element. Should be either MAST::BERNOULLI, MAST::TIMOSHENKO, MAST::NO_BENDING, OR MAST::DEFAULT_BENDING; " << __PRETTY_FUNCTION__ << " in " << __FILE__ << " at line number " << __LINE__);
+    }
+    
     // for an EDGE2 element, default bending is Bernoulli. For all other elements
     // the default is Timoshenko. Otherwise it returns the model set for
     // this card.
@@ -34,7 +40,7 @@ MAST::ElementPropertyCard1D::bending_model(const MAST::GeomElem& elem) const {
                 (_bending_model == MAST::DEFAULT_BENDING))
                 return MAST::BERNOULLI;
             else
-                return MAST::TIMOSHENKO;
+                return _bending_model; // Fixed bug. See github issue #41
             break;
             
         default:

--- a/src/property_cards/element_property_card_1D.cpp
+++ b/src/property_cards/element_property_card_1D.cpp
@@ -40,7 +40,7 @@ MAST::ElementPropertyCard1D::bending_model(const MAST::GeomElem& elem) const {
                 (_bending_model == MAST::DEFAULT_BENDING))
                 return MAST::BERNOULLI;
             else
-                return _bending_model; // Fixed bug. See github issue #41
+                return _bending_model;
             break;
             
         default:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ add_subdirectory(base)
 add_subdirectory(boundary_condition)
 add_subdirectory(material)
 add_subdirectory(property)
-#add_subdirectory(element)
+add_subdirectory(element)
 
 message(NOTICE "It is recommended to run 'make check' instead of 'make test'. Alternatively, for 'ctest' or \
 'make test' to output Catch2 error messages when a failure occurs, you must set the environment variable \
@@ -28,7 +28,7 @@ CTEST_OUTPUT_ON_FAILURE=1.")
 # "check" instead. This "check" command will generate a graph to visualize test
 # dependencies, run ctest with output-on-failure enabled so that Catch2 output
 # is available, and then generate a graph to visualize which tests passed, 
-# failed, or where not ran.
+# failed, or were not ran.
 #
 # References 
 # ----------

--- a/tests/element/CMakeLists.txt
+++ b/tests/element/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(structural)

--- a/tests/element/structural/1D/CMakeLists.txt
+++ b/tests/element/structural/1D/CMakeLists.txt
@@ -1,0 +1,14 @@
+target_sources( mast_catch_tests
+                PRIVATE
+                ${CMAKE_CURRENT_LIST_DIR}/mast_structural_element_1d.cpp)
+
+# 1D Structural Element Test Basic Tests
+add_test(NAME Element_1D_Structural_Basic_Tests
+         COMMAND mast_catch_tests "structural_element_1d_base_tests")
+set_tests_properties(Element_1D_Structural_Basic_Tests
+                     PROPERTIES 
+                     FIXTURES_REQUIRED  "Element_Property_Card_1D_Structural;libMesh_Mesh_Generation_1d"
+                     FIXTURES_SETUP     Element_1D_Structural_Basic_Tests)
+
+                     
+#add_subdirectory(edge2)

--- a/tests/element/structural/1D/CMakeLists.txt
+++ b/tests/element/structural/1D/CMakeLists.txt
@@ -20,4 +20,4 @@ set_tests_properties(Element_1D_Structural_Basic_Tests_mpi
         FIXTURES_SETUP     Element_1D_Structural_Basic_Tests_mpi)
 
                      
-#add_subdirectory(edge2)
+add_subdirectory(edge2)

--- a/tests/element/structural/1D/CMakeLists.txt
+++ b/tests/element/structural/1D/CMakeLists.txt
@@ -1,14 +1,23 @@
-target_sources( mast_catch_tests
-                PRIVATE
-                ${CMAKE_CURRENT_LIST_DIR}/mast_structural_element_1d.cpp)
+target_sources(mast_catch_tests
+    PRIVATE
+        ${CMAKE_CURRENT_LIST_DIR}/mast_structural_element_1d.cpp)
 
 # 1D Structural Element Test Basic Tests
 add_test(NAME Element_1D_Structural_Basic_Tests
-         COMMAND mast_catch_tests "structural_element_1d_base_tests")
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "structural_element_1d_base_tests")
 set_tests_properties(Element_1D_Structural_Basic_Tests
-                     PROPERTIES 
-                     FIXTURES_REQUIRED  "Element_Property_Card_1D_Structural;libMesh_Mesh_Generation_1d"
-                     FIXTURES_SETUP     Element_1D_Structural_Basic_Tests)
+    PROPERTIES
+        LABELS "SEQ"
+        FIXTURES_REQUIRED  "Element_Property_Card_1D_Structural;libMesh_Mesh_Generation_1d"
+        FIXTURES_SETUP     Element_1D_Structural_Basic_Tests)
+
+add_test(NAME Element_1D_Structural_Basic_Tests_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2  $<TARGET_FILE:mast_catch_tests> -w NoTests "structural_element_1d_base_tests")
+set_tests_properties(Element_1D_Structural_Basic_Tests_mpi
+    PROPERTIES
+        LABELS "MPI"
+        FIXTURES_REQUIRED  "Element_Property_Card_1D_Structural_mpi;libMesh_Mesh_Generation_1d_mpi"
+        FIXTURES_SETUP     Element_1D_Structural_Basic_Tests_mpi)
 
                      
 #add_subdirectory(edge2)

--- a/tests/element/structural/1D/edge2/CMakeLists.txt
+++ b/tests/element/structural/1D/edge2/CMakeLists.txt
@@ -1,0 +1,72 @@
+target_sources( mast_catch_tests
+                PRIVATE
+                ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_extension_internal_jacobian.cpp)
+#                 ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_extension_bending_internal_jacobian.cpp
+#                 ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_extension_bending_coupling_internal_jacobian.cpp
+#                 ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_extension_bending_shear_internal_jacobian.cpp
+#                 ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_internal_jacobian.cpp
+#                 ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_inertial_jacobian.cpp
+#                 ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_thermal_jacobian.cpp
+#                 ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_nonlinear_structural_thermal_jacobian.cpp)
+
+#1D Structural Element Test Basic Tests
+add_test(NAME Element_Edge2_Linear_Structural_Extension
+         COMMAND mast_catch_tests "edge2_linear_extension_structural")
+set_tests_properties(Element_Edge2_Linear_Structural_Extension
+                     PROPERTIES 
+                     FIXTURES_REQUIRED  Element_1D_Structural_Basic_Tests
+                     FIXTURES_SETUP  Element_Edge2_Linear_Structural_Extension)
+                     
+# add_test(NAME Element_Edge2_Linear_Structural_Extension_Bending
+#          COMMAND mast_catch_tests "edge2_linear_extension_bending_structural")
+# set_tests_properties(Element_Edge2_Linear_Structural_Extension_Bending
+#                      PROPERTIES 
+#                      FIXTURES_REQUIRED  Element_Edge2_Linear_Structural_Extension
+#                      FIXTURES_SETUP     Element_Edge2_Linear_Structural_Extension_Bending)
+# 
+# add_test(NAME Element_Edge2_Linear_Structural_Extension_Bending_Coupling
+# COMMAND mast_catch_tests "edge2_linear_extension_bending_coupling_structural")
+# set_tests_properties(Element_Edge2_Linear_Structural_Extension_Bending_Coupling
+#                      PROPERTIES 
+#                      FIXTURES_REQUIRED  Element_Edge2_Linear_Structural_Extension_Bending
+#                      FIXTURES_SETUP     Element_Edge2_Linear_Structural_Extension_Bending_Coupling)
+#                      
+# add_test(NAME Element_Edge2_Linear_Structural_Extension_Bending_Shear
+# COMMAND mast_catch_tests "edge2_linear_extension_bending_shear_structural")
+# set_tests_properties(Element_Edge2_Linear_Structural_Extension_Bending_Shear
+#                      PROPERTIES 
+#                      FIXTURES_REQUIRED  Element_Edge2_Linear_Structural_Extension_Bending
+#                      FIXTURES_SETUP     Element_Edge2_Linear_Structural_Extension_Bending_Shear)
+#                      
+# add_test(NAME Element_Edge2_Linear_Structural_All
+#          COMMAND mast_catch_tests "edge2_linear_structural")
+# set_tests_properties(Element_Edge2_Linear_Structural_All
+#                      PROPERTIES 
+#                      FIXTURES_REQUIRED "Element_Edge2_Linear_Structural_Extension_Bending_Coupling;Element_Edge2_Linear_Structural_Extension_Bending_Shear"
+#                      )
+#                      
+# add_test(NAME Element_Edge2_Linear_Structural_Inertial_Consistent
+#          COMMAND mast_catch_tests "edge2_linear_structural_inertial_consistent")
+# set_tests_properties(Element_Edge2_Linear_Structural_Inertial_Consistent
+#                      PROPERTIES 
+#                      FIXTURES_REQUIRED Element_1D_Structural_Basic_Tests)
+#                      
+# add_test(NAME Element_Edge2_Linear_Structural_Inertial_Lumped
+#          COMMAND mast_catch_tests "edge2_linear_structural_inertial_lumped")
+# set_tests_properties(Element_Edge2_Linear_Structural_Inertial_Lumped
+#                      PROPERTIES 
+#                      FIXTURES_REQUIRED Element_1D_Structural_Basic_Tests)
+#                      
+# add_test(NAME Element_Edge2_Linear_Structural_Thermal
+#          COMMAND mast_catch_tests "edge2_linear_structural_thermal_jacobian")
+# set_tests_properties(Element_Edge2_Linear_Structural_Thermal
+#                      PROPERTIES 
+#                      FIXTURES_REQUIRED "Element_1D_Structural_Basic_Tests;Thermoelastic_Load"
+#                      )
+#                      
+# add_test(NAME Element_Edge2_Nonlinear_Structural_Thermal
+#          COMMAND mast_catch_tests "edge2_nonlinear_structural_thermal_jacobian")
+# set_tests_properties(Element_Edge2_Nonlinear_Structural_Thermal
+#                      PROPERTIES 
+#                      FIXTURES_REQUIRED "Element_1D_Structural_Basic_Tests;Thermoelastic_Load"
+#                      )

--- a/tests/element/structural/1D/edge2/CMakeLists.txt
+++ b/tests/element/structural/1D/edge2/CMakeLists.txt
@@ -1,13 +1,13 @@
 target_sources( mast_catch_tests
                 PRIVATE
-                ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_extension_internal_jacobian.cpp)
-#                 ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_extension_bending_internal_jacobian.cpp
-#                 ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_extension_bending_coupling_internal_jacobian.cpp
-#                 ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_extension_bending_shear_internal_jacobian.cpp
-#                 ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_internal_jacobian.cpp
-#                 ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_inertial_jacobian.cpp
-#                 ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_thermal_jacobian.cpp
-#                 ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_nonlinear_structural_thermal_jacobian.cpp)
+                ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_extension_internal_jacobian.cpp
+                ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_extension_bending_internal_jacobian.cpp
+                ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_extension_bending_coupling_internal_jacobian.cpp
+                ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_extension_bending_shear_internal_jacobian.cpp
+                ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_internal_jacobian.cpp
+                ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_inertial_jacobian.cpp
+                ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_thermal_jacobian.cpp
+                ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_nonlinear_structural_thermal_jacobian.cpp)
 
 #1D Structural Element Test Basic Tests
 add_test(NAME Element_Edge2_Linear_Structural_Extension
@@ -17,56 +17,56 @@ set_tests_properties(Element_Edge2_Linear_Structural_Extension
                      FIXTURES_REQUIRED  Element_1D_Structural_Basic_Tests
                      FIXTURES_SETUP  Element_Edge2_Linear_Structural_Extension)
                      
-# add_test(NAME Element_Edge2_Linear_Structural_Extension_Bending
-#          COMMAND mast_catch_tests "edge2_linear_extension_bending_structural")
-# set_tests_properties(Element_Edge2_Linear_Structural_Extension_Bending
-#                      PROPERTIES 
-#                      FIXTURES_REQUIRED  Element_Edge2_Linear_Structural_Extension
-#                      FIXTURES_SETUP     Element_Edge2_Linear_Structural_Extension_Bending)
-# 
-# add_test(NAME Element_Edge2_Linear_Structural_Extension_Bending_Coupling
-# COMMAND mast_catch_tests "edge2_linear_extension_bending_coupling_structural")
-# set_tests_properties(Element_Edge2_Linear_Structural_Extension_Bending_Coupling
-#                      PROPERTIES 
-#                      FIXTURES_REQUIRED  Element_Edge2_Linear_Structural_Extension_Bending
-#                      FIXTURES_SETUP     Element_Edge2_Linear_Structural_Extension_Bending_Coupling)
-#                      
-# add_test(NAME Element_Edge2_Linear_Structural_Extension_Bending_Shear
-# COMMAND mast_catch_tests "edge2_linear_extension_bending_shear_structural")
-# set_tests_properties(Element_Edge2_Linear_Structural_Extension_Bending_Shear
-#                      PROPERTIES 
-#                      FIXTURES_REQUIRED  Element_Edge2_Linear_Structural_Extension_Bending
-#                      FIXTURES_SETUP     Element_Edge2_Linear_Structural_Extension_Bending_Shear)
-#                      
-# add_test(NAME Element_Edge2_Linear_Structural_All
-#          COMMAND mast_catch_tests "edge2_linear_structural")
-# set_tests_properties(Element_Edge2_Linear_Structural_All
-#                      PROPERTIES 
-#                      FIXTURES_REQUIRED "Element_Edge2_Linear_Structural_Extension_Bending_Coupling;Element_Edge2_Linear_Structural_Extension_Bending_Shear"
-#                      )
-#                      
-# add_test(NAME Element_Edge2_Linear_Structural_Inertial_Consistent
-#          COMMAND mast_catch_tests "edge2_linear_structural_inertial_consistent")
-# set_tests_properties(Element_Edge2_Linear_Structural_Inertial_Consistent
-#                      PROPERTIES 
-#                      FIXTURES_REQUIRED Element_1D_Structural_Basic_Tests)
-#                      
-# add_test(NAME Element_Edge2_Linear_Structural_Inertial_Lumped
-#          COMMAND mast_catch_tests "edge2_linear_structural_inertial_lumped")
-# set_tests_properties(Element_Edge2_Linear_Structural_Inertial_Lumped
-#                      PROPERTIES 
-#                      FIXTURES_REQUIRED Element_1D_Structural_Basic_Tests)
-#                      
-# add_test(NAME Element_Edge2_Linear_Structural_Thermal
-#          COMMAND mast_catch_tests "edge2_linear_structural_thermal_jacobian")
-# set_tests_properties(Element_Edge2_Linear_Structural_Thermal
-#                      PROPERTIES 
-#                      FIXTURES_REQUIRED "Element_1D_Structural_Basic_Tests;Thermoelastic_Load"
-#                      )
-#                      
-# add_test(NAME Element_Edge2_Nonlinear_Structural_Thermal
-#          COMMAND mast_catch_tests "edge2_nonlinear_structural_thermal_jacobian")
-# set_tests_properties(Element_Edge2_Nonlinear_Structural_Thermal
-#                      PROPERTIES 
-#                      FIXTURES_REQUIRED "Element_1D_Structural_Basic_Tests;Thermoelastic_Load"
-#                      )
+add_test(NAME Element_Edge2_Linear_Structural_Extension_Bending
+         COMMAND mast_catch_tests "edge2_linear_extension_bending_structural")
+set_tests_properties(Element_Edge2_Linear_Structural_Extension_Bending
+                     PROPERTIES 
+                     FIXTURES_REQUIRED  Element_Edge2_Linear_Structural_Extension
+                     FIXTURES_SETUP     Element_Edge2_Linear_Structural_Extension_Bending)
+
+add_test(NAME Element_Edge2_Linear_Structural_Extension_Bending_Coupling
+COMMAND mast_catch_tests "edge2_linear_extension_bending_coupling_structural")
+set_tests_properties(Element_Edge2_Linear_Structural_Extension_Bending_Coupling
+                     PROPERTIES 
+                     FIXTURES_REQUIRED  Element_Edge2_Linear_Structural_Extension_Bending
+                     FIXTURES_SETUP     Element_Edge2_Linear_Structural_Extension_Bending_Coupling)
+                     
+add_test(NAME Element_Edge2_Linear_Structural_Extension_Bending_Shear
+COMMAND mast_catch_tests "edge2_linear_extension_bending_shear_structural")
+set_tests_properties(Element_Edge2_Linear_Structural_Extension_Bending_Shear
+                     PROPERTIES 
+                     FIXTURES_REQUIRED  Element_Edge2_Linear_Structural_Extension_Bending
+                     FIXTURES_SETUP     Element_Edge2_Linear_Structural_Extension_Bending_Shear)
+                     
+add_test(NAME Element_Edge2_Linear_Structural_All
+         COMMAND mast_catch_tests "edge2_linear_structural")
+set_tests_properties(Element_Edge2_Linear_Structural_All
+                     PROPERTIES 
+                     FIXTURES_REQUIRED "Element_Edge2_Linear_Structural_Extension_Bending_Coupling;Element_Edge2_Linear_Structural_Extension_Bending_Shear"
+                     )
+                     
+add_test(NAME Element_Edge2_Linear_Structural_Inertial_Consistent
+         COMMAND mast_catch_tests "edge2_linear_structural_inertial_consistent")
+set_tests_properties(Element_Edge2_Linear_Structural_Inertial_Consistent
+                     PROPERTIES 
+                     FIXTURES_REQUIRED Element_1D_Structural_Basic_Tests)
+                     
+add_test(NAME Element_Edge2_Linear_Structural_Inertial_Lumped
+         COMMAND mast_catch_tests "edge2_linear_structural_inertial_lumped")
+set_tests_properties(Element_Edge2_Linear_Structural_Inertial_Lumped
+                     PROPERTIES 
+                     FIXTURES_REQUIRED Element_1D_Structural_Basic_Tests)
+                     
+add_test(NAME Element_Edge2_Linear_Structural_Thermal
+         COMMAND mast_catch_tests "edge2_linear_structural_thermal_jacobian")
+set_tests_properties(Element_Edge2_Linear_Structural_Thermal
+                     PROPERTIES 
+                     FIXTURES_REQUIRED "Element_1D_Structural_Basic_Tests;Thermoelastic_Load"
+                     )
+                     
+add_test(NAME Element_Edge2_Nonlinear_Structural_Thermal
+         COMMAND mast_catch_tests "edge2_nonlinear_structural_thermal_jacobian")
+set_tests_properties(Element_Edge2_Nonlinear_Structural_Thermal
+                     PROPERTIES 
+                     FIXTURES_REQUIRED "Element_1D_Structural_Basic_Tests;Thermoelastic_Load"
+                     )

--- a/tests/element/structural/1D/edge2/CMakeLists.txt
+++ b/tests/element/structural/1D/edge2/CMakeLists.txt
@@ -9,6 +9,12 @@ target_sources(mast_catch_tests
         ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_thermal_jacobian.cpp
         ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_nonlinear_structural_thermal_jacobian.cpp)
 
+        
+# TODO: Implement patch test
+# TODO: Implement surface pressure residual / Jacobian
+# TODO: Implement piston theory residual / Jacobian testing
+# TODO: Implement other elements (Edge3, etc.)
+        
 add_test(NAME Element_Edge2_Linear_Structural_Extension
     COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "edge2_linear_extension_structural")
 set_tests_properties(Element_Edge2_Linear_Structural_Extension

--- a/tests/element/structural/1D/edge2/CMakeLists.txt
+++ b/tests/element/structural/1D/edge2/CMakeLists.txt
@@ -1,72 +1,160 @@
-target_sources( mast_catch_tests
-                PRIVATE
-                ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_extension_internal_jacobian.cpp
-                ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_extension_bending_internal_jacobian.cpp
-                ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_extension_bending_coupling_internal_jacobian.cpp
-                ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_extension_bending_shear_internal_jacobian.cpp
-                ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_internal_jacobian.cpp
-                ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_inertial_jacobian.cpp
-                ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_thermal_jacobian.cpp
-                ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_nonlinear_structural_thermal_jacobian.cpp)
+target_sources(mast_catch_tests
+    PRIVATE
+        ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_extension_internal_jacobian.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_extension_bending_internal_jacobian.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_extension_bending_coupling_internal_jacobian.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_extension_bending_shear_internal_jacobian.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_internal_jacobian.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_inertial_jacobian.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_linear_structural_thermal_jacobian.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/mast_edge2_nonlinear_structural_thermal_jacobian.cpp)
 
-#1D Structural Element Test Basic Tests
 add_test(NAME Element_Edge2_Linear_Structural_Extension
-         COMMAND mast_catch_tests "edge2_linear_extension_structural")
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "edge2_linear_extension_structural")
 set_tests_properties(Element_Edge2_Linear_Structural_Extension
-                     PROPERTIES 
-                     FIXTURES_REQUIRED  Element_1D_Structural_Basic_Tests
-                     FIXTURES_SETUP  Element_Edge2_Linear_Structural_Extension)
-                     
+    PROPERTIES
+        LABELS "SEQ"
+        FIXTURES_REQUIRED  Element_1D_Structural_Basic_Tests
+        FIXTURES_SETUP  Element_Edge2_Linear_Structural_Extension)
+
+add_test(NAME Element_Edge2_Linear_Structural_Extension_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "edge2_linear_extension_structural")
+set_tests_properties(Element_Edge2_Linear_Structural_Extension_mpi
+    PROPERTIES
+        LABELS "MPI"
+        FIXTURES_REQUIRED  Element_1D_Structural_Basic_Tests_mpi
+        FIXTURES_SETUP  Element_Edge2_Linear_Structural_Extension_mpi)
+
+
+
 add_test(NAME Element_Edge2_Linear_Structural_Extension_Bending
-         COMMAND mast_catch_tests "edge2_linear_extension_bending_structural")
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "edge2_linear_extension_bending_structural")
 set_tests_properties(Element_Edge2_Linear_Structural_Extension_Bending
-                     PROPERTIES 
-                     FIXTURES_REQUIRED  Element_Edge2_Linear_Structural_Extension
-                     FIXTURES_SETUP     Element_Edge2_Linear_Structural_Extension_Bending)
+    PROPERTIES
+        LABELS "SEQ"
+        FIXTURES_REQUIRED  Element_Edge2_Linear_Structural_Extension
+        FIXTURES_SETUP     Element_Edge2_Linear_Structural_Extension_Bending)
+
+add_test(NAME Element_Edge2_Linear_Structural_Extension_Bending_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "edge2_linear_extension_bending_structural")
+set_tests_properties(Element_Edge2_Linear_Structural_Extension_Bending_mpi
+    PROPERTIES
+        LABELS "MPI"
+        FIXTURES_REQUIRED  Element_Edge2_Linear_Structural_Extension_mpi
+        FIXTURES_SETUP     Element_Edge2_Linear_Structural_Extension_Bending_mpi)
+
+
 
 add_test(NAME Element_Edge2_Linear_Structural_Extension_Bending_Coupling
-COMMAND mast_catch_tests "edge2_linear_extension_bending_coupling_structural")
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "edge2_linear_extension_bending_coupling_structural")
 set_tests_properties(Element_Edge2_Linear_Structural_Extension_Bending_Coupling
-                     PROPERTIES 
-                     FIXTURES_REQUIRED  Element_Edge2_Linear_Structural_Extension_Bending
-                     FIXTURES_SETUP     Element_Edge2_Linear_Structural_Extension_Bending_Coupling)
-                     
+    PROPERTIES
+        LABELS "SEQ"
+        FIXTURES_REQUIRED  Element_Edge2_Linear_Structural_Extension_Bending
+        FIXTURES_SETUP     Element_Edge2_Linear_Structural_Extension_Bending_Coupling)
+
+add_test(NAME Element_Edge2_Linear_Structural_Extension_Bending_Coupling_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "edge2_linear_extension_bending_coupling_structural")
+set_tests_properties(Element_Edge2_Linear_Structural_Extension_Bending_Coupling_mpi
+    PROPERTIES
+        LABELS "MPI"
+        FIXTURES_REQUIRED  Element_Edge2_Linear_Structural_Extension_Bending_mpi
+        FIXTURES_SETUP     Element_Edge2_Linear_Structural_Extension_Bending_Coupling_mpi)
+
+
+
 add_test(NAME Element_Edge2_Linear_Structural_Extension_Bending_Shear
-COMMAND mast_catch_tests "edge2_linear_extension_bending_shear_structural")
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "edge2_linear_extension_bending_shear_structural")
 set_tests_properties(Element_Edge2_Linear_Structural_Extension_Bending_Shear
-                     PROPERTIES 
-                     FIXTURES_REQUIRED  Element_Edge2_Linear_Structural_Extension_Bending
-                     FIXTURES_SETUP     Element_Edge2_Linear_Structural_Extension_Bending_Shear)
-                     
+    PROPERTIES
+        LABELS "SEQ"
+        FIXTURES_REQUIRED  Element_Edge2_Linear_Structural_Extension_Bending
+        FIXTURES_SETUP     Element_Edge2_Linear_Structural_Extension_Bending_Shear)
+
+add_test(NAME Element_Edge2_Linear_Structural_Extension_Bending_Shear_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "edge2_linear_extension_bending_shear_structural")
+set_tests_properties(Element_Edge2_Linear_Structural_Extension_Bending_Shear_mpi
+    PROPERTIES
+        LABELS "MPI"
+        FIXTURES_REQUIRED  Element_Edge2_Linear_Structural_Extension_Bending_mpi
+        FIXTURES_SETUP     Element_Edge2_Linear_Structural_Extension_Bending_Shear_mpi)
+
+
+
 add_test(NAME Element_Edge2_Linear_Structural_All
-         COMMAND mast_catch_tests "edge2_linear_structural")
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "edge2_linear_structural")
 set_tests_properties(Element_Edge2_Linear_Structural_All
-                     PROPERTIES 
-                     FIXTURES_REQUIRED "Element_Edge2_Linear_Structural_Extension_Bending_Coupling;Element_Edge2_Linear_Structural_Extension_Bending_Shear"
-                     )
-                     
+    PROPERTIES
+        LABELS "SEQ"
+        FIXTURES_REQUIRED "Element_Edge2_Linear_Structural_Extension_Bending_Coupling;Element_Edge2_Linear_Structural_Extension_Bending_Shear")
+
+add_test(NAME Element_Edge2_Linear_Structural_All_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "edge2_linear_structural")
+set_tests_properties(Element_Edge2_Linear_Structural_All_mpi
+    PROPERTIES
+        LABELS "MPI"
+        FIXTURES_REQUIRED "Element_Edge2_Linear_Structural_Extension_Bending_Coupling_mpi;Element_Edge2_Linear_Structural_Extension_Bending_Shear_mpi")
+
+
+
 add_test(NAME Element_Edge2_Linear_Structural_Inertial_Consistent
-         COMMAND mast_catch_tests "edge2_linear_structural_inertial_consistent")
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "edge2_linear_structural_inertial_consistent")
 set_tests_properties(Element_Edge2_Linear_Structural_Inertial_Consistent
-                     PROPERTIES 
-                     FIXTURES_REQUIRED Element_1D_Structural_Basic_Tests)
-                     
+    PROPERTIES
+        LABELS "SEQ"
+        FIXTURES_REQUIRED Element_1D_Structural_Basic_Tests)
+
+add_test(NAME Element_Edge2_Linear_Structural_Inertial_Consistent_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "edge2_linear_structural_inertial_consistent")
+set_tests_properties(Element_Edge2_Linear_Structural_Inertial_Consistent_mpi
+    PROPERTIES
+        LABELS "MPI"
+        FIXTURES_REQUIRED Element_1D_Structural_Basic_Tests_mpi)
+
+
+
 add_test(NAME Element_Edge2_Linear_Structural_Inertial_Lumped
-         COMMAND mast_catch_tests "edge2_linear_structural_inertial_lumped")
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "edge2_linear_structural_inertial_lumped")
 set_tests_properties(Element_Edge2_Linear_Structural_Inertial_Lumped
-                     PROPERTIES 
-                     FIXTURES_REQUIRED Element_1D_Structural_Basic_Tests)
-                     
+    PROPERTIES
+        LABELS "SEQ"
+        FIXTURES_REQUIRED Element_1D_Structural_Basic_Tests)
+
+add_test(NAME Element_Edge2_Linear_Structural_Inertial_Lumped_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "edge2_linear_structural_inertial_lumped")
+set_tests_properties(Element_Edge2_Linear_Structural_Inertial_Lumped_mpi
+    PROPERTIES
+        LABELS "MPI"
+        FIXTURES_REQUIRED Element_1D_Structural_Basic_Tests_mpi)
+
+
+
 add_test(NAME Element_Edge2_Linear_Structural_Thermal
-         COMMAND mast_catch_tests "edge2_linear_structural_thermal_jacobian")
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "edge2_linear_structural_thermal_jacobian")
 set_tests_properties(Element_Edge2_Linear_Structural_Thermal
-                     PROPERTIES 
-                     FIXTURES_REQUIRED "Element_1D_Structural_Basic_Tests;Thermoelastic_Load"
-                     )
-                     
+    PROPERTIES
+        LABELS "SEQ"
+        FIXTURES_REQUIRED "Element_1D_Structural_Basic_Tests;Thermoelastic_Load")
+
+add_test(NAME Element_Edge2_Linear_Structural_Thermal_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "edge2_linear_structural_thermal_jacobian")
+set_tests_properties(Element_Edge2_Linear_Structural_Thermal_mpi
+    PROPERTIES
+        LABELS "MPI"
+        FIXTURES_REQUIRED "Element_1D_Structural_Basic_Tests;Thermoelastic_Load_mpi")
+
+
+
 add_test(NAME Element_Edge2_Nonlinear_Structural_Thermal
-         COMMAND mast_catch_tests "edge2_nonlinear_structural_thermal_jacobian")
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "edge2_nonlinear_structural_thermal_jacobian")
 set_tests_properties(Element_Edge2_Nonlinear_Structural_Thermal
-                     PROPERTIES 
-                     FIXTURES_REQUIRED "Element_1D_Structural_Basic_Tests;Thermoelastic_Load"
-                     )
+    PROPERTIES
+        LABELS "SEQ"
+        FIXTURES_REQUIRED "Element_1D_Structural_Basic_Tests;Thermoelastic_Load")
+
+add_test(NAME Element_Edge2_Nonlinear_Structural_Thermal_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "edge2_nonlinear_structural_thermal_jacobian")
+set_tests_properties(Element_Edge2_Nonlinear_Structural_Thermal_mpi
+    PROPERTIES
+        LABELS "MPI"
+        FIXTURES_REQUIRED "Element_1D_Structural_Basic_Tests;Thermoelastic_Load_mpi")

--- a/tests/element/structural/1D/edge2/mast_edge2_linear_structural_extension_bending_coupling_internal_jacobian.cpp
+++ b/tests/element/structural/1D/edge2/mast_edge2_linear_structural_extension_bending_coupling_internal_jacobian.cpp
@@ -35,7 +35,7 @@
 extern libMesh::LibMeshInit* p_global_init;
 
 
-TEST_CASE("edge2_linear_extension_structural",
+TEST_CASE("edge2_linear_extension_bending_coupling_structural",
           "[1D],[structural],[edge],[edge2],[linear]")
 {
     const int n_elems = 1;
@@ -97,6 +97,7 @@ TEST_CASE("edge2_linear_extension_structural",
     // Create field functions to dsitribute these constant parameters throughout the model
     MAST::ConstantFieldFunction E_f("E", E);
     MAST::ConstantFieldFunction nu_f("nu", nu);
+
     MAST::ConstantFieldFunction rho_f("rho", rho);
     MAST::ConstantFieldFunction alpha_f("alpha_expansion", alpha);
     MAST::ConstantFieldFunction cp_f("cp", cp);
@@ -134,12 +135,16 @@ TEST_CASE("edge2_linear_extension_structural",
     section.set_material(material);
     
     // Specify a section orientation point and add it to the section.
+    // FIXME: Orientation isn't affecting the element's jacobian for some reason
     RealVectorX orientation = RealVectorX::Zero(3);
-    orientation(1) = 1.0;
+    orientation(2) = 1.0;
     section.y_vector() = orientation;
     
     // Set the strain type to linear for the section
     section.set_strain(MAST::LINEAR_STRAIN);
+    
+    // Set the bending operator to Euler-Bernoulli
+    section.set_bending_model(MAST::BERNOULLI);
     
     // Now initialize the section
     section.init();
@@ -208,16 +213,8 @@ TEST_CASE("edge2_linear_extension_structural",
      */
     
     // Set shear coefficient to zero to disable transverse shear stiffness
-    kappa_zz = 0.0;
     kappa_yy = 0.0;
-    
-    // Set the offset to zero to disable extension-bending coupling
-    offset_y = 0.0;
-    offset_z = 0.0;
-    
-    // Set the bending operator to no_bending to disable bending stiffness
-    // NOTE: This also disables the transverse shear stiffness
-    section.set_bending_model(MAST::NO_BENDING);
+    kappa_zz = 0.0;
     
     // Calculate residual and jacobian
     RealVectorX residual = RealVectorX::Zero(n_dofs);
@@ -225,7 +222,9 @@ TEST_CASE("edge2_linear_extension_structural",
     elem->internal_residual(true, residual, jacobian0);
             
     double val_margin = (jacobian0.array().abs()).mean() * 1.490116119384766e-08;
-        
+    
+    libMesh::out << "J =\n" << jacobian0 << std::endl;
+    
     SECTION("internal_jacobian_finite_difference_check")                   
     {
         // Approximate Jacobian with Finite Difference
@@ -262,24 +261,25 @@ TEST_CASE("edge2_linear_extension_structural",
     {
         /**
          * Number of zero eigenvalues should equal the number of rigid body
-         * modes.  For 1D extension (including torsion), we have 1 rigid 
-         * translations along the element's x-axis and 1 rigid rotation about 
-         * the element's x-axis, for a total of 2 rigid body modes.
+         * modes.  With extension (including torsion) and bending about y and 
+         * z axes, we have 6 rigid body modes (3 translations, 3 rotations).
          * 
          * Note that the use of reduced integration can result in more rigid
          * body modes than expected.
          */
         SelfAdjointEigenSolver<RealMatrixX> eigensolver(jacobian0, false);
         RealVectorX eigenvalues = eigensolver.eigenvalues();
+        libMesh::out << "Eigenvalues are:\n" << eigenvalues << std::endl;
         uint nz = 0;
         for (uint i=0; i<eigenvalues.size(); i++)
         {
-            if (std::abs(eigenvalues(i))<1e-10)
+            if (std::abs(eigenvalues(i))<1.4901161193847656e-08)
             {
                 nz++;
             }
         }
-        REQUIRE( nz == 2);
+        libMesh::out << "Eigenvalues:\n" << eigenvalues << std::endl;
+        REQUIRE( nz == 6);
         
         /**
          * All non-zero eigenvalues should be positive.
@@ -288,10 +288,24 @@ TEST_CASE("edge2_linear_extension_structural",
     }
     
     
-//     SECTION("internal_jacobian_orientation_invariant")
-//     {
-//         
-//     }
+    SECTION("internal_jacobian_orientation_invariant")
+    {
+        section.clear();
+        RealVectorX orientation = RealVectorX::Zero(3);
+        orientation(2) = 1.0;
+        section.y_vector() = orientation;
+        section.init();
+        discipline.set_property_for_subdomain(0, section);
+        
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+                
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
+
+        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+    }
     
     
     SECTION("internal_jacobian_displacement_invariant")

--- a/tests/element/structural/1D/edge2/mast_edge2_linear_structural_extension_bending_coupling_internal_jacobian.cpp
+++ b/tests/element/structural/1D/edge2/mast_edge2_linear_structural_extension_bending_coupling_internal_jacobian.cpp
@@ -267,13 +267,14 @@ TEST_CASE("edge2_linear_extension_bending_coupling_structural",
          * Note that the use of reduced integration can result in more rigid
          * body modes than expected.
          */
+        Real eps = 1.4901161193847656e-07;
         SelfAdjointEigenSolver<RealMatrixX> eigensolver(jacobian0, false);
         RealVectorX eigenvalues = eigensolver.eigenvalues();
         libMesh::out << "Eigenvalues are:\n" << eigenvalues << std::endl;
         uint nz = 0;
         for (uint i=0; i<eigenvalues.size(); i++)
         {
-            if (std::abs(eigenvalues(i))<1.4901161193847656e-08)
+            if (std::abs(eigenvalues(i))<eps)
             {
                 nz++;
             }
@@ -284,7 +285,7 @@ TEST_CASE("edge2_linear_extension_bending_coupling_structural",
         /**
          * All non-zero eigenvalues should be positive.
          */
-        REQUIRE(eigenvalues.minCoeff()>(-1e-10));
+        REQUIRE(eigenvalues.minCoeff()>(-eps));
     }
     
     
@@ -295,7 +296,6 @@ TEST_CASE("edge2_linear_extension_bending_coupling_structural",
         orientation(2) = 1.0;
         section.y_vector() = orientation;
         section.init();
-        discipline.set_property_for_subdomain(0, section);
         
         RealVectorX residual = RealVectorX::Zero(n_dofs);
         RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);

--- a/tests/element/structural/1D/edge2/mast_edge2_linear_structural_extension_bending_internal_jacobian.cpp
+++ b/tests/element/structural/1D/edge2/mast_edge2_linear_structural_extension_bending_internal_jacobian.cpp
@@ -297,7 +297,6 @@ TEST_CASE("edge2_linear_extension_bending_structural",
         orientation(2) = 1.0;
         section.y_vector() = orientation;
         section.init();
-        discipline.set_property_for_subdomain(0, section);
         
         RealVectorX residual = RealVectorX::Zero(n_dofs);
         RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);

--- a/tests/element/structural/1D/edge2/mast_edge2_linear_structural_extension_bending_shear_internal_jacobian.cpp
+++ b/tests/element/structural/1D/edge2/mast_edge2_linear_structural_extension_bending_shear_internal_jacobian.cpp
@@ -293,7 +293,6 @@ TEST_CASE("edge2_linear_extension_bending_shear_structural",
         orientation(2) = 1.0;
         section.y_vector() = orientation;
         section.init();
-        discipline.set_property_for_subdomain(0, section);
         
         RealVectorX residual = RealVectorX::Zero(n_dofs);
         RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);

--- a/tests/element/structural/1D/edge2/mast_edge2_linear_structural_extension_internal_jacobian.cpp
+++ b/tests/element/structural/1D/edge2/mast_edge2_linear_structural_extension_internal_jacobian.cpp
@@ -1,0 +1,675 @@
+// C++ Stanard Includes
+#include <math.h>
+
+// Catch2 includes
+#include "catch.hpp"
+
+// libMesh includes
+#include "libmesh/libmesh.h"
+#include "libmesh/replicated_mesh.h"
+#include "libmesh/point.h"
+#include "libmesh/elem.h"
+#include "libmesh/edge_edge2.h"
+#include "libmesh/equation_systems.h"
+#include "libmesh/dof_map.h"
+
+// MAST includes
+#include "base/parameter.h"
+#include "base/constant_field_function.h"
+#include "property_cards/isotropic_material_property_card.h"
+#include "property_cards/solid_1d_section_element_property_card.h"
+#include "elasticity/structural_element_1d.h"
+#include "elasticity/structural_system_initialization.h"
+#include "base/physics_discipline_base.h"
+#include "base/nonlinear_implicit_assembly.h"
+#include "elasticity/structural_nonlinear_assembly.h"
+#include "base/nonlinear_system.h"
+#include "elasticity/structural_element_base.h"
+#include "mesh/geom_elem.h"
+
+// Custom includes
+#include "test_helpers.h"
+
+#define pi 3.14159265358979323846
+
+extern libMesh::LibMeshInit* p_global_init;
+
+// TODO: Implement patch test
+// TODO: Implement thermoelastic residual / Jacboian testing
+// TODO: Implement surface pressure residual / Jacobian
+// TODO: Implement piston theory residual / Jacobian testing
+// TODO: Implement other elements (Tri3, Tri6, Quad8, etc.)
+
+
+TEST_CASE("edge2_linear_extension_structural",
+          "[1D],[structural],[edge],[edge2],[linear]")
+{
+    const int n_elems = 1;
+    const int n_nodes = 2;
+    
+    RealMatrixX temp = RealMatrixX::Zero(3,n_nodes);
+    temp << -1.0, 1.0, 0.0, 0.0, 0.0, 0.0;
+    const RealMatrixX X0 = temp;
+    
+    /**
+     * Create the mesh with the one element we are testing
+     */
+    libMesh::ReplicatedMesh mesh(p_global_init->comm());
+    mesh.set_mesh_dimension(1);
+    mesh.set_spatial_dimension(3);
+    mesh.reserve_elem(n_elems);
+    mesh.reserve_nodes(n_nodes);
+    
+    // Add nodes to the mesh
+    for (uint i=0; i<n_nodes; i++)
+    {
+        mesh.add_point(libMesh::Point(X0(0,i), X0(1,i), X0(2,i)));
+    }
+    
+    // Add the element to the mesh
+    libMesh::Elem *reference_elem = new libMesh::Edge2;
+    reference_elem->set_id(0);    
+    reference_elem->subdomain_id() = 0;
+    reference_elem = mesh.add_elem(reference_elem);
+    for (int i=0; i<n_nodes; i++)
+    {
+        reference_elem->set_node(i) = mesh.node_ptr(i);
+    }
+    
+    // Prepare the mesh for use
+    mesh.prepare_for_use();
+    
+    // Ensure the libMesh element has the expected volume
+    const Real elem_volume = reference_elem->volume();
+    Real true_volume = 2.0;
+    REQUIRE( elem_volume == true_volume );
+    
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
+    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
+    MAST::Parameter rho("rho_param", 1420.5);         // Density
+    MAST::Parameter alpha("alpha_param", 5.43e-05);   // Coefficient of thermal expansion
+    MAST::Parameter cp("cp_param",   908.0);          // Specific Heat Capacity
+    MAST::Parameter k("k_param",     237.0);          // Thermal Conductivity
+    
+    // Define Section Properties as MAST Parameters
+    MAST::Parameter thickness_y("thy_param", 0.06);   // Section thickness in y-direction
+    MAST::Parameter thickness_z("thz_param", 0.04);   // Section thickness in z-direction
+    MAST::Parameter offset_y("offy_param", 0.035);    // Section offset in y-direction
+    MAST::Parameter offset_z("offz_param", 0.026);    // Section offset in z-direction
+    MAST::Parameter kappa_zz("kappa_zz", 5.0/6.0);    // Shear coefficient
+    MAST::Parameter kappa_yy("kappa_yy", 2.0/6.0);    // Shear coefficient
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction E_f("E", E);
+    MAST::ConstantFieldFunction nu_f("nu", nu);
+    MAST::ConstantFieldFunction rho_f("rho", rho);
+    MAST::ConstantFieldFunction alpha_f("alpha_expansion", alpha);
+    MAST::ConstantFieldFunction cp_f("cp", cp);
+    MAST::ConstantFieldFunction k_f("k_th", k);
+    MAST::ConstantFieldFunction thicknessy_f("hy", thickness_y);
+    MAST::ConstantFieldFunction offsety_f("hy_off", offset_y);
+    MAST::ConstantFieldFunction thicknessz_f("hz", thickness_z);
+    MAST::ConstantFieldFunction offsetz_f("hz_off", offset_z);
+    MAST::ConstantFieldFunction kappa_zz_f("Kappazz", kappa_zz);
+    MAST::ConstantFieldFunction kappa_yy_f("Kappayy", kappa_yy);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(E_f);
+    material.add(nu_f);
+    material.add(rho_f);
+    material.add(alpha_f);
+    material.add(k_f);
+    material.add(cp_f);
+    
+    // Initialize the section
+    MAST::Solid1DSectionElementPropertyCard section;
+    
+    // Add the section property constant field functions to the section card
+    section.add(thicknessy_f);
+    section.add(offsety_f);
+    section.add(thicknessz_f);
+    section.add(offsetz_f);
+    section.add(kappa_zz_f);
+    section.add(kappa_yy_f);
+    
+    // Add the material card to the section card
+    section.set_material(material);
+    
+    // Specify a section orientation point and add it to the section.
+    RealVectorX orientation = RealVectorX::Zero(3);
+    orientation(1) = 1.0;
+    section.y_vector() = orientation;
+    
+    // Set the strain type to linear for the section
+    section.set_strain(MAST::LINEAR_STRAIN);
+    
+    // Now initialize the section
+    section.init();
+    
+    /**
+     *  Now we setup the structural system we will be solving.
+     */
+    libMesh::EquationSystems equation_systems(mesh);
+    
+    MAST::NonlinearSystem& system = equation_systems.add_system<MAST::NonlinearSystem>("structural");
+    
+    libMesh::FEType fetype(libMesh::FIRST, libMesh::LAGRANGE);
+    
+    MAST::StructuralSystemInitialization structural_system(system, 
+                                                           system.name(), 
+                                                           fetype);
+    
+    MAST::PhysicsDisciplineBase discipline(equation_systems);
+    
+    discipline.set_property_for_subdomain(0, section);
+    
+    equation_systems.init();
+    //equation_systems.print_info();
+    
+    MAST::NonlinearImplicitAssembly assembly;
+    assembly.set_discipline_and_system(discipline, structural_system);
+    
+    // Create the MAST element from the libMesh reference element
+    MAST::GeomElem geom_elem;
+    geom_elem.init(*reference_elem, structural_system);
+    std::unique_ptr<MAST::StructuralElementBase> elem_base = build_structural_element(structural_system, geom_elem, section);
+    
+    // Cast the base structural element as a 2D structural element
+    MAST::StructuralElement1D* elem = (dynamic_cast<MAST::StructuralElement1D*>(elem_base.get()));
+    
+    // Get element DOFs
+    const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
+    std::vector<libMesh::dof_id_type> dof_indices;
+    dof_map.dof_indices (reference_elem, dof_indices);
+    uint n_dofs = uint(dof_indices.size());
+    
+    // Set element's initial solution and solution sensitivity to zero
+    RealVectorX elem_solution = RealVectorX::Zero(n_dofs);
+    elem->set_solution(elem_solution);
+    elem->set_solution(elem_solution, true);
+    
+    const Real V0 = reference_elem->volume();
+    
+    /**
+     *  Below, we start building the Jacobian up for a very basic element that 
+     *  is already in an isoparametric format.  The following four steps:
+     *      Extension Only Stiffness
+     *      Extension & Bending Stiffness
+     *      Extension, Bending, & Transverse Shear Stiffness
+     *      Extension, Bending, & Extension-Bending Coupling Stiffness
+     *      Extension, Bending, Transverse Shear & Extension-Bending Coupling Stiffness
+     * 
+     *  Testing the Jacobian incrementally this way allows errors in the
+     *  Jacobian to be located more precisely.
+     * 
+     *  It would probably be even better to test each stiffness contribution 
+     *  separately, but currently, we don't have a way to disable extension
+     *  stiffness and transverse shear stiffness doesn't exist without bending 
+     *  and extension-bending coupling stiffness don't make sense without both
+     *  extension and/or bending. 
+     */
+    
+    // Set shear coefficient to zero to disable transverse shear stiffness
+    kappa_zz = 0.0;
+    kappa_yy = 0.0;
+    
+    // Set the offset to zero to disable extension-bending coupling
+    offset_y = 0.0;
+    offset_z = 0.0;
+    
+    // Set the bending operator to no_bending to disable bending stiffness
+    // NOTE: This also disables the transverse shear stiffness
+    section.set_bending_model(MAST::NO_BENDING);
+    
+    // Calculate residual and jacobian
+    RealVectorX residual = RealVectorX::Zero(n_dofs);
+    RealMatrixX jacobian0 = RealMatrixX::Zero(n_dofs, n_dofs);
+    elem->internal_residual(true, residual, jacobian0);
+            
+    double val_margin = (jacobian0.array().abs()).mean() * 1.490116119384766e-08;
+        
+    SECTION("internal_jacobian_finite_difference_check")                   
+    {
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+    }
+    
+    
+    SECTION("internal_jacobian_symmetry_check")
+    {
+        // Element stiffness matrix should be symmetric
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0.transpose());
+        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    
+    SECTION("internal_jacobian_determinant_check")
+    {
+        // Determinant of undeformed element stiffness matrix should be zero
+        REQUIRE( jacobian0.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    
+    SECTION("internal_jacobian_eigenvalue_check")
+    {
+        /**
+         * Number of zero eigenvalues should equal the number of rigid body
+         * modes.  For 1D extension (including torsion), we have 1 rigid 
+         * translations along the element's x-axis and 1 rigid rotation about 
+         * the element's x-axis, for a total of 2 rigid body modes.
+         * 
+         * Note that the use of reduced integration can result in more rigid
+         * body modes than expected.
+         */
+        SelfAdjointEigenSolver<RealMatrixX> eigensolver(jacobian0, false);
+        RealVectorX eigenvalues = eigensolver.eigenvalues();
+        uint nz = 0;
+        for (uint i=0; i<eigenvalues.size(); i++)
+        {
+            if (std::abs(eigenvalues(i))<1e-10)
+            {
+                nz++;
+            }
+        }
+        REQUIRE( nz == 2);
+        
+        /**
+         * All non-zero eigenvalues should be positive.
+         */
+        REQUIRE(eigenvalues.minCoeff()>(-1e-10));
+    }
+    
+    
+//     SECTION("internal_jacobian_orientation_invariant")
+//     {
+//         
+//     }
+    
+    
+    SECTION("internal_jacobian_displacement_invariant")
+    {
+        // Calculate residual and jacobian at arbitrary displacement
+        RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
+        elem_sol << 0.05727841,  0.08896581,  0.09541619, -0.03774913,  
+                    0.07510557, -0.07122266, -0.00979117, -0.08300009, 
+                    -0.03453369, -0.05487761, -0.01407677, -0.09268421;
+        elem->set_solution(elem_sol);
+        
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+                
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
+
+        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+    }
+    
+    SECTION("internal_jacobian_shifted_x_invariant")
+    {
+        // Shifted in x-direction
+        transform_element(mesh, X0, 5.2, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+                
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
+
+        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+    }
+    
+    SECTION("internal_jacobian_shifted_y_invariant")
+    {
+        // Shifted in y-direction
+        transform_element(mesh, X0, 0.0, -11.5, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
+        
+        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+    }
+    
+    SECTION("internal_jacobian_shifted_z_invariant")
+    {
+        // Shifted in y-direction
+        transform_element(mesh, X0, 0.0, 0.0, 7.6, 1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
+        
+        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+    }
+    
+    
+    SECTION("internal_jacobian_aligned_y")
+    {
+        /*
+         * NOTE: We could try to use the transform_element method here, but the
+         * issue is that if the sin and cos calculations are not exact, then we
+         * may not be perfectly aligned along the y axis like we want.
+         */
+        RealMatrixX X= RealMatrixX::Zero(3,n_nodes);
+        X << 0.0, 0.0, -1.0, 1.0, 0.0, 0.0;
+        for (int i=0; i<n_nodes; i++)
+        {
+            (*mesh.node_ptr(i)) = libMesh::Point(X(0,i), X(1,i), X(2,i));
+        }
+        
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_aligned_z")
+    {
+        /*
+         * NOTE: We could try to use the transform_element method here, but the
+         * issue is that if the sin and cos calculations are not exact, then we
+         * may not be perfectly aligned along the z axis like we want.
+         */
+        RealMatrixX X= RealMatrixX::Zero(3,n_nodes);
+        X << 0.0, 0.0, 0.0, 0.0, -1.0, 1.0;
+        for (int i=0; i<n_nodes; i++)
+        {
+            (*mesh.node_ptr(i)) = libMesh::Point(X(0,i), X(1,i), X(2,i));
+        }
+        
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_rotated_about_z")
+    {
+        // Rotated 63.4 about z-axis at element's centroid
+        transform_element(mesh, X0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 63.4);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_rotated_about_y")
+    {
+        // Rotated 35.8 about y-axis at element's centroid
+        transform_element(mesh, X0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 35.8, 0.0);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_scaled_x")
+    {
+        // Rotated 63.4 about z-axis at element's centroid
+        transform_element(mesh, X0, 0.0, 0.0, 0.0, 3.2, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_arbitrary_transformation")
+    {
+        // Arbitrary transformations applied to the element
+        transform_element(mesh, X0, -5.0, 7.8, -13.1, 2.7, 6.4, 20.0, 47.8, -70.1);
+        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_arbitrary_with_displacements")
+    {
+        // Arbitrary transformations applied to the element
+        transform_element(mesh, X0, 4.1, -6.3, 7.5, 4.2, 1.5, -18.0, -24.8, 
+                          30.1);
+        
+        // Calculate residual and jacobian at arbitrary displacement
+        RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
+        elem_sol << 0.08158724,  0.07991906, -0.00719128,  0.02025461, 
+                    -0.04602193, 0.05280159,  0.03700081,  0.04636344,  
+                    0.05559377,  0.06448206, 0.08919238, -0.03079122;
+        elem->set_solution(elem_sol);
+        
+        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+}

--- a/tests/element/structural/1D/edge2/mast_edge2_linear_structural_inertial_jacobian.cpp
+++ b/tests/element/structural/1D/edge2/mast_edge2_linear_structural_inertial_jacobian.cpp
@@ -1,0 +1,475 @@
+// C++ Stanard Includes
+#include <math.h>
+
+// Catch2 includes
+#include "catch.hpp"
+
+// libMesh includes
+#include "libmesh/libmesh.h"
+#include "libmesh/replicated_mesh.h"
+#include "libmesh/point.h"
+#include "libmesh/elem.h"
+#include "libmesh/edge_edge2.h"
+#include "libmesh/equation_systems.h"
+#include "libmesh/dof_map.h"
+
+// MAST includes
+#include "base/parameter.h"
+#include "base/constant_field_function.h"
+#include "property_cards/isotropic_material_property_card.h"
+#include "property_cards/solid_1d_section_element_property_card.h"
+#include "elasticity/structural_element_1d.h"
+#include "elasticity/structural_system_initialization.h"
+#include "base/physics_discipline_base.h"
+#include "base/nonlinear_implicit_assembly.h"
+#include "elasticity/structural_nonlinear_assembly.h"
+#include "base/nonlinear_system.h"
+#include "elasticity/structural_element_base.h"
+#include "mesh/geom_elem.h"
+
+// Custom includes
+#include "test_helpers.h"
+
+#define pi 3.14159265358979323846
+
+extern libMesh::LibMeshInit* p_global_init;
+
+
+TEST_CASE("edge2_linear_structural_inertial_consistent",
+          "[1D],[dynamic],[edge],[edge2],[element]")
+{
+    const int n_elems = 1;
+    const int n_nodes = 2;
+    
+    RealMatrixX temp = RealMatrixX::Zero(3,n_nodes);
+    temp << -1.0, 1.0, 0.0, 0.0, 0.0, 0.0;
+    const RealMatrixX X0 = temp;
+    
+    /**
+     * Create the mesh with the one element we are testing
+     */
+    libMesh::ReplicatedMesh mesh(p_global_init->comm());
+    mesh.set_mesh_dimension(1);
+    mesh.set_spatial_dimension(3);
+    mesh.reserve_elem(n_elems);
+    mesh.reserve_nodes(n_nodes);
+    
+    // Add nodes to the mesh
+    for (uint i=0; i<n_nodes; i++)
+    {
+        mesh.add_point(libMesh::Point(X0(0,i), X0(1,i), X0(2,i)));
+    }
+    
+    // Add the element to the mesh
+    libMesh::Elem *reference_elem = new libMesh::Edge2;
+    reference_elem->set_id(0);    
+    reference_elem->subdomain_id() = 0;
+    reference_elem = mesh.add_elem(reference_elem);
+    for (int i=0; i<n_nodes; i++)
+    {
+        reference_elem->set_node(i) = mesh.node_ptr(i);
+    }
+    
+    // Prepare the mesh for use
+    mesh.prepare_for_use();
+    
+    // Ensure the libMesh element has the expected volume
+    const Real elem_volume = reference_elem->volume();
+    Real true_volume = 2.0;
+    REQUIRE( elem_volume == true_volume );
+    
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
+    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
+    MAST::Parameter rho("rho_param", 1420.5);         // Density
+    MAST::Parameter alpha("alpha_param", 5.43e-05);   // Coefficient of thermal expansion
+    MAST::Parameter cp("cp_param",   908.0);          // Specific Heat Capacity
+    MAST::Parameter k("k_param",     237.0);          // Thermal Conductivity
+    
+    // Define Section Properties as MAST Parameters
+    MAST::Parameter thickness_y("thy_param", 0.8);   // Section thickness in y-direction
+    MAST::Parameter thickness_z("thz_param", 0.7);   // Section thickness in z-direction
+    MAST::Parameter offset_y("offy_param", 0.5);    // Section offset in y-direction
+    MAST::Parameter offset_z("offz_param", 0.4);    // Section offset in z-direction
+    MAST::Parameter kappa_zz("kappa_zz", 5.0/6.0);    // Shear coefficient
+    MAST::Parameter kappa_yy("kappa_yy", 2.0/6.0);    // Shear coefficient
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction E_f("E", E);
+    MAST::ConstantFieldFunction nu_f("nu", nu);
+    MAST::ConstantFieldFunction rho_f("rho", rho);
+    MAST::ConstantFieldFunction alpha_f("alpha_expansion", alpha);
+    MAST::ConstantFieldFunction cp_f("cp", cp);
+    MAST::ConstantFieldFunction k_f("k_th", k);
+    MAST::ConstantFieldFunction thicknessy_f("hy", thickness_y);
+    MAST::ConstantFieldFunction offsety_f("hy_off", offset_y);
+    MAST::ConstantFieldFunction thicknessz_f("hz", thickness_z);
+    MAST::ConstantFieldFunction offsetz_f("hz_off", offset_z);
+    MAST::ConstantFieldFunction kappa_zz_f("Kappazz", kappa_zz);
+    MAST::ConstantFieldFunction kappa_yy_f("Kappayy", kappa_yy);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(E_f);
+    material.add(nu_f);
+    material.add(rho_f);
+    material.add(alpha_f);
+    material.add(k_f);
+    material.add(cp_f);
+    
+    // Initialize the section
+    MAST::Solid1DSectionElementPropertyCard section;
+    
+    // Add the section property constant field functions to the section card
+    section.add(thicknessy_f);
+    section.add(offsety_f);
+    section.add(thicknessz_f);
+    section.add(offsetz_f);
+    section.add(kappa_zz_f);
+    section.add(kappa_yy_f);
+    
+    // Add the material card to the section card
+    section.set_material(material);
+    
+    // Specify a section orientation point and add it to the section.
+    RealVectorX orientation = RealVectorX::Zero(3);
+    orientation(2) = 1.0;
+    section.y_vector() = orientation;
+    
+    // Set the strain type to linear for the section
+    section.set_strain(MAST::LINEAR_STRAIN);
+    
+    // Set the bending operator to Timoshenko
+    section.set_bending_model(MAST::TIMOSHENKO);
+    
+    // Now initialize the section
+    section.init();
+    
+    /**
+     *  Now we setup the structural system we will be solving.
+     */
+    libMesh::EquationSystems equation_systems(mesh);
+    
+    MAST::NonlinearSystem& system = equation_systems.add_system<MAST::NonlinearSystem>("structural");
+    
+    libMesh::FEType fetype(libMesh::FIRST, libMesh::LAGRANGE);
+    
+    MAST::StructuralSystemInitialization structural_system(system, 
+                                                           system.name(), 
+                                                           fetype);
+    
+    MAST::PhysicsDisciplineBase discipline(equation_systems);
+    
+    discipline.set_property_for_subdomain(0, section);
+    
+    equation_systems.init();
+    //equation_systems.print_info();
+    
+    MAST::NonlinearImplicitAssembly assembly;
+    assembly.set_discipline_and_system(discipline, structural_system);
+    
+    // Create the MAST element from the libMesh reference element
+    MAST::GeomElem geom_elem;
+    geom_elem.init(*reference_elem, structural_system);
+    std::unique_ptr<MAST::StructuralElementBase> elem_base = build_structural_element(structural_system, geom_elem, section);
+    
+    // Cast the base structural element as a 2D structural element
+    MAST::StructuralElement1D* elem = (dynamic_cast<MAST::StructuralElement1D*>(elem_base.get()));
+    
+    // Get element DOFs
+    const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
+    std::vector<libMesh::dof_id_type> dof_indices;
+    dof_map.dof_indices (reference_elem, dof_indices);
+    uint n_dofs = uint(dof_indices.size());
+    
+    // Set element's initial solution and solution sensitivity to zero
+    RealVectorX elem_solution = RealVectorX::Zero(n_dofs);
+    elem->set_solution(elem_solution);
+    elem->set_solution(elem_solution, true);
+    
+    // Set element's initial acceleration and acceleration sensitivity to zero
+    RealVectorX elem_accel = RealVectorX::Zero(n_dofs);
+    elem->set_acceleration(elem_accel);
+    elem->set_acceleration(elem_accel, true);
+    
+    const Real V0 = reference_elem->volume();
+    
+    // Calculate residual and jacobian
+    RealVectorX residual = RealVectorX::Zero(n_dofs);
+    RealMatrixX jac0 = RealMatrixX::Zero(n_dofs, n_dofs);
+    RealMatrixX jac_xddot0 = RealMatrixX::Zero(n_dofs, n_dofs);
+    RealMatrixX jac_xdot0 = RealMatrixX::Zero(n_dofs, n_dofs);
+    elem->inertial_residual(true, residual, jac_xddot0, jac_xdot0, jac0);
+            
+    double val_margin = (jac_xddot0.array().abs()).mean() * 1.490116119384766e-08;
+    
+    //libMesh::out << "Jac_xddot0:\n" << jac_xddot0 << std::endl;
+    
+    SECTION("inertial_jacobian_finite_difference_check")                   
+    {
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_inertial_jacobian_with_finite_difference(*elem, elem_accel, jacobian_fd);
+        
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        
+        std::vector<double> test =  eigen_matrix_to_std_vector(jac_xddot0);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+    }
+    
+    
+    SECTION("inertial_jacobian_symmetry_check")
+    {
+        // Element inertial jacobian should be symmetric
+        std::vector<double> test =  eigen_matrix_to_std_vector(jac_xddot0);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jac_xddot0.transpose());
+        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    
+    SECTION("inertial_jacobian_determinant_check")
+    {
+        // Determinant of inertial jacobian should be positive
+        REQUIRE( jac_xddot0.determinant() > 0.0 );
+    }
+    
+    
+    SECTION("inertial_jacobian_eigenvalue_check")
+    {
+        /**
+         * A lumped mass matrix should have all positive eigenvalues since it
+         * is a diagonal matrix and masses should not be zero or negative.
+         */
+        SelfAdjointEigenSolver<RealMatrixX> eigensolver(jac_xddot0, false);
+        RealVectorX eigenvalues = eigensolver.eigenvalues();
+        //libMesh::out << "Eigenvalues are:\n" << eigenvalues << std::endl;
+        REQUIRE(eigenvalues.minCoeff()>0.0);
+    }
+}
+
+
+TEST_CASE("edge2_linear_structural_inertial_lumped",
+          "[1D],[dynamic],[edge],[edge2]")
+{
+    const int n_elems = 1;
+    const int n_nodes = 2;
+    
+    RealMatrixX temp = RealMatrixX::Zero(3,n_nodes);
+    temp << -1.0, 1.0, 0.0, 0.0, 0.0, 0.0;
+    const RealMatrixX X0 = temp;
+    
+    /**
+     * Create the mesh with the one element we are testing
+     */
+    libMesh::ReplicatedMesh mesh(p_global_init->comm());
+    mesh.set_mesh_dimension(1);
+    mesh.set_spatial_dimension(3);
+    mesh.reserve_elem(n_elems);
+    mesh.reserve_nodes(n_nodes);
+    
+    // Add nodes to the mesh
+    for (uint i=0; i<n_nodes; i++)
+    {
+        mesh.add_point(libMesh::Point(X0(0,i), X0(1,i), X0(2,i)));
+    }
+    
+    // Add the element to the mesh
+    libMesh::Elem *reference_elem = new libMesh::Edge2;
+    reference_elem->set_id(0);    
+    reference_elem->subdomain_id() = 0;
+    reference_elem = mesh.add_elem(reference_elem);
+    for (int i=0; i<n_nodes; i++)
+    {
+        reference_elem->set_node(i) = mesh.node_ptr(i);
+    }
+    
+    // Prepare the mesh for use
+    mesh.prepare_for_use();
+    
+    // Ensure the libMesh element has the expected volume
+    const Real elem_volume = reference_elem->volume();
+    Real true_volume = 2.0;
+    REQUIRE( elem_volume == true_volume );
+    
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
+    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
+    MAST::Parameter rho("rho_param", 1420.5);         // Density
+    MAST::Parameter alpha("alpha_param", 5.43e-05);   // Coefficient of thermal expansion
+    MAST::Parameter cp("cp_param",   908.0);          // Specific Heat Capacity
+    MAST::Parameter k("k_param",     237.0);          // Thermal Conductivity
+    
+    // Define Section Properties as MAST Parameters
+    MAST::Parameter thickness_y("thy_param", 0.8);   // Section thickness in y-direction
+    MAST::Parameter thickness_z("thz_param", 0.7);   // Section thickness in z-direction
+    MAST::Parameter offset_y("offy_param", 0.5);    // Section offset in y-direction
+    MAST::Parameter offset_z("offz_param", 0.4);    // Section offset in z-direction
+    MAST::Parameter kappa_zz("kappa_zz", 5.0/6.0);    // Shear coefficient
+    MAST::Parameter kappa_yy("kappa_yy", 2.0/6.0);    // Shear coefficient
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction E_f("E", E);
+    MAST::ConstantFieldFunction nu_f("nu", nu);
+    MAST::ConstantFieldFunction rho_f("rho", rho);
+    MAST::ConstantFieldFunction alpha_f("alpha_expansion", alpha);
+    MAST::ConstantFieldFunction cp_f("cp", cp);
+    MAST::ConstantFieldFunction k_f("k_th", k);
+    MAST::ConstantFieldFunction thicknessy_f("hy", thickness_y);
+    MAST::ConstantFieldFunction offsety_f("hy_off", offset_y);
+    MAST::ConstantFieldFunction thicknessz_f("hz", thickness_z);
+    MAST::ConstantFieldFunction offsetz_f("hz_off", offset_z);
+    MAST::ConstantFieldFunction kappa_zz_f("Kappazz", kappa_zz);
+    MAST::ConstantFieldFunction kappa_yy_f("Kappayy", kappa_yy);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(E_f);
+    material.add(nu_f);
+    material.add(rho_f);
+    material.add(alpha_f);
+    material.add(k_f);
+    material.add(cp_f);
+    
+    // Initialize the section
+    MAST::Solid1DSectionElementPropertyCard section;
+    
+    // Add the section property constant field functions to the section card
+    section.add(thicknessy_f);
+    section.add(offsety_f);
+    section.add(thicknessz_f);
+    section.add(offsetz_f);
+    section.add(kappa_zz_f);
+    section.add(kappa_yy_f);
+    
+    // Add the material card to the section card
+    section.set_material(material);
+    
+    // Specify a section orientation point and add it to the section.
+    RealVectorX orientation = RealVectorX::Zero(3);
+    orientation(2) = 1.0;
+    section.y_vector() = orientation;
+    
+    // Set the strain type to linear for the section
+    section.set_strain(MAST::LINEAR_STRAIN);
+    
+    // Set the bending operator to Euler-Bernoulli
+    section.set_bending_model(MAST::TIMOSHENKO);
+    
+    // Set the mass matrix to be lumped as opposed to the default, consistent
+    section.set_diagonal_mass_matrix(true);
+    REQUIRE( section.if_diagonal_mass_matrix() );
+    
+    // Now initialize the section
+    section.init();
+    
+    /**
+     *  Now we setup the structural system we will be solving.
+     */
+    libMesh::EquationSystems equation_systems(mesh);
+    
+    MAST::NonlinearSystem& system = equation_systems.add_system<MAST::NonlinearSystem>("structural");
+    
+    libMesh::FEType fetype(libMesh::FIRST, libMesh::LAGRANGE);
+    
+    MAST::StructuralSystemInitialization structural_system(system, 
+                                                           system.name(), 
+                                                           fetype);
+    
+    MAST::PhysicsDisciplineBase discipline(equation_systems);
+    
+    discipline.set_property_for_subdomain(0, section);
+    
+    equation_systems.init();
+    //equation_systems.print_info();
+    
+    MAST::NonlinearImplicitAssembly assembly;
+    assembly.set_discipline_and_system(discipline, structural_system);
+    
+    // Create the MAST element from the libMesh reference element
+    MAST::GeomElem geom_elem;
+    geom_elem.init(*reference_elem, structural_system);
+    std::unique_ptr<MAST::StructuralElementBase> elem_base = build_structural_element(structural_system, geom_elem, section);
+    
+    // Cast the base structural element as a 2D structural element
+    MAST::StructuralElement1D* elem = (dynamic_cast<MAST::StructuralElement1D*>(elem_base.get()));
+    
+    // Get element DOFs
+    const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
+    std::vector<libMesh::dof_id_type> dof_indices;
+    dof_map.dof_indices (reference_elem, dof_indices);
+    uint n_dofs = uint(dof_indices.size());
+    
+    // Set element's initial solution and solution sensitivity to zero
+    RealVectorX elem_solution = RealVectorX::Zero(n_dofs);
+    elem->set_solution(elem_solution);
+    elem->set_solution(elem_solution, true);
+    
+    // Set element's initial acceleration and acceleration sensitivity to zero
+    RealVectorX elem_accel = RealVectorX::Zero(n_dofs);
+    elem->set_acceleration(elem_accel);
+    elem->set_acceleration(elem_accel, true);
+    
+    const Real V0 = reference_elem->volume();
+    
+    // Calculate residual and jacobian
+    RealVectorX residual = RealVectorX::Zero(n_dofs);
+    RealMatrixX jac0 = RealMatrixX::Zero(n_dofs, n_dofs);
+    RealMatrixX jac_xddot0 = RealMatrixX::Zero(n_dofs, n_dofs);
+    RealMatrixX jac_xdot0 = RealMatrixX::Zero(n_dofs, n_dofs);
+    elem->inertial_residual(true, residual, jac_xddot0, jac_xdot0, jac0);
+            
+    double val_margin = (jac_xddot0.array().abs()).mean() * 1.490116119384766e-08;
+    
+    //libMesh::out << "Jac_xddot0:\n" << jac_xddot0 << std::endl;
+    
+    SECTION("inertial_jacobian_finite_difference_check")                   
+    {
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_inertial_jacobian_with_finite_difference(*elem, elem_accel, jacobian_fd);
+        
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        
+        std::vector<double> test =  eigen_matrix_to_std_vector(jac_xddot0);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+    }
+    
+    
+    SECTION("inertial_jacobian_symmetry_check")
+    {
+        // Element interial jacobian should be symmetric
+        std::vector<double> test =  eigen_matrix_to_std_vector(jac_xddot0);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jac_xddot0.transpose());
+        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    
+    SECTION("inertial_jacobian_determinant_check")
+    {
+        // Determinant of inertial jacobian should be positive
+        REQUIRE( jac_xddot0.determinant() > 0.0 );
+    }
+    
+    
+    SECTION("inertial_jacobian_eigenvalue_check")
+    {
+        /**
+         * A lumped mass matrix should have all positive eigenvalues since it
+         * is a diagonal matrix and masses should not be zero or negative.
+         */
+        SelfAdjointEigenSolver<RealMatrixX> eigensolver(jac_xddot0, false);
+        RealVectorX eigenvalues = eigensolver.eigenvalues();
+        //libMesh::out << "Eigenvalues are:\n" << eigenvalues << std::endl;
+        REQUIRE(eigenvalues.minCoeff()>0.0);
+    }
+}

--- a/tests/element/structural/1D/edge2/mast_edge2_linear_structural_internal_jacobian.cpp
+++ b/tests/element/structural/1D/edge2/mast_edge2_linear_structural_internal_jacobian.cpp
@@ -34,8 +34,14 @@
 
 extern libMesh::LibMeshInit* p_global_init;
 
+// TODO: Implement patch test
+// TODO: Implement thermoelastic residual / Jacboian testing
+// TODO: Implement surface pressure residual / Jacobian
+// TODO: Implement piston theory residual / Jacobian testing
+// TODO: Implement other elements (Tri3, Tri6, Quad8, etc.)
 
-TEST_CASE("edge2_linear_extension_structural",
+
+TEST_CASE("edge2_linear_structural",
           "[1D],[structural],[edge],[edge2],[linear]")
 {
     const int n_elems = 1;
@@ -87,10 +93,10 @@ TEST_CASE("edge2_linear_extension_structural",
     MAST::Parameter k("k_param",     237.0);          // Thermal Conductivity
     
     // Define Section Properties as MAST Parameters
-    MAST::Parameter thickness_y("thy_param", 0.06);   // Section thickness in y-direction
-    MAST::Parameter thickness_z("thz_param", 0.04);   // Section thickness in z-direction
-    MAST::Parameter offset_y("offy_param", 0.035);    // Section offset in y-direction
-    MAST::Parameter offset_z("offz_param", 0.026);    // Section offset in z-direction
+    MAST::Parameter thickness_y("thy_param", 0.8);   // Section thickness in y-direction
+    MAST::Parameter thickness_z("thz_param", 0.7);   // Section thickness in z-direction
+    MAST::Parameter offset_y("offy_param", 0.5);    // Section offset in y-direction
+    MAST::Parameter offset_z("offz_param", 0.4);    // Section offset in z-direction
     MAST::Parameter kappa_zz("kappa_zz", 5.0/6.0);    // Shear coefficient
     MAST::Parameter kappa_yy("kappa_yy", 2.0/6.0);    // Shear coefficient
     
@@ -134,12 +140,16 @@ TEST_CASE("edge2_linear_extension_structural",
     section.set_material(material);
     
     // Specify a section orientation point and add it to the section.
+    // FIXME: Orientation isn't affecting the element's jacobian for some reason
     RealVectorX orientation = RealVectorX::Zero(3);
-    orientation(1) = 1.0;
+    orientation(2) = 1.0;
     section.y_vector() = orientation;
     
     // Set the strain type to linear for the section
     section.set_strain(MAST::LINEAR_STRAIN);
+    
+    // Set the bending operator to Euler-Bernoulli
+    section.set_bending_model(MAST::TIMOSHENKO);
     
     // Now initialize the section
     section.init();
@@ -207,25 +217,15 @@ TEST_CASE("edge2_linear_extension_structural",
      *  extension and/or bending. 
      */
     
-    // Set shear coefficient to zero to disable transverse shear stiffness
-    kappa_zz = 0.0;
-    kappa_yy = 0.0;
-    
-    // Set the offset to zero to disable extension-bending coupling
-    offset_y = 0.0;
-    offset_z = 0.0;
-    
-    // Set the bending operator to no_bending to disable bending stiffness
-    // NOTE: This also disables the transverse shear stiffness
-    section.set_bending_model(MAST::NO_BENDING);
-    
     // Calculate residual and jacobian
     RealVectorX residual = RealVectorX::Zero(n_dofs);
     RealMatrixX jacobian0 = RealMatrixX::Zero(n_dofs, n_dofs);
     elem->internal_residual(true, residual, jacobian0);
             
     double val_margin = (jacobian0.array().abs()).mean() * 1.490116119384766e-08;
-        
+    
+    libMesh::out << "J =\n" << jacobian0 << std::endl;
+    
     SECTION("internal_jacobian_finite_difference_check")                   
     {
         // Approximate Jacobian with Finite Difference
@@ -262,36 +262,50 @@ TEST_CASE("edge2_linear_extension_structural",
     {
         /**
          * Number of zero eigenvalues should equal the number of rigid body
-         * modes.  For 1D extension (including torsion), we have 1 rigid 
-         * translations along the element's x-axis and 1 rigid rotation about 
-         * the element's x-axis, for a total of 2 rigid body modes.
+         * modes.  With extension (including torsion) and bending about y and 
+         * z axes, we have 6 rigid body modes (3 translations, 3 rotations).
          * 
          * Note that the use of reduced integration can result in more rigid
          * body modes than expected.
          */
         SelfAdjointEigenSolver<RealMatrixX> eigensolver(jacobian0, false);
         RealVectorX eigenvalues = eigensolver.eigenvalues();
+        libMesh::out << "Eigenvalues are:\n" << eigenvalues << std::endl;
         uint nz = 0;
         for (uint i=0; i<eigenvalues.size(); i++)
         {
-            if (std::abs(eigenvalues(i))<1e-10)
+            if (std::abs(eigenvalues(i))<0.0001220703125)
             {
                 nz++;
             }
         }
-        REQUIRE( nz == 2);
+        REQUIRE( nz == 6);
         
         /**
          * All non-zero eigenvalues should be positive.
          */
-        REQUIRE(eigenvalues.minCoeff()>(-1e-10));
+        REQUIRE(eigenvalues.minCoeff()>(-0.0001220703125));
     }
     
     
-//     SECTION("internal_jacobian_orientation_invariant")
-//     {
-//         
-//     }
+    SECTION("internal_jacobian_orientation_invariant")
+    {
+        section.clear();
+        RealVectorX orientation = RealVectorX::Zero(3);
+        orientation(2) = 1.0;
+        section.y_vector() = orientation;
+        section.init();
+        discipline.set_property_for_subdomain(0, section);
+        
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+                
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
+
+        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+    }
     
     
     SECTION("internal_jacobian_displacement_invariant")

--- a/tests/element/structural/1D/edge2/mast_edge2_linear_structural_internal_jacobian.cpp
+++ b/tests/element/structural/1D/edge2/mast_edge2_linear_structural_internal_jacobian.cpp
@@ -34,12 +34,6 @@
 
 extern libMesh::LibMeshInit* p_global_init;
 
-// TODO: Implement patch test
-// TODO: Implement thermoelastic residual / Jacboian testing
-// TODO: Implement surface pressure residual / Jacobian
-// TODO: Implement piston theory residual / Jacobian testing
-// TODO: Implement other elements (Tri3, Tri6, Quad8, etc.)
-
 
 TEST_CASE("edge2_linear_structural",
           "[1D],[structural],[edge],[edge2],[linear]")
@@ -295,7 +289,7 @@ TEST_CASE("edge2_linear_structural",
         orientation(2) = 1.0;
         section.y_vector() = orientation;
         section.init();
-        discipline.set_property_for_subdomain(0, section);
+        //discipline.set_property_for_subdomain(0, section);
         
         RealVectorX residual = RealVectorX::Zero(n_dofs);
         RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);

--- a/tests/element/structural/1D/edge2/mast_edge2_linear_structural_thermal_jacobian.cpp
+++ b/tests/element/structural/1D/edge2/mast_edge2_linear_structural_thermal_jacobian.cpp
@@ -301,7 +301,6 @@ TEST_CASE("edge2_linear_structural_thermal_jacobian",
         orientation(2) = 1.0;
         section.y_vector() = orientation;
         section.init();
-        discipline.set_property_for_subdomain(0, section);
         
         RealVectorX residual = RealVectorX::Zero(n_dofs);
         RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);

--- a/tests/element/structural/1D/edge2/mast_edge2_linear_structural_thermal_jacobian.cpp
+++ b/tests/element/structural/1D/edge2/mast_edge2_linear_structural_thermal_jacobian.cpp
@@ -1,3 +1,7 @@
+// We need access to the protected thermal_residual method to test it
+// NOTE: Be careful with this, it could cause unexpected problems
+#define protected public
+
 // C++ Stanard Includes
 #include <math.h>
 
@@ -26,6 +30,7 @@
 #include "base/nonlinear_system.h"
 #include "elasticity/structural_element_base.h"
 #include "mesh/geom_elem.h"
+#include "base/boundary_condition_base.h"
 
 // Custom includes
 #include "test_helpers.h"
@@ -34,9 +39,15 @@
 
 extern libMesh::LibMeshInit* p_global_init;
 
+// TODO: Implement patch test
+// TODO: Implement thermoelastic residual / Jacboian testing
+// TODO: Implement surface pressure residual / Jacobian
+// TODO: Implement piston theory residual / Jacobian testing
+// TODO: Implement other elements (Tri3, Tri6, Quad8, etc.)
 
-TEST_CASE("edge2_linear_extension_structural",
-          "[1D],[structural],[edge],[edge2],[linear]")
+
+TEST_CASE("edge2_linear_structural_thermal_jacobian",
+          "[1D],[thermoelastic],[edge],[edge2],[linear],[protected]")
 {
     const int n_elems = 1;
     const int n_nodes = 2;
@@ -87,12 +98,17 @@ TEST_CASE("edge2_linear_extension_structural",
     MAST::Parameter k("k_param",     237.0);          // Thermal Conductivity
     
     // Define Section Properties as MAST Parameters
-    MAST::Parameter thickness_y("thy_param", 0.06);   // Section thickness in y-direction
-    MAST::Parameter thickness_z("thz_param", 0.04);   // Section thickness in z-direction
-    MAST::Parameter offset_y("offy_param", 0.035);    // Section offset in y-direction
-    MAST::Parameter offset_z("offz_param", 0.026);    // Section offset in z-direction
+    MAST::Parameter thickness_y("thy_param", 0.8);   // Section thickness in y-direction
+    MAST::Parameter thickness_z("thz_param", 0.7);   // Section thickness in z-direction
+    MAST::Parameter offset_y("offy_param", 0.5);    // Section offset in y-direction
+    MAST::Parameter offset_z("offz_param", 0.4);    // Section offset in z-direction
     MAST::Parameter kappa_zz("kappa_zz", 5.0/6.0);    // Shear coefficient
     MAST::Parameter kappa_yy("kappa_yy", 2.0/6.0);    // Shear coefficient
+    
+    // Define the Thermoelastic Properties
+    // Define the Uniform Temperature and Uniform Reference Temperature
+    MAST::Parameter temperature("T", 400.0);
+    MAST::Parameter ref_temperature("T0", 0.0);
     
     // Create field functions to dsitribute these constant parameters throughout the model
     MAST::ConstantFieldFunction E_f("E", E);
@@ -105,6 +121,8 @@ TEST_CASE("edge2_linear_extension_structural",
     MAST::ConstantFieldFunction offsety_f("hy_off", offset_y);
     MAST::ConstantFieldFunction thicknessz_f("hz", thickness_z);
     MAST::ConstantFieldFunction offsetz_f("hz_off", offset_z);
+    MAST::ConstantFieldFunction temperature_f("temperature", temperature);
+    MAST::ConstantFieldFunction ref_temperature_f("ref_temperature", ref_temperature);
     MAST::ConstantFieldFunction kappa_zz_f("Kappazz", kappa_zz);
     MAST::ConstantFieldFunction kappa_yy_f("Kappayy", kappa_yy);
     
@@ -134,15 +152,20 @@ TEST_CASE("edge2_linear_extension_structural",
     section.set_material(material);
     
     // Specify a section orientation point and add it to the section.
+    // FIXME: Orientation isn't affecting the element's jacobian for some reason
     RealVectorX orientation = RealVectorX::Zero(3);
-    orientation(1) = 1.0;
+    orientation(2) = 1.0;
     section.y_vector() = orientation;
     
     // Set the strain type to linear for the section
     section.set_strain(MAST::LINEAR_STRAIN);
     
+    // Set the bending operator to Euler-Bernoulli
+    section.set_bending_model(MAST::TIMOSHENKO);
+    
     // Now initialize the section
     section.init();
+    
     
     /**
      *  Now we setup the structural system we will be solving.
@@ -163,6 +186,14 @@ TEST_CASE("edge2_linear_extension_structural",
     
     equation_systems.init();
     //equation_systems.print_info();
+    
+    /**
+     * Setup the temperature change boundary condition
+     */
+    MAST::BoundaryConditionBase temperature_load(MAST::TEMPERATURE);
+    temperature_load.add(temperature_f);
+    temperature_load.add(ref_temperature_f);
+    discipline.add_volume_load(0, temperature_load);
     
     MAST::NonlinearImplicitAssembly assembly;
     assembly.set_discipline_and_system(discipline, structural_system);
@@ -188,49 +219,33 @@ TEST_CASE("edge2_linear_extension_structural",
     
     const Real V0 = reference_elem->volume();
     
-    /**
-     *  Below, we start building the Jacobian up for a very basic element that 
-     *  is already in an isoparametric format.  The following four steps:
-     *      Extension Only Stiffness
-     *      Extension & Bending Stiffness
-     *      Extension, Bending, & Transverse Shear Stiffness
-     *      Extension, Bending, & Extension-Bending Coupling Stiffness
-     *      Extension, Bending, Transverse Shear & Extension-Bending Coupling Stiffness
-     * 
-     *  Testing the Jacobian incrementally this way allows errors in the
-     *  Jacobian to be located more precisely.
-     * 
-     *  It would probably be even better to test each stiffness contribution 
-     *  separately, but currently, we don't have a way to disable extension
-     *  stiffness and transverse shear stiffness doesn't exist without bending 
-     *  and extension-bending coupling stiffness don't make sense without both
-     *  extension and/or bending. 
-     */
-    
-    // Set shear coefficient to zero to disable transverse shear stiffness
-    kappa_zz = 0.0;
-    kappa_yy = 0.0;
-    
-    // Set the offset to zero to disable extension-bending coupling
-    offset_y = 0.0;
-    offset_z = 0.0;
-    
-    // Set the bending operator to no_bending to disable bending stiffness
-    // NOTE: This also disables the transverse shear stiffness
-    section.set_bending_model(MAST::NO_BENDING);
-    
     // Calculate residual and jacobian
     RealVectorX residual = RealVectorX::Zero(n_dofs);
     RealMatrixX jacobian0 = RealMatrixX::Zero(n_dofs, n_dofs);
-    elem->internal_residual(true, residual, jacobian0);
+    elem->thermal_residual(true, residual, jacobian0, temperature_load);
             
     double val_margin = (jacobian0.array().abs()).mean() * 1.490116119384766e-08;
+    
+    libMesh::out << "R=\n" << residual << std::endl;
+    libMesh::out << "J =\n" << jacobian0 << std::endl;
+    
+    SECTION("thermal_jacobian_is_zero_matrix")
+    {
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX zero_matrix = RealMatrixX::Zero(n_dofs, n_dofs);
         
-    SECTION("internal_jacobian_finite_difference_check")                   
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
+        std::vector<double> truth = eigen_matrix_to_std_vector(zero_matrix);
+        
+        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(0.0) );
+    }
+    
+    
+    SECTION("thermal_jacobian_finite_difference_check")                   
     {
         // Approximate Jacobian with Finite Difference
         RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        approximate_thermal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd, temperature_load);
         
         //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
         val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
@@ -242,7 +257,7 @@ TEST_CASE("edge2_linear_extension_structural",
     }
     
     
-    SECTION("internal_jacobian_symmetry_check")
+    SECTION("thermal_jacobian_symmetry_check")
     {
         // Element stiffness matrix should be symmetric
         std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
@@ -251,50 +266,55 @@ TEST_CASE("edge2_linear_extension_structural",
     }
     
     
-    SECTION("internal_jacobian_determinant_check")
+    SECTION("thermal_jacobian_determinant_check")
     {
-        // Determinant of undeformed element stiffness matrix should be zero
+        // Determinant of linear thermoelastic jacobian should be zero
         REQUIRE( jacobian0.determinant() == Approx(0.0).margin(1e-06) );
     }
     
     
-    SECTION("internal_jacobian_eigenvalue_check")
+    SECTION("thermal_jacobian_eigenvalue_check")
     {
         /**
-         * Number of zero eigenvalues should equal the number of rigid body
-         * modes.  For 1D extension (including torsion), we have 1 rigid 
-         * translations along the element's x-axis and 1 rigid rotation about 
-         * the element's x-axis, for a total of 2 rigid body modes.
-         * 
-         * Note that the use of reduced integration can result in more rigid
-         * body modes than expected.
+         * Linear thermoelastic Jacobian should be independent of the 
+         * displacements and thus should be a zero matrix.
          */
         SelfAdjointEigenSolver<RealMatrixX> eigensolver(jacobian0, false);
         RealVectorX eigenvalues = eigensolver.eigenvalues();
+        libMesh::out << "Eigenvalues are:\n" << eigenvalues << std::endl;
         uint nz = 0;
         for (uint i=0; i<eigenvalues.size(); i++)
         {
-            if (std::abs(eigenvalues(i))<1e-10)
+            if (std::abs(eigenvalues(i))<0.0001220703125)
             {
                 nz++;
             }
         }
-        REQUIRE( nz == 2);
-        
-        /**
-         * All non-zero eigenvalues should be positive.
-         */
-        REQUIRE(eigenvalues.minCoeff()>(-1e-10));
+        REQUIRE( nz == 12);
     }
     
     
-//     SECTION("internal_jacobian_orientation_invariant")
-//     {
-//         
-//     }
+    SECTION("thermal_jacobian_orientation_invariant")
+    {
+        section.clear();
+        RealVectorX orientation = RealVectorX::Zero(3);
+        orientation(2) = 1.0;
+        section.y_vector() = orientation;
+        section.init();
+        discipline.set_property_for_subdomain(0, section);
+        
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->thermal_residual(true, residual, jacobian, temperature_load);
+                
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
+
+        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+    }
     
     
-    SECTION("internal_jacobian_displacement_invariant")
+    SECTION("thermal_jacobian_displacement_invariant")
     {
         // Calculate residual and jacobian at arbitrary displacement
         RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
@@ -305,7 +325,7 @@ TEST_CASE("edge2_linear_extension_structural",
         
         RealVectorX residual = RealVectorX::Zero(n_dofs);
         RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
+        elem->thermal_residual(true, residual, jacobian, temperature_load);
                 
         std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
         std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
@@ -313,7 +333,7 @@ TEST_CASE("edge2_linear_extension_structural",
         REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
     }
     
-    SECTION("internal_jacobian_shifted_x_invariant")
+    SECTION("thermal_jacobian_shifted_x_invariant")
     {
         // Shifted in x-direction
         transform_element(mesh, X0, 5.2, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
@@ -322,7 +342,7 @@ TEST_CASE("edge2_linear_extension_structural",
         // Calculate residual and jacobian
         RealVectorX residual = RealVectorX::Zero(n_dofs);
         RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
+        elem->thermal_residual(true, residual, jacobian, temperature_load);
                 
         std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
         std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
@@ -330,7 +350,7 @@ TEST_CASE("edge2_linear_extension_structural",
         REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
     }
     
-    SECTION("internal_jacobian_shifted_y_invariant")
+    SECTION("thermal_jacobian_shifted_y_invariant")
     {
         // Shifted in y-direction
         transform_element(mesh, X0, 0.0, -11.5, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
@@ -339,7 +359,7 @@ TEST_CASE("edge2_linear_extension_structural",
         // Calculate residual and jacobian
         RealVectorX residual = RealVectorX::Zero(n_dofs);
         RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
+        elem->thermal_residual(true, residual, jacobian, temperature_load);
         
         std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
         std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
@@ -347,7 +367,7 @@ TEST_CASE("edge2_linear_extension_structural",
         REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
     }
     
-    SECTION("internal_jacobian_shifted_z_invariant")
+    SECTION("thermal_jacobian_shifted_z_invariant")
     {
         // Shifted in y-direction
         transform_element(mesh, X0, 0.0, 0.0, 7.6, 1.0, 1.0, 0.0, 0.0, 0.0);
@@ -356,7 +376,7 @@ TEST_CASE("edge2_linear_extension_structural",
         // Calculate residual and jacobian
         RealVectorX residual = RealVectorX::Zero(n_dofs);
         RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
+        elem->thermal_residual(true, residual, jacobian, temperature_load);
         
         std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
         std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
@@ -365,7 +385,7 @@ TEST_CASE("edge2_linear_extension_structural",
     }
     
     
-    SECTION("internal_jacobian_aligned_y")
+    SECTION("thermal_jacobian_aligned_y")
     {
         /*
          * NOTE: We could try to use the transform_element method here, but the
@@ -384,11 +404,11 @@ TEST_CASE("edge2_linear_extension_structural",
         // Calculate residual and jacobian
         RealVectorX residual = RealVectorX::Zero(n_dofs);
         RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
+        elem->thermal_residual(true, residual, jacobian, temperature_load);
         
         // Approximate Jacobian with Finite Difference
         RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        approximate_thermal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd, temperature_load);
         
         // This is necessary because MAST manually (hard-coded) adds a small 
         // value to the diagonal to prevent singularities at inactive DOFs
@@ -414,7 +434,7 @@ TEST_CASE("edge2_linear_extension_structural",
         REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
     }
     
-    SECTION("internal_jacobian_aligned_z")
+    SECTION("thermal_jacobian_aligned_z")
     {
         /*
          * NOTE: We could try to use the transform_element method here, but the
@@ -433,11 +453,11 @@ TEST_CASE("edge2_linear_extension_structural",
         // Calculate residual and jacobian
         RealVectorX residual = RealVectorX::Zero(n_dofs);
         RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
+        elem->thermal_residual(true, residual, jacobian, temperature_load);
         
         // Approximate Jacobian with Finite Difference
         RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        approximate_thermal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd, temperature_load);
         
         // This is necessary because MAST manually (hard-coded) adds a small 
         // value to the diagonal to prevent singularities at inactive DOFs
@@ -463,7 +483,7 @@ TEST_CASE("edge2_linear_extension_structural",
         REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
     }
     
-    SECTION("internal_jacobian_rotated_about_z")
+    SECTION("thermal_jacobian_rotated_about_z")
     {
         // Rotated 63.4 about z-axis at element's centroid
         transform_element(mesh, X0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 63.4);
@@ -472,11 +492,11 @@ TEST_CASE("edge2_linear_extension_structural",
         // Calculate residual and jacobian
         RealVectorX residual = RealVectorX::Zero(n_dofs);
         RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
+        elem->thermal_residual(true, residual, jacobian, temperature_load);
         
         // Approximate Jacobian with Finite Difference
         RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        approximate_thermal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd, temperature_load);
         
         // This is necessary because MAST manually (hard-coded) adds a small 
         // value to the diagonal to prevent singularities at inactive DOFs
@@ -502,7 +522,7 @@ TEST_CASE("edge2_linear_extension_structural",
         REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
     }
     
-    SECTION("internal_jacobian_rotated_about_y")
+    SECTION("thermal_jacobian_rotated_about_y")
     {
         // Rotated 35.8 about y-axis at element's centroid
         transform_element(mesh, X0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 35.8, 0.0);
@@ -511,11 +531,11 @@ TEST_CASE("edge2_linear_extension_structural",
         // Calculate residual and jacobian
         RealVectorX residual = RealVectorX::Zero(n_dofs);
         RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
+        elem->thermal_residual(true, residual, jacobian, temperature_load);
         
         // Approximate Jacobian with Finite Difference
         RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        approximate_thermal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd, temperature_load);
         
         // This is necessary because MAST manually (hard-coded) adds a small 
         // value to the diagonal to prevent singularities at inactive DOFs
@@ -541,7 +561,7 @@ TEST_CASE("edge2_linear_extension_structural",
         REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
     }
     
-    SECTION("internal_jacobian_scaled_x")
+    SECTION("thermal_jacobian_scaled_x")
     {
         // Rotated 63.4 about z-axis at element's centroid
         transform_element(mesh, X0, 0.0, 0.0, 0.0, 3.2, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
@@ -550,11 +570,11 @@ TEST_CASE("edge2_linear_extension_structural",
         // Calculate residual and jacobian
         RealVectorX residual = RealVectorX::Zero(n_dofs);
         RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
+        elem->thermal_residual(true, residual, jacobian, temperature_load);
         
         // Approximate Jacobian with Finite Difference
         RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        approximate_thermal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd, temperature_load);
         
         // This is necessary because MAST manually (hard-coded) adds a small 
         // value to the diagonal to prevent singularities at inactive DOFs
@@ -580,7 +600,7 @@ TEST_CASE("edge2_linear_extension_structural",
         REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
     }
     
-    SECTION("internal_jacobian_arbitrary_transformation")
+    SECTION("thermal_jacobian_arbitrary_transformation")
     {
         // Arbitrary transformations applied to the element
         transform_element(mesh, X0, -5.0, 7.8, -13.1, 2.7, 6.4, 20.0, 47.8, -70.1);
@@ -589,11 +609,11 @@ TEST_CASE("edge2_linear_extension_structural",
         // Calculate residual and jacobian
         RealVectorX residual = RealVectorX::Zero(n_dofs);
         RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
+        elem->thermal_residual(true, residual, jacobian, temperature_load);
         
         // Approximate Jacobian with Finite Difference
         RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        approximate_thermal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd, temperature_load);
         
         // This is necessary because MAST manually (hard-coded) adds a small 
         // value to the diagonal to prevent singularities at inactive DOFs
@@ -619,7 +639,7 @@ TEST_CASE("edge2_linear_extension_structural",
         REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
     }
     
-    SECTION("internal_jacobian_arbitrary_with_displacements")
+    SECTION("thermal_jacobian_arbitrary_with_displacements")
     {
         // Arbitrary transformations applied to the element
         transform_element(mesh, X0, 4.1, -6.3, 7.5, 4.2, 1.5, -18.0, -24.8, 
@@ -637,11 +657,11 @@ TEST_CASE("edge2_linear_extension_structural",
         // Calculate residual and jacobian
         RealVectorX residual = RealVectorX::Zero(n_dofs);
         RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
+        elem->thermal_residual(true, residual, jacobian, temperature_load);
         
         // Approximate Jacobian with Finite Difference
         RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        approximate_thermal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd, temperature_load);
         
         // This is necessary because MAST manually (hard-coded) adds a small 
         // value to the diagonal to prevent singularities at inactive DOFs

--- a/tests/element/structural/1D/edge2/mast_edge2_linear_structural_thermal_jacobian.cpp
+++ b/tests/element/structural/1D/edge2/mast_edge2_linear_structural_thermal_jacobian.cpp
@@ -39,12 +39,6 @@
 
 extern libMesh::LibMeshInit* p_global_init;
 
-// TODO: Implement patch test
-// TODO: Implement thermoelastic residual / Jacboian testing
-// TODO: Implement surface pressure residual / Jacobian
-// TODO: Implement piston theory residual / Jacobian testing
-// TODO: Implement other elements (Tri3, Tri6, Quad8, etc.)
-
 
 TEST_CASE("edge2_linear_structural_thermal_jacobian",
           "[1D],[thermoelastic],[edge],[edge2],[linear],[protected]")

--- a/tests/element/structural/1D/edge2/mast_edge2_nonlinear_structural_thermal_jacobian.cpp
+++ b/tests/element/structural/1D/edge2/mast_edge2_nonlinear_structural_thermal_jacobian.cpp
@@ -285,7 +285,6 @@ TEST_CASE("edge2_nonlinear_structural_thermal_jacobian",
         orientation(2) = 1.0;
         section.y_vector() = orientation;
         section.init();
-        discipline.set_property_for_subdomain(0, section);
         
         RealVectorX residual = RealVectorX::Zero(n_dofs);
         RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);

--- a/tests/element/structural/1D/mast_structural_element_1d.cpp
+++ b/tests/element/structural/1D/mast_structural_element_1d.cpp
@@ -1,0 +1,269 @@
+// C++ Stanard Includes
+#include <math.h>
+
+// Catch2 includes
+#include "catch.hpp"
+
+// libMesh includes
+#include "libmesh/libmesh.h"
+#include "libmesh/replicated_mesh.h"
+#include "libmesh/point.h"
+#include "libmesh/elem.h"
+#include "libmesh/edge_edge2.h"
+#include "libmesh/equation_systems.h"
+#include "libmesh/dof_map.h"
+
+// MAST includes
+#include "base/parameter.h"
+#include "base/constant_field_function.h"
+#include "property_cards/isotropic_material_property_card.h"
+#include "property_cards/solid_1d_section_element_property_card.h"
+#include "elasticity/structural_element_1d.h"
+#include "elasticity/structural_system_initialization.h"
+#include "base/physics_discipline_base.h"
+#include "base/nonlinear_implicit_assembly.h"
+#include "elasticity/structural_nonlinear_assembly.h"
+#include "base/nonlinear_system.h"
+#include "elasticity/structural_element_base.h"
+#include "mesh/geom_elem.h"
+
+// Custom includes
+#include "test_helpers.h"
+
+#define pi 3.14159265358979323846
+
+extern libMesh::LibMeshInit* p_global_init;
+
+TEST_CASE("structural_element_1d_base_tests",
+          "[1D],[structural],[base]")
+{
+    const int n_elems = 1;
+    const int n_nodes = 2;
+    
+    RealMatrixX temp = RealMatrixX::Zero(3,n_nodes);
+    temp << -1.0, 1.0, 0.0, 0.0, 0.0, 0.0;
+    const RealMatrixX X0 = temp;
+    
+    /**
+     * Create the mesh with the one element we are testing
+     */
+    libMesh::ReplicatedMesh mesh(p_global_init->comm());
+    mesh.set_mesh_dimension(1);
+    mesh.set_spatial_dimension(3);
+    mesh.reserve_elem(n_elems);
+    mesh.reserve_nodes(n_nodes);
+    
+    // Add nodes to the mesh
+    for (uint i=0; i<n_nodes; i++)
+    {
+        mesh.add_point(libMesh::Point(X0(0,i), X0(1,i), X0(2,i)));
+    }
+    
+    // Add the element to the mesh
+    libMesh::Elem *reference_elem = new libMesh::Edge2;
+    reference_elem->set_id(0);    
+    reference_elem->subdomain_id() = 0;
+    reference_elem = mesh.add_elem(reference_elem);
+    for (int i=0; i<n_nodes; i++)
+    {
+        reference_elem->set_node(i) = mesh.node_ptr(i);
+    }
+    
+    // Prepare the mesh for use
+    mesh.prepare_for_use();
+    
+    // Ensure the libMesh element has the expected volume
+    const Real elem_volume = reference_elem->volume();
+    Real true_volume = 2.0;
+    REQUIRE( elem_volume == true_volume );
+    
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
+    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
+    MAST::Parameter rho("rho_param", 1420.5);         // Density
+    MAST::Parameter alpha("alpha_param", 5.43e-05);   // Coefficient of thermal expansion
+    MAST::Parameter cp("cp_param",   908.0);          // Specific Heat Capacity
+    MAST::Parameter k("k_param",     237.0);          // Thermal Conductivity
+    
+    // Define Section Properties as MAST Parameters
+    MAST::Parameter thickness_y("thy_param", 0.06);   // Section thickness in y-direction
+    MAST::Parameter thickness_z("thz_param", 0.04);   // Section thickness in z-direction
+    MAST::Parameter offset_y("offy_param", 0.035);    // Section offset in y-direction
+    MAST::Parameter Kzz("kappa_zz", 5.0/6.0);         // Shear coefficient
+    MAST::Parameter Kyy("kappa_yy", 2.0/6.0);         // Shear coefficient
+    MAST::Parameter offset_z("offz_param", 0.026);    // Section offset in z-direction
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction E_f("E", E);
+    MAST::ConstantFieldFunction nu_f("nu", nu);
+    MAST::ConstantFieldFunction rho_f("rho", rho);
+    MAST::ConstantFieldFunction alpha_f("alpha_expansion", alpha);
+    MAST::ConstantFieldFunction cp_f("cp", cp);
+    MAST::ConstantFieldFunction k_f("k_th", k);
+    MAST::ConstantFieldFunction thicknessy_f("hy", thickness_y);
+    MAST::ConstantFieldFunction offsety_f("hy_off", offset_y);
+    MAST::ConstantFieldFunction thicknessz_f("hz", thickness_z);
+    MAST::ConstantFieldFunction offsetz_f("hz_off", offset_z);
+    MAST::ConstantFieldFunction Kappazz_f("Kappazz", Kzz);
+    MAST::ConstantFieldFunction Kappayy_f("Kappayy", Kyy);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(E_f);
+    material.add(nu_f);
+    material.add(rho_f);
+    material.add(alpha_f);
+    material.add(k_f);
+    material.add(cp_f);
+    
+    // Initialize the section
+    MAST::Solid1DSectionElementPropertyCard section;
+    
+    // Add the section property constant field functions to the section card
+    section.add(thicknessy_f);
+    section.add(offsety_f);
+    section.add(thicknessz_f);
+    section.add(offsetz_f);
+    section.add(Kappazz_f);
+    section.add(Kappayy_f);
+    
+    // Add the material card to the section card
+    section.set_material(material);
+    
+    // Specify a section orientation point and add it to the section.
+    RealVectorX orientation = RealVectorX::Zero(3);
+    orientation(1) = 1.0;
+    section.y_vector() = orientation;
+    
+    // Now initialize the section
+    section.init();
+    
+    /**
+     *  Now we setup the structural system we will be solving.
+     */
+    libMesh::EquationSystems equation_systems(mesh);
+    
+    MAST::NonlinearSystem& system = equation_systems.add_system<MAST::NonlinearSystem>("structural");
+    
+    libMesh::FEType fetype(libMesh::FIRST, libMesh::LAGRANGE);
+    
+    MAST::StructuralSystemInitialization structural_system(system, 
+                                                           system.name(), 
+                                                           fetype);
+    
+    MAST::PhysicsDisciplineBase discipline(equation_systems);
+    
+    discipline.set_property_for_subdomain(0, section);
+    
+    equation_systems.init();
+    //equation_systems.print_info();
+    
+    MAST::NonlinearImplicitAssembly assembly;
+    assembly.set_discipline_and_system(discipline, structural_system);
+    
+    // Create the MAST element from the libMesh reference element
+    MAST::GeomElem geom_elem;
+    geom_elem.init(*reference_elem, structural_system);
+    std::unique_ptr<MAST::StructuralElementBase> elem_base = build_structural_element(structural_system, geom_elem, section);
+    
+    // Cast the base structural element as a 2D structural element
+    MAST::StructuralElement1D* elem = (dynamic_cast<MAST::StructuralElement1D*>(elem_base.get()));
+    
+    SECTION("number_strain_components")
+    {
+        REQUIRE(elem->n_direct_strain_components() == 2);
+        REQUIRE(elem->n_von_karman_strain_components() == 2);
+    }
+    
+    SECTION("no_incompatible_modes")
+    {
+        REQUIRE_FALSE( elem->if_incompatible_modes() );
+    }
+    
+    SECTION("return_section_property")
+    {
+        const MAST::ElementPropertyCardBase& elem_section = elem->elem_property();
+        CHECK( elem_section.if_isotropic() );
+    }
+    
+    SECTION("set_get_local_solution")
+    {
+        const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
+        std::vector<libMesh::dof_id_type> dof_indices;
+        dof_map.dof_indices (reference_elem, dof_indices);
+        uint n_dofs = uint(dof_indices.size());
+        
+        RealVectorX elem_solution = 5.3*RealVectorX::Ones(n_dofs);
+        elem->set_solution(elem_solution);
+        
+        const RealVectorX& local_solution = elem->local_solution();
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(elem_solution);
+        std::vector<double> truth = eigen_matrix_to_std_vector(local_solution);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    SECTION("set_get_local_solution_sensitivity")
+    {
+        const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
+        std::vector<libMesh::dof_id_type> dof_indices;
+        dof_map.dof_indices (reference_elem, dof_indices);
+        uint n_dofs = uint(dof_indices.size());
+        
+        RealVectorX elem_solution_sens = 3.1*RealVectorX::Ones(n_dofs);
+        elem->set_solution(elem_solution_sens, true);
+        
+        const RealVectorX& local_solution_sens = elem->local_solution(true);
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(elem_solution_sens);
+        std::vector<double> truth = eigen_matrix_to_std_vector(local_solution_sens);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    SECTION("element shape can be transformed")
+    {
+        const Real V0 = reference_elem->volume();
+        
+        // Stretch in x-direction
+        transform_element(mesh, X0, 0.0, 0.0, 0.0, 3.1, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(reference_elem->volume() == 6.2);
+        
+        // Rotation about z-axis
+        transform_element(mesh, X0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 60.0);
+        REQUIRE(reference_elem->volume() == V0);
+        
+        // Rotation about y-axis
+        transform_element(mesh, X0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 30.0, 0.0);
+        REQUIRE(reference_elem->volume() == V0);
+        
+        // Rotation about x-axis
+        transform_element(mesh, X0, 0.0, 0.0, 0.0, 1.0, 1.0, 20.0, 0.0, 0.0);
+        REQUIRE(reference_elem->volume() == V0);
+        
+        // Shifted in x-direction
+        transform_element(mesh, X0, 10.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(reference_elem->volume() == V0);
+        
+        // Shifted in y-direction
+        transform_element(mesh, X0, 0.0, 7.5, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(reference_elem->volume() == V0);
+        
+        // Shifted in z-direction
+        transform_element(mesh, X0, 0.0, 0.0, 4.2, 1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(reference_elem->volume() == V0);
+    }
+}

--- a/tests/element/structural/CMakeLists.txt
+++ b/tests/element/structural/CMakeLists.txt
@@ -1,0 +1,2 @@
+#add_subdirectory(2D)
+add_subdirectory(1D)


### PR DESCRIPTION
This PR is an extension of #60 and #70 and adds tests of existing MAST library capability related primarily to Structural 1D elements. Most tests were originally implemented by @JohnDN90.

Below is a checklist of commits implemented by @JohnDN90 in his `add_catch2_tests` branch the whose contents/functionality need rolled in. The checklist ones will be covered in this PR:
- Added catch2 header file for upcoming new tests. (#60)
- Bug fixes and enhancements to CMake files. (#60)
- Added option to use libmesh_devel (development) version. (#60)
- Added catch2 tests for some MAST base functions. (#60)
- Added catch2 test for TEMPERATURE boundary condition. (#70)
- Added catch2 tests for mast_boundary_condition_base (#70)
- Removed shear coefficient (kappa) from isotropic material. Added plane strain support to isotropic material. (#60)
- Added catch2 tests for mast_isotropic_material. (#60)
- Multiple changes to orthotropic material, including added plane strain support. (#60)
- Added catch2 tests for orthotropic_material_property_card. (#60)
- Moved shear coefficient (kappa) to 2D section card and added overloaded functions to 2D section card. (#60)
- Added catch2 tests for solid_2d_section_element_property_card. (#70)
- Added overloaded functions to isotropic 3D section property card. (#70)
- Added catch2 tests for isotropic_element_property_card_3D. (#70)
- Added new public release statement to README.
- Add overloaded functions to solid_1d_section_element_property_card. (#70)
- Formatting for README.md
- Multiple changes to 1d_solid_section_element_property_card. (#70)
- Added catch2 tests for solid_1d_section_element_property_card. (#70)
- [x] Added basic catch2 tests for generic 1D structural elements.
- [x] Fixed bug in GitHub Issue #41 where NO_BENDING incorrectly called TIMOSHENKO.
- [x] Added catch2 tests for 1D structural element with extension and torsion.
- Fixed bug in GitHub issue #43, where incorrect I value was being used for bending about y-axis. (#75)
- [x] Added many for tests for 1D structural 2-noded (edge2) element.
- Added generic catch2 tests for 2D structrual elements.
- Added many catch2 tests for 4-node quadrilaterial 2D element (quad4).
- UPDATE EXAMPLES MOVING KAPPA FROM MATERIAL TO SECTION CARD (#60)
- [x] Fixed bugs in catch2 tests which caused some to fail when run with a debug version of MAST.
- [x] Necessary tweak to tests for zero and negative eigenvalues.