### PR TITLE
First Catch2 tests for structural 2D elements

### DIFF
--- a/tests/base/mast_mesh.cpp
+++ b/tests/base/mast_mesh.cpp
@@ -33,7 +33,7 @@ TEST_CASE("libmesh_mesh_generation_1d",
     coords << -1.0, 1.0, 0.0,
                0.0, 0.0, 0.0;
 
-    SECTION("replicated_mesh_1d")
+    SECTION("Creation of a single 2-node 1D element (EDGE2) in a libMesh::ReplicatedMesh")
     {
         TEST::TestMeshSingleElement test_mesh(libMesh::EDGE2, coords);
         // Compare element against true volume (actually length for 1D elements)
@@ -50,7 +50,7 @@ TEST_CASE("libmesh_mesh_generation_2d",
               -1.0, -1.0, 1.0,  1.0,
                0.0,  0.0, 0.0,  0.0;
 
-    SECTION("replicated_mesh_2d")
+    SECTION("Creation of a single 4-node 2D element (QUAD4) in a libMesh::ReplicatedMesh")
     {
         TEST::TestMeshSingleElement test_mesh(libMesh::QUAD4, coords);
         // Compare element against true volume (actually area for 2D elements)

--- a/tests/base/mast_mesh.h
+++ b/tests/base/mast_mesh.h
@@ -38,17 +38,33 @@ extern libMesh::LibMeshInit* p_global_init;
 
 namespace TEST {
 
+    /**
+     * Storage class for a mesh consisting of a single element used in testing.
+     *
+     * The single element has an ID of 0 (zero) and is placed into the subdomain of ID 0 (zero).
+     */
     class TestMeshSingleElement {
     public:
-        int n_elems;
-        int n_nodes;
-        int n_dim;
-        libMesh::Elem* reference_elem;
-        libMesh::ReplicatedMesh mesh;
+        int n_elems; ///< Number of elements in the test mesh
+        int n_nodes; ///< Number of nodes per element in the test mesh
+        int n_dim;   ///< Dimension of the test element (1, 2, 3)
+        libMesh::Elem* reference_elem; ///< Pointer to the actual libMesh element object
+        libMesh::ReplicatedMesh mesh;  ///< The actual libMesh mesh object
         // Convert this to pointer to enable both Replicated/Distributed Mesh
         // libMesh::UnstructuredMesh* mesh;
         // ---> currently can't run this with DistributedMesh. On second processor this.reference_elem doesn't exist!
 
+        /**
+         * Construct a single element mesh using the specified type and nodal coordinates. Nodal
+         * connectivity is specified according to the Exodus-II mesh format. Valid element types
+         * are currently:
+         *  - 1D: EDGE2
+         *  - 2D: QUAD4
+         *
+         * @param e_type libMesh element type to create
+         * @param coordinates (3 by n) matrix where each column specifies a node with rows giving
+         *                    the x, y, z locations
+         */
         TestMeshSingleElement(libMesh::ElemType e_type, RealMatrixX& coordinates):
             mesh(p_global_init->comm()) {
             n_elems = 1;
@@ -88,6 +104,12 @@ namespace TEST {
             mesh.prepare_for_use();
         };
 
+        /**
+         * Update the nodal coordinates in the mesh.
+         *
+         * @param new_coordinates (3 by n) matrix where each column specifies a node with rows
+         *                        giving the x, y, z locations
+         */
         void update_coordinates(RealMatrixX& new_coordinates) {
             for (int i=0; i<n_nodes; i++)
             {

--- a/tests/element/structural/1D/edge2/mast_edge2_linear_structural_extension_bending_coupling_internal_jacobian.cpp
+++ b/tests/element/structural/1D/edge2/mast_edge2_linear_structural_extension_bending_coupling_internal_jacobian.cpp
@@ -39,8 +39,6 @@
 #include "test_helpers.h"
 #include "element/structural/1D/mast_structural_element_1d.h"
 
-#define pi 3.14159265358979323846
-
 extern libMesh::LibMeshInit* p_global_init;
 
 

--- a/tests/element/structural/1D/edge2/mast_edge2_linear_structural_extension_bending_internal_jacobian.cpp
+++ b/tests/element/structural/1D/edge2/mast_edge2_linear_structural_extension_bending_internal_jacobian.cpp
@@ -38,7 +38,6 @@
 #include "catch.hpp"
 #include "test_helpers.h"
 #include "element/structural/1D/mast_structural_element_1d.h"
-#define pi 3.14159265358979323846
 
 extern libMesh::LibMeshInit* p_global_init;
 

--- a/tests/element/structural/1D/edge2/mast_edge2_linear_structural_extension_bending_shear_internal_jacobian.cpp
+++ b/tests/element/structural/1D/edge2/mast_edge2_linear_structural_extension_bending_shear_internal_jacobian.cpp
@@ -39,8 +39,6 @@
 #include "test_helpers.h"
 #include "element/structural/1D/mast_structural_element_1d.h"
 
-#define pi 3.14159265358979323846
-
 extern libMesh::LibMeshInit* p_global_init;
 
 

--- a/tests/element/structural/1D/edge2/mast_edge2_linear_structural_extension_internal_jacobian.cpp
+++ b/tests/element/structural/1D/edge2/mast_edge2_linear_structural_extension_internal_jacobian.cpp
@@ -39,8 +39,6 @@
 #include "test_helpers.h"
 #include "element/structural/1D/mast_structural_element_1d.h"
 
-#define pi 3.14159265358979323846
-
 extern libMesh::LibMeshInit* p_global_init;
 
 

--- a/tests/element/structural/1D/edge2/mast_edge2_linear_structural_inertial_jacobian.cpp
+++ b/tests/element/structural/1D/edge2/mast_edge2_linear_structural_inertial_jacobian.cpp
@@ -39,8 +39,6 @@
 #include "test_helpers.h"
 #include "element/structural/1D/mast_structural_element_1d.h"
 
-#define pi 3.14159265358979323846
-
 extern libMesh::LibMeshInit* p_global_init;
 
 

--- a/tests/element/structural/1D/edge2/mast_edge2_linear_structural_internal_jacobian.cpp
+++ b/tests/element/structural/1D/edge2/mast_edge2_linear_structural_internal_jacobian.cpp
@@ -39,8 +39,6 @@
 #include "test_helpers.h"
 #include "element/structural/1D/mast_structural_element_1d.h"
 
-#define pi 3.14159265358979323846
-
 extern libMesh::LibMeshInit* p_global_init;
 
 

--- a/tests/element/structural/1D/edge2/mast_edge2_linear_structural_thermal_jacobian.cpp
+++ b/tests/element/structural/1D/edge2/mast_edge2_linear_structural_thermal_jacobian.cpp
@@ -44,8 +44,6 @@
 #include "test_helpers.h"
 #include "element/structural/1D/mast_structural_element_1d.h"
 
-#define pi 3.14159265358979323846
-
 extern libMesh::LibMeshInit* p_global_init;
 
 

--- a/tests/element/structural/1D/edge2/mast_edge2_nonlinear_structural_thermal_jacobian.cpp
+++ b/tests/element/structural/1D/edge2/mast_edge2_nonlinear_structural_thermal_jacobian.cpp
@@ -44,8 +44,6 @@
 #include "test_helpers.h"
 #include "element/structural/1D/mast_structural_element_1d.h"
 
-#define pi 3.14159265358979323846
-
 extern libMesh::LibMeshInit* p_global_init;
 
 

--- a/tests/element/structural/1D/mast_structural_element_1d.cpp
+++ b/tests/element/structural/1D/mast_structural_element_1d.cpp
@@ -39,8 +39,6 @@
 #include "test_helpers.h"
 #include "element/structural/1D/mast_structural_element_1d.h"
 
-#define pi 3.14159265358979323846
-
 extern libMesh::LibMeshInit* p_global_init;
 
 TEST_CASE("structural_element_1d_base_tests",
@@ -49,36 +47,36 @@ TEST_CASE("structural_element_1d_base_tests",
     RealMatrixX coords = RealMatrixX::Zero(3, 2);
     coords << -1.0, 1.0, 0.0,
                0.0, 0.0, 0.0;
-    TEST::TestStructuralSingleElement1D test_struct_elem(libMesh::EDGE2, coords);
+    TEST::TestStructuralSingleElement1D test_elem(libMesh::EDGE2, coords);
 
-    SECTION("number_strain_components")
+    SECTION("Element returns proper number of strain components")
     {
-        REQUIRE(test_struct_elem.elem->n_direct_strain_components() == 2);
-        REQUIRE(test_struct_elem.elem->n_von_karman_strain_components() == 2);
-    }
-    
-    SECTION("no_incompatible_modes")
-    {
-        REQUIRE_FALSE(test_struct_elem.elem->if_incompatible_modes() );
+        REQUIRE(test_elem.elem->n_direct_strain_components() == 2);
+        REQUIRE(test_elem.elem->n_von_karman_strain_components() == 2);
     }
 
-    SECTION("return_section_property")
+    SECTION("Incompatible modes flag returns false for basic element")
     {
-        const MAST::ElementPropertyCardBase& elem_section = test_struct_elem.elem->elem_property();
+        REQUIRE_FALSE(test_elem.elem->if_incompatible_modes() );
+    }
+
+    SECTION("Isotropic flag returns true for basic element")
+    {
+        const MAST::ElementPropertyCardBase& elem_section = test_elem.elem->elem_property();
         CHECK( elem_section.if_isotropic() );
     }
 
-    SECTION("set_get_local_solution")
+    SECTION("Check setting/getting element local solution")
     {
-        const libMesh::DofMap& dof_map = test_struct_elem.assembly.system().get_dof_map();
+        const libMesh::DofMap& dof_map = test_elem.assembly.system().get_dof_map();
         std::vector<libMesh::dof_id_type> dof_indices;
-        dof_map.dof_indices (test_struct_elem.reference_elem, dof_indices);
+        dof_map.dof_indices (test_elem.reference_elem, dof_indices);
         uint n_dofs = uint(dof_indices.size());
 
         RealVectorX elem_solution = 5.3*RealVectorX::Ones(n_dofs);
-        test_struct_elem.elem->set_solution(elem_solution);
+        test_elem.elem->set_solution(elem_solution);
 
-        const RealVectorX& local_solution = test_struct_elem.elem->local_solution();
+        const RealVectorX& local_solution = test_elem.elem->local_solution();
 
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
@@ -91,59 +89,50 @@ TEST_CASE("structural_element_1d_base_tests",
         REQUIRE_THAT( test, Catch::Approx<double>(truth) );
     }
 
-    SECTION("set_get_local_solution_sensitivity")
+    SECTION("Check setting/getting element local sensitivity solution")
     {
-        const libMesh::DofMap& dof_map = test_struct_elem.assembly.system().get_dof_map();
+        const libMesh::DofMap& dof_map = test_elem.assembly.system().get_dof_map();
         std::vector<libMesh::dof_id_type> dof_indices;
-        dof_map.dof_indices (test_struct_elem.reference_elem, dof_indices);
+        dof_map.dof_indices (test_elem.reference_elem, dof_indices);
         uint n_dofs = uint(dof_indices.size());
 
-        RealVectorX elem_solution_sens = 3.1*RealVectorX::Ones(n_dofs);
-        test_struct_elem.elem->set_solution(elem_solution_sens, true);
+        RealVectorX elem_solution = 5.3*RealVectorX::Ones(n_dofs);
+        test_elem.elem->set_solution(elem_solution);
 
-        const RealVectorX& local_solution_sens = test_struct_elem.elem->local_solution(true);
-
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(elem_solution_sens);
-        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(local_solution_sens);
-
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(elem_solution),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.elem->local_solution())));
     }
-    
-    SECTION("element shape can be transformed")
+
+    SECTION("Element shape can be transformed")
     {
-        const Real V0 = test_struct_elem.reference_elem->volume();
+        const Real V0 = test_elem.reference_elem->volume();
         
         // Stretch in x-direction
-        TEST::transform_element(test_struct_elem.mesh, coords, 0.0, 0.0, 0.0, 3.1, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE(test_struct_elem.reference_elem->volume() == 6.2);
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0, 3.1, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == 6.2);
         
         // Rotation about z-axis
-        TEST::transform_element(test_struct_elem.mesh, coords, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 60.0);
-        REQUIRE(test_struct_elem.reference_elem->volume() == V0);
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 60.0);
+        REQUIRE(test_elem.reference_elem->volume() == V0);
         
         // Rotation about y-axis
-        TEST::transform_element(test_struct_elem.mesh, coords, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 30.0, 0.0);
-        REQUIRE(test_struct_elem.reference_elem->volume() == V0);
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 30.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == V0);
         
         // Rotation about x-axis
-        TEST::transform_element(test_struct_elem.mesh, coords, 0.0, 0.0, 0.0, 1.0, 1.0, 20.0, 0.0, 0.0);
-        REQUIRE(test_struct_elem.reference_elem->volume() == V0);
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0, 1.0, 1.0, 20.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == V0);
         
         // Shifted in x-direction
-        TEST::transform_element(test_struct_elem.mesh, coords, 10.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE(test_struct_elem.reference_elem->volume() == V0);
+        TEST::transform_element(test_elem.mesh, coords, 10.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == V0);
         
         // Shifted in y-direction
-        TEST::transform_element(test_struct_elem.mesh, coords, 0.0, 7.5, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE(test_struct_elem.reference_elem->volume() == V0);
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 7.5, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == V0);
         
         // Shifted in z-direction
-        TEST::transform_element(test_struct_elem.mesh, coords, 0.0, 0.0, 4.2, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE(test_struct_elem.reference_elem->volume() == V0);
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 4.2, 1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == V0);
     }
 }

--- a/tests/element/structural/2D/CMakeLists.txt
+++ b/tests/element/structural/2D/CMakeLists.txt
@@ -1,13 +1,23 @@
 target_sources(mast_catch_tests
-               PRIVATE
-               ${CMAKE_CURRENT_LIST_DIR}/mast_structural_element_2d.cpp)
+    PRIVATE
+        ${CMAKE_CURRENT_LIST_DIR}/mast_structural_element_2d.cpp)
+
+
+# 2D Structural Element Test Basic Tests
+add_test(NAME Element_2D_Structural_Basic_Tests
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "structural_element_2d_base_tests")
+set_tests_properties(Element_2D_Structural_Basic_Tests
+    PROPERTIES
+        LABELS "SEQ"
+        FIXTURES_REQUIRED  "Element_Property_Card_2D_Structural;libMesh_Mesh_Generation_2d"
+        FIXTURES_SETUP     Element_2D_Structural_Basic_Tests)
+
+add_test(NAME Element_2D_Structural_Basic_Tests_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "structural_element_2d_base_tests")
+set_tests_properties(Element_2D_Structural_Basic_Tests_mpi
+    PROPERTIES
+        LABELS "MPI"
+        FIXTURES_REQUIRED  "Element_Property_Card_2D_Structural_mpi;libMesh_Mesh_Generation_2d_mpi"
+        FIXTURES_SETUP     Element_2D_Structural_Basic_Tests_mpi)
 
 add_subdirectory(quad4)
-
-#2D Structural Element Test Basic Tests
-add_test(NAME Element_2D_Structural_Basic_Tests
-         COMMAND mast_catch_tests "structural_element_2d_base_tests")
-set_tests_properties(Element_2D_Structural_Basic_Tests
-                     PROPERTIES 
-                     FIXTURES_REQUIRED  "Element_Property_Card_2D_Structural;libMesh_Mesh_Generation_2d"
-                     FIXTURES_SETUP     Element_2D_Structural_Basic_Tests)

--- a/tests/element/structural/2D/CMakeLists.txt
+++ b/tests/element/structural/2D/CMakeLists.txt
@@ -1,0 +1,13 @@
+target_sources(mast_catch_tests
+               PRIVATE
+               ${CMAKE_CURRENT_LIST_DIR}/mast_structural_element_2d.cpp)
+
+#add_subdirectory(quad4)
+
+#2D Structural Element Test Basic Tests
+add_test(NAME Element_2D_Structural_Basic_Tests
+         COMMAND mast_catch_tests "structural_element_2d_base_tests")
+set_tests_properties(Element_2D_Structural_Basic_Tests
+                     PROPERTIES 
+                     FIXTURES_REQUIRED  "Element_Property_Card_2D_Structural;libMesh_Mesh_Generation_2d"
+                     FIXTURES_SETUP     Element_2D_Structural_Basic_Tests)

--- a/tests/element/structural/2D/CMakeLists.txt
+++ b/tests/element/structural/2D/CMakeLists.txt
@@ -2,7 +2,7 @@ target_sources(mast_catch_tests
                PRIVATE
                ${CMAKE_CURRENT_LIST_DIR}/mast_structural_element_2d.cpp)
 
-#add_subdirectory(quad4)
+add_subdirectory(quad4)
 
 #2D Structural Element Test Basic Tests
 add_test(NAME Element_2D_Structural_Basic_Tests

--- a/tests/element/structural/2D/mast_structural_element_2d.cpp
+++ b/tests/element/structural/2D/mast_structural_element_2d.cpp
@@ -1,0 +1,292 @@
+// C++ Stanard Includes
+#include <math.h>
+
+// Catch2 includes
+#include "catch.hpp"
+
+// libMesh includes
+#include "libmesh/libmesh.h"
+#include "libmesh/replicated_mesh.h"
+#include "libmesh/point.h"
+#include "libmesh/elem.h"
+#include "libmesh/face_quad4.h"
+#include "libmesh/equation_systems.h"
+#include "libmesh/dof_map.h"
+
+// MAST includes
+#include "base/parameter.h"
+#include "base/constant_field_function.h"
+#include "property_cards/isotropic_material_property_card.h"
+#include "property_cards/solid_2d_section_element_property_card.h"
+#include "elasticity/structural_element_2d.h"
+#include "elasticity/structural_system_initialization.h"
+#include "base/physics_discipline_base.h"
+#include "base/nonlinear_implicit_assembly.h"
+#include "elasticity/structural_nonlinear_assembly.h"
+#include "base/nonlinear_system.h"
+#include "elasticity/structural_element_base.h"
+#include "mesh/geom_elem.h"
+
+// Custom includes
+#include "test_helpers.h"
+
+#define pi 3.14159265358979323846
+
+extern libMesh::LibMeshInit* p_global_init;
+
+
+TEST_CASE("structural_element_2d_base_tests",
+          "[2D],[structural],[base]")
+{
+    const int n_elems = 1;
+    const int n_nodes = 4;
+    
+    // Point Coordinates
+    const std::vector<Real> x0 = {-1.0, 1.0, 1.0, -1.0};
+    const std::vector<Real> y0 = {-1.0, -1.0, 1.0, 1.0};
+    const std::vector<Real> z0 = {0.0, 0.0, 0.0, 0.0};
+    
+    RealMatrixX temp = RealMatrixX::Zero(3,4);
+    temp << -1.0,  1.0, 1.0, -1.0, 
+            -1.0, -1.0, 1.0,  1.0, 
+             0.0,  0.0, 0.0,  0.0;
+    const RealMatrixX X = temp;
+    
+    std::vector<Real> x = x0;
+    std::vector<Real> y = y0;
+    std::vector<Real> z = z0;
+    
+    /**
+     *  First create the mesh with the one element we are testing.
+     */
+    // Setup the mesh properties
+    libMesh::ReplicatedMesh mesh(p_global_init->comm());
+    mesh.set_mesh_dimension(2);
+    mesh.set_spatial_dimension(2);
+    mesh.reserve_elem(n_elems);
+    mesh.reserve_nodes(n_nodes);
+    
+    // Add nodes to the mesh
+    for (uint i=0; i<n_nodes; i++)
+    {
+        mesh.add_point(libMesh::Point(x[i], y[i], z[i]));
+    }
+    
+    // Add the element to the mesh
+    libMesh::Elem *reference_elem = new libMesh::Quad4;
+    reference_elem->set_id(0);    
+    reference_elem->subdomain_id() = 0;
+    reference_elem = mesh.add_elem(reference_elem);
+    for (int i=0; i<n_nodes; i++)
+    {
+        reference_elem->set_node(i) = mesh.node_ptr(i);
+    }
+    
+    // Prepare the mesh for use
+    mesh.prepare_for_use();
+    //mesh.print_info();
+    
+    const Real elem_volume = reference_elem->volume();
+    // Calculate true volume using 2D shoelace formula
+    Real true_volume = 0.0;
+    for (uint i=0; i<n_nodes-1; i++)
+    {
+        true_volume += x[i]*y[i+1] - x[i+1]*y[i];
+    }
+    true_volume += x[n_nodes-1]*y[0] - x[0]*y[n_nodes-1];
+    true_volume = std::abs(true_volume);
+    true_volume *= 0.5;
+    
+    // Ensure the libMesh element has the expected volume
+    REQUIRE( elem_volume == true_volume );
+            
+    /**
+     *  Setup the material and section properties to be used in the element
+     */
+    
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
+    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
+    MAST::Parameter alpha("alpha_param", 5.43e-05);   // Coefficient of thermal expansion
+    MAST::Parameter rho("rho_param", 1420.5);         // Density
+    MAST::Parameter cp("cp_param",   908.0);          // Specific Heat Capacity
+    MAST::Parameter k("k_param",     237.0);          // Thermal Conductivity
+    
+    // Define Section Properties as MAST Parameters
+    MAST::Parameter thickness("th_param", 0.06);      // Section thickness
+    MAST::Parameter offset("off_param", 0.03);        // Section offset
+    MAST::Parameter kappa("kappa_param", 5.0/6.0);    // Shear coefficient
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction E_f("E", E);
+    MAST::ConstantFieldFunction nu_f("nu", nu);
+    MAST::ConstantFieldFunction alpha_f("alpha_expansion", alpha);
+    MAST::ConstantFieldFunction rho_f("rho", rho);
+    MAST::ConstantFieldFunction cp_f("cp", cp);
+    MAST::ConstantFieldFunction k_f("k_th", k);
+    MAST::ConstantFieldFunction thickness_f("h", thickness);
+    MAST::ConstantFieldFunction offset_f("off", offset);
+    MAST::ConstantFieldFunction kappa_f("kappa", kappa);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(E_f);                                             
+    material.add(nu_f);
+    material.add(alpha_f);
+    material.add(rho_f);
+    material.add(k_f);
+    material.add(cp_f);
+    
+    // Initialize the section
+    MAST::Solid2DSectionElementPropertyCard section;
+    
+    // Add the section property constant field functions to the section card
+    section.add(thickness_f);
+    section.add(offset_f);
+    section.add(kappa_f);
+    
+    // Add the material card to the section card
+    section.set_material(material);
+    
+    
+    /**
+     *  Now we setup the structural system we will be solving.
+     */
+    libMesh::EquationSystems equation_systems(mesh);
+    
+    MAST::NonlinearSystem& system = equation_systems.add_system<MAST::NonlinearSystem>("structural");
+    
+    libMesh::FEType fetype(libMesh::FIRST, libMesh::LAGRANGE);
+    
+    MAST::StructuralSystemInitialization structural_system(system, 
+                                                           system.name(), 
+                                                           fetype);
+    
+    MAST::PhysicsDisciplineBase discipline(equation_systems);
+    
+    discipline.set_property_for_subdomain(0, section);
+    
+    equation_systems.init();
+    //equation_systems.print_info();
+    
+    MAST::NonlinearImplicitAssembly assembly;
+    assembly.set_discipline_and_system(discipline, structural_system);
+    
+    // Create the MAST element from the libMesh reference element
+    MAST::GeomElem geom_elem;
+    geom_elem.init(*reference_elem, structural_system);
+    std::unique_ptr<MAST::StructuralElementBase> elem_base = build_structural_element(structural_system, geom_elem, section);
+    
+    // Cast the base structural element as a 2D structural element
+    MAST::StructuralElement2D* elem = (dynamic_cast<MAST::StructuralElement2D*>(elem_base.get()));
+    
+    SECTION("number_strain_components")
+    {
+        REQUIRE(elem->n_direct_strain_components() == 3);
+        REQUIRE(elem->n_von_karman_strain_components() == 2);
+    }
+    
+    SECTION("no_incompatible_modes")
+    {
+        REQUIRE_FALSE( elem->if_incompatible_modes() );
+    }
+    
+    SECTION("return_section_property")
+    {
+        const MAST::ElementPropertyCardBase& elem_section = elem->elem_property();
+        CHECK( elem_section.if_isotropic() );
+    }
+    
+    SECTION("set_get_local_solution")
+    {
+        const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
+        std::vector<libMesh::dof_id_type> dof_indices;
+        dof_map.dof_indices (reference_elem, dof_indices);
+        uint n_dofs = uint(dof_indices.size());
+        
+        RealVectorX elem_solution = 5.3*RealVectorX::Ones(n_dofs);
+        elem->set_solution(elem_solution);
+        
+        const RealVectorX& local_solution = elem->local_solution();
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(elem_solution);
+        std::vector<double> truth = eigen_matrix_to_std_vector(local_solution);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    SECTION("set_get_local_solution_sensitivity")
+    {
+        const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
+        std::vector<libMesh::dof_id_type> dof_indices;
+        dof_map.dof_indices (reference_elem, dof_indices);
+        uint n_dofs = uint(dof_indices.size());
+        
+        RealVectorX elem_solution_sens = 3.1*RealVectorX::Ones(n_dofs);
+        elem->set_solution(elem_solution_sens, true);
+        
+        const RealVectorX& local_solution_sens = elem->local_solution(true);
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> test =  eigen_matrix_to_std_vector(elem_solution_sens);
+        std::vector<double> truth = eigen_matrix_to_std_vector(local_solution_sens);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    SECTION("element shape can be transformed")
+    {
+        const Real V0 = reference_elem->volume();
+        
+        // Stretch in x-direction
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 3.1, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(reference_elem->volume() == 12.4);
+        
+        // Stretch in y-direction
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 3.1, 0.0, 0.0, 0.0);
+        REQUIRE(reference_elem->volume() == 12.4);
+        
+        // Rotation about z-axis
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 60.0);
+        REQUIRE(reference_elem->volume() == V0);
+        
+        // Rotation about y-axis
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 30.0, 0.0);
+        REQUIRE(reference_elem->volume() == V0);
+        
+        // Rotation about x-axis
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 20.0, 0.0, 0.0);
+        REQUIRE(reference_elem->volume() == V0);
+        
+        // Shifted in x-direction
+        transform_element(mesh, X, 10.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(reference_elem->volume() == V0);
+        
+        // Shifted in y-direction
+        transform_element(mesh, X, 0.0, 7.5, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(reference_elem->volume() == V0);
+        
+        // Shifted in z-direction
+        transform_element(mesh, X, 0.0, 0.0, 4.2, 1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(reference_elem->volume() == V0);
+        
+        // Shear in x
+        transform_element(mesh, X, 0.0, 0.0, 4.2, 1.0, 1.0, 0.0, 0.0, 0.0, 5.2, 0.0);
+        REQUIRE(reference_elem->volume() == Approx(V0));
+        
+        // Shear in y
+        transform_element(mesh, X, 0.0, 0.0, 4.2, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, -6.4);
+        REQUIRE(reference_elem->volume() == Approx(V0));
+    }
+}

--- a/tests/element/structural/2D/mast_structural_element_2d.cpp
+++ b/tests/element/structural/2D/mast_structural_element_2d.cpp
@@ -1,16 +1,25 @@
-// C++ Stanard Includes
-#include <math.h>
-
-// Catch2 includes
-#include "catch.hpp"
+/*
+ * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
+ * Copyright (C) 2013-2020  Manav Bhatia and MAST authors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
 
 // libMesh includes
 #include "libmesh/libmesh.h"
-#include "libmesh/replicated_mesh.h"
-#include "libmesh/point.h"
 #include "libmesh/elem.h"
-#include "libmesh/face_quad4.h"
-#include "libmesh/equation_systems.h"
 #include "libmesh/dof_map.h"
 
 // MAST includes
@@ -20,273 +29,118 @@
 #include "property_cards/solid_2d_section_element_property_card.h"
 #include "elasticity/structural_element_2d.h"
 #include "elasticity/structural_system_initialization.h"
-#include "base/physics_discipline_base.h"
 #include "base/nonlinear_implicit_assembly.h"
 #include "elasticity/structural_nonlinear_assembly.h"
 #include "base/nonlinear_system.h"
-#include "elasticity/structural_element_base.h"
 #include "mesh/geom_elem.h"
 
-// Custom includes
+// Test includes
+#include "catch.hpp"
 #include "test_helpers.h"
-
-#define pi 3.14159265358979323846
+#include "element/structural/2D/mast_structural_element_2d.h"
 
 extern libMesh::LibMeshInit* p_global_init;
 
-
 TEST_CASE("structural_element_2d_base_tests",
-          "[2D],[structural],[base]")
+          "[2D][structural][base]")
 {
-    const int n_elems = 1;
-    const int n_nodes = 4;
-    
-    // Point Coordinates
-    const std::vector<Real> x0 = {-1.0, 1.0, 1.0, -1.0};
-    const std::vector<Real> y0 = {-1.0, -1.0, 1.0, 1.0};
-    const std::vector<Real> z0 = {0.0, 0.0, 0.0, 0.0};
-    
-    RealMatrixX temp = RealMatrixX::Zero(3,4);
-    temp << -1.0,  1.0, 1.0, -1.0, 
-            -1.0, -1.0, 1.0,  1.0, 
-             0.0,  0.0, 0.0,  0.0;
-    const RealMatrixX X = temp;
-    
-    std::vector<Real> x = x0;
-    std::vector<Real> y = y0;
-    std::vector<Real> z = z0;
-    
-    /**
-     *  First create the mesh with the one element we are testing.
-     */
-    // Setup the mesh properties
-    libMesh::ReplicatedMesh mesh(p_global_init->comm());
-    mesh.set_mesh_dimension(2);
-    mesh.set_spatial_dimension(2);
-    mesh.reserve_elem(n_elems);
-    mesh.reserve_nodes(n_nodes);
-    
-    // Add nodes to the mesh
-    for (uint i=0; i<n_nodes; i++)
+    RealMatrixX coords = RealMatrixX::Zero(3,4);
+    coords << -1.0,  1.0, 1.0, -1.0,
+              -1.0, -1.0, 1.0,  1.0,
+               0.0,  0.0, 0.0,  0.0;
+    TEST::TestStructuralSingleElement2D test_elem(libMesh::QUAD4, coords);
+
+    REQUIRE(test_elem.reference_elem->volume() == TEST::get_shoelace_area(coords));
+
+    SECTION("Element returns proper number of strain components")
     {
-        mesh.add_point(libMesh::Point(x[i], y[i], z[i]));
+        REQUIRE(test_elem.elem->n_direct_strain_components() == 3);
+        REQUIRE(test_elem.elem->n_von_karman_strain_components() == 2);
     }
     
-    // Add the element to the mesh
-    libMesh::Elem *reference_elem = new libMesh::Quad4;
-    reference_elem->set_id(0);    
-    reference_elem->subdomain_id() = 0;
-    reference_elem = mesh.add_elem(reference_elem);
-    for (int i=0; i<n_nodes; i++)
+    SECTION("Incompatible modes flag returns false for basic element")
     {
-        reference_elem->set_node(i) = mesh.node_ptr(i);
+        REQUIRE_FALSE(test_elem.elem->if_incompatible_modes());
     }
-    
-    // Prepare the mesh for use
-    mesh.prepare_for_use();
-    //mesh.print_info();
-    
-    const Real elem_volume = reference_elem->volume();
-    // Calculate true volume using 2D shoelace formula
-    Real true_volume = 0.0;
-    for (uint i=0; i<n_nodes-1; i++)
+
+    SECTION("Isotropic flag returns true for basic element")
     {
-        true_volume += x[i]*y[i+1] - x[i+1]*y[i];
-    }
-    true_volume += x[n_nodes-1]*y[0] - x[0]*y[n_nodes-1];
-    true_volume = std::abs(true_volume);
-    true_volume *= 0.5;
-    
-    // Ensure the libMesh element has the expected volume
-    REQUIRE( elem_volume == true_volume );
-            
-    /**
-     *  Setup the material and section properties to be used in the element
-     */
-    
-    // Define Material Properties as MAST Parameters
-    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
-    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
-    MAST::Parameter alpha("alpha_param", 5.43e-05);   // Coefficient of thermal expansion
-    MAST::Parameter rho("rho_param", 1420.5);         // Density
-    MAST::Parameter cp("cp_param",   908.0);          // Specific Heat Capacity
-    MAST::Parameter k("k_param",     237.0);          // Thermal Conductivity
-    
-    // Define Section Properties as MAST Parameters
-    MAST::Parameter thickness("th_param", 0.06);      // Section thickness
-    MAST::Parameter offset("off_param", 0.03);        // Section offset
-    MAST::Parameter kappa("kappa_param", 5.0/6.0);    // Shear coefficient
-    
-    // Create field functions to dsitribute these constant parameters throughout the model
-    MAST::ConstantFieldFunction E_f("E", E);
-    MAST::ConstantFieldFunction nu_f("nu", nu);
-    MAST::ConstantFieldFunction alpha_f("alpha_expansion", alpha);
-    MAST::ConstantFieldFunction rho_f("rho", rho);
-    MAST::ConstantFieldFunction cp_f("cp", cp);
-    MAST::ConstantFieldFunction k_f("k_th", k);
-    MAST::ConstantFieldFunction thickness_f("h", thickness);
-    MAST::ConstantFieldFunction offset_f("off", offset);
-    MAST::ConstantFieldFunction kappa_f("kappa", kappa);
-    
-    // Initialize the material
-    MAST::IsotropicMaterialPropertyCard material;                   
-    
-    // Add the material property constant field functions to the material card
-    material.add(E_f);                                             
-    material.add(nu_f);
-    material.add(alpha_f);
-    material.add(rho_f);
-    material.add(k_f);
-    material.add(cp_f);
-    
-    // Initialize the section
-    MAST::Solid2DSectionElementPropertyCard section;
-    
-    // Add the section property constant field functions to the section card
-    section.add(thickness_f);
-    section.add(offset_f);
-    section.add(kappa_f);
-    
-    // Add the material card to the section card
-    section.set_material(material);
-    
-    
-    /**
-     *  Now we setup the structural system we will be solving.
-     */
-    libMesh::EquationSystems equation_systems(mesh);
-    
-    MAST::NonlinearSystem& system = equation_systems.add_system<MAST::NonlinearSystem>("structural");
-    
-    libMesh::FEType fetype(libMesh::FIRST, libMesh::LAGRANGE);
-    
-    MAST::StructuralSystemInitialization structural_system(system, 
-                                                           system.name(), 
-                                                           fetype);
-    
-    MAST::PhysicsDisciplineBase discipline(equation_systems);
-    
-    discipline.set_property_for_subdomain(0, section);
-    
-    equation_systems.init();
-    //equation_systems.print_info();
-    
-    MAST::NonlinearImplicitAssembly assembly;
-    assembly.set_discipline_and_system(discipline, structural_system);
-    
-    // Create the MAST element from the libMesh reference element
-    MAST::GeomElem geom_elem;
-    geom_elem.init(*reference_elem, structural_system);
-    std::unique_ptr<MAST::StructuralElementBase> elem_base = build_structural_element(structural_system, geom_elem, section);
-    
-    // Cast the base structural element as a 2D structural element
-    MAST::StructuralElement2D* elem = (dynamic_cast<MAST::StructuralElement2D*>(elem_base.get()));
-    
-    SECTION("number_strain_components")
-    {
-        REQUIRE(elem->n_direct_strain_components() == 3);
-        REQUIRE(elem->n_von_karman_strain_components() == 2);
-    }
-    
-    SECTION("no_incompatible_modes")
-    {
-        REQUIRE_FALSE( elem->if_incompatible_modes() );
-    }
-    
-    SECTION("return_section_property")
-    {
-        const MAST::ElementPropertyCardBase& elem_section = elem->elem_property();
+        const MAST::ElementPropertyCardBase& elem_section = test_elem.elem->elem_property();
         CHECK( elem_section.if_isotropic() );
     }
-    
-    SECTION("set_get_local_solution")
+
+    SECTION("Check setting/getting element local solution")
     {
-        const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
+        const libMesh::DofMap& dof_map = test_elem.assembly.system().get_dof_map();
         std::vector<libMesh::dof_id_type> dof_indices;
-        dof_map.dof_indices (reference_elem, dof_indices);
+        dof_map.dof_indices (test_elem.reference_elem, dof_indices);
         uint n_dofs = uint(dof_indices.size());
-        
+
         RealVectorX elem_solution = 5.3*RealVectorX::Ones(n_dofs);
-        elem->set_solution(elem_solution);
-        
-        const RealVectorX& local_solution = elem->local_solution();
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(elem_solution);
-        std::vector<double> truth = eigen_matrix_to_std_vector(local_solution);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+        test_elem.elem->set_solution(elem_solution);
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(elem_solution),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.elem->local_solution())));
     }
-    
-    SECTION("set_get_local_solution_sensitivity")
+
+    SECTION("Check setting/getting element local sensitivity solution")
     {
-        const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
+        const libMesh::DofMap& dof_map = test_elem.assembly.system().get_dof_map();;
         std::vector<libMesh::dof_id_type> dof_indices;
-        dof_map.dof_indices (reference_elem, dof_indices);
+        dof_map.dof_indices (test_elem.reference_elem, dof_indices);
         uint n_dofs = uint(dof_indices.size());
-        
+
         RealVectorX elem_solution_sens = 3.1*RealVectorX::Ones(n_dofs);
-        elem->set_solution(elem_solution_sens, true);
-        
-        const RealVectorX& local_solution_sens = elem->local_solution(true);
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(elem_solution_sens);
-        std::vector<double> truth = eigen_matrix_to_std_vector(local_solution_sens);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+        test_elem.elem->set_solution(elem_solution_sens, true);
+
+        const RealVectorX& local_solution_sens = test_elem.elem->local_solution(true);
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(elem_solution_sens),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.elem->local_solution(true))));
     }
-    
-    SECTION("element shape can be transformed")
+
+    SECTION("Element shape can be transformed")
     {
-        const Real V0 = reference_elem->volume();
-        
+        const Real V0 = test_elem.reference_elem->volume();
+
         // Stretch in x-direction
-        transform_element(mesh, X, 0.0, 0.0, 0.0, 3.1, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE(reference_elem->volume() == 12.4);
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0, 3.1, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == 12.4);
+
         // Stretch in y-direction
-        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 3.1, 0.0, 0.0, 0.0);
-        REQUIRE(reference_elem->volume() == 12.4);
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0, 1.0, 3.1, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == 12.4);
+
         // Rotation about z-axis
-        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 60.0);
-        REQUIRE(reference_elem->volume() == V0);
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 60.0);
+        REQUIRE(test_elem.reference_elem->volume() == V0);
+
         // Rotation about y-axis
-        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 30.0, 0.0);
-        REQUIRE(reference_elem->volume() == V0);
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 30.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == V0);
+
         // Rotation about x-axis
-        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 20.0, 0.0, 0.0);
-        REQUIRE(reference_elem->volume() == V0);
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0, 1.0, 1.0, 20.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == V0);
+
         // Shifted in x-direction
-        transform_element(mesh, X, 10.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE(reference_elem->volume() == V0);
-        
+        TEST::transform_element(test_elem.mesh, coords, 10.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == V0);
+
         // Shifted in y-direction
-        transform_element(mesh, X, 0.0, 7.5, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE(reference_elem->volume() == V0);
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 7.5, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == V0);
+
         // Shifted in z-direction
-        transform_element(mesh, X, 0.0, 0.0, 4.2, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE(reference_elem->volume() == V0);
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 4.2, 1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == V0);
+
         // Shear in x
-        transform_element(mesh, X, 0.0, 0.0, 4.2, 1.0, 1.0, 0.0, 0.0, 0.0, 5.2, 0.0);
-        REQUIRE(reference_elem->volume() == Approx(V0));
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 4.2, 1.0, 1.0, 0.0, 0.0, 0.0, 5.2, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+
         // Shear in y
-        transform_element(mesh, X, 0.0, 0.0, 4.2, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, -6.4);
-        REQUIRE(reference_elem->volume() == Approx(V0));
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 4.2, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, -6.4);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
     }
 }

--- a/tests/element/structural/2D/mast_structural_element_2d.h
+++ b/tests/element/structural/2D/mast_structural_element_2d.h
@@ -1,0 +1,168 @@
+/*
+ * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
+ * Copyright (C) 2013-2020  Manav Bhatia and MAST authors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef MAST_MAST_STRUCTURAL_ELEMENT_2D_H
+#define MAST_MAST_STRUCTURAL_ELEMENT_2D_H
+
+// Test includes
+#include "base/mast_mesh.h"
+
+extern libMesh::LibMeshInit* p_global_init;
+
+namespace TEST {
+
+    /**
+     *
+     */
+    class TestStructuralSingleElement2D: public TEST::TestMeshSingleElement {
+    public:
+        // Material properties.
+        MAST::Parameter E;                ///< Modulus of Elasticity
+        MAST::Parameter nu;               ///<  Poisson's ratio
+        MAST::Parameter rho;              ///<  Density
+        MAST::Parameter alpha;            ///<  Coefficient of thermal expansion
+        MAST::Parameter cp;               ///<  Specific heat capacity
+        MAST::Parameter k;                ///<  Thermal conductivity
+        // Section properties.
+        MAST::Parameter thickness;  ///< Section thickness
+        MAST::Parameter offset;     ///< Section offset
+        MAST::Parameter kappa;      ///< Shear coefficient
+        // Field functions to distribution parameters throughout model.
+        MAST::ConstantFieldFunction E_f;
+        MAST::ConstantFieldFunction nu_f;
+        MAST::ConstantFieldFunction rho_f;
+        MAST::ConstantFieldFunction alpha_f;
+        MAST::ConstantFieldFunction cp_f;
+        MAST::ConstantFieldFunction k_f;
+        MAST::ConstantFieldFunction thickness_f;
+        MAST::ConstantFieldFunction offset_f;
+        MAST::ConstantFieldFunction kappa_f;
+        // Material and property cards.
+        MAST::IsotropicMaterialPropertyCard material;
+        MAST::Solid2DSectionElementPropertyCard section;
+        // Data associated with finite element system/assembly and discipline.
+        libMesh::EquationSystems equation_systems;
+        MAST::NonlinearSystem& system;
+        libMesh::FEType fetype;
+        MAST::StructuralSystemInitialization structural_system;
+        MAST::PhysicsDisciplineBase discipline;
+        MAST::NonlinearImplicitAssembly assembly;
+        // Data for actual structural element.
+        MAST::GeomElem geom_elem;
+        std::unique_ptr<MAST::StructuralElementBase> elem_base;
+        MAST::StructuralElement2D* elem;
+        // Quick reference to element degree of freedom IDs.
+        std::vector<libMesh::dof_id_type> dof_indices;
+        uint n_dofs;
+        // Element states.
+        RealVectorX elem_solution;
+        RealVectorX elem_accel;
+        // Storage for element residual & Jacobian for zero solution.
+        RealVectorX residual;    ///< Vector storage for element's residual vector.
+        RealMatrixX jacobian0;   ///< Matrix storage for Jacobian of baseline/undeformed element.
+        RealMatrixX jacobian_xdot0;   ///< Matrix storage for velocity Jacobian of baseline/undeformed element.
+        RealMatrixX jacobian_xddot0;  ///< Matrix storage for acceleration Jacobian of baseline/undeformed element.
+        RealMatrixX jacobian;    ///< Matrix storage for Jacobian of the element in a perturbed/modified state.
+        RealMatrixX jacobian_fd; ///< Matrix storage for element Jacobian approximated by finite difference.
+
+        TestStructuralSingleElement2D(libMesh::ElemType e_type, RealMatrixX& coordinates):
+        TestMeshSingleElement(e_type, coordinates),
+        // Initialize material properties to some default values.
+        E("E_param", 72.0e9),
+        nu("nu_param", 0.33),
+        rho("rho_param", 1420.5),
+        alpha("alpha_param", 5.43e-05),
+        cp("cp_param",   908.0),
+        k("k_param",     237.0),
+        // Initialize section properties to some default values.
+        thickness("th_param", 0.06),
+        offset("off_param", 0.03),
+        kappa("kappa_param", 5.0/6.0),
+        // Initialize field functions using parameters.
+        E_f("E", E),
+        nu_f("nu", nu),
+        rho_f("rho", rho),
+        alpha_f("alpha_expansion", alpha),
+        cp_f("cp", cp),
+        k_f("k_th", k),
+        thickness_f("h", thickness),
+        offset_f("off", offset),
+        kappa_f("kappa", kappa),
+        // Initialize system/discipline/etc.
+        equation_systems(mesh),
+        system(equation_systems.add_system<MAST::NonlinearSystem>("structural")),
+        fetype(libMesh::FIRST, libMesh::LAGRANGE),
+        structural_system(system, system.name(), fetype),
+        discipline(equation_systems)
+        {
+            // Configure material card.
+            material.add(E_f);
+            material.add(nu_f);
+            material.add(rho_f);
+            material.add(alpha_f);
+            material.add(k_f);
+            material.add(cp_f);
+
+            // Configure section property card.
+            section.add(thickness_f);
+            section.add(offset_f);
+            section.add(kappa_f);
+            section.set_material(material);
+            discipline.set_property_for_subdomain(0, section);
+
+            // Setup finite element system and discipline.
+            equation_systems.init();
+            assembly.set_discipline_and_system(discipline, structural_system);
+
+            // Create the MAST element from the libMesh reference element.
+            geom_elem.init(*reference_elem, structural_system);
+            elem_base = MAST::build_structural_element(structural_system, geom_elem, section);
+            elem = (dynamic_cast<MAST::StructuralElement2D*>(elem_base.get()));
+
+            // Get element DOFs for easy reference in tests.
+            const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
+            dof_map.dof_indices (reference_elem, dof_indices);
+            n_dofs = uint(dof_indices.size());
+
+            // Set element's initial solution and solution sensitivity to zero.
+            elem_solution = RealVectorX::Zero(n_dofs);
+            elem->set_solution(elem_solution);
+            elem->set_solution(elem_solution, true);
+
+            // Set element's initial acceleration and acceleration sensitivity to zero.
+            elem_accel = RealVectorX::Zero(n_dofs);
+            elem->set_acceleration(elem_accel);
+            elem->set_acceleration(elem_accel, true);
+
+            // Calculate residual and jacobian
+            residual = RealVectorX::Zero(n_dofs);
+            jacobian0 = RealMatrixX::Zero(n_dofs, n_dofs);
+            jacobian_xdot0 = RealMatrixX::Zero(n_dofs, n_dofs);
+            jacobian_xddot0 = RealMatrixX::Zero(n_dofs, n_dofs);
+            jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+            jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        }
+        void update_residual_and_jacobian0() {elem->internal_residual(true, residual, jacobian0);}
+        void update_residual_and_jacobian() {elem->internal_residual(true, residual, jacobian);}
+        void update_inertial_residual_and_jacobian0() {elem->inertial_residual(true, residual, jacobian_xddot0, jacobian_xdot0, jacobian0);}
+    };
+
+}
+
+#endif //MAST_MAST_STRUCTURAL_ELEMENT_2D_H

--- a/tests/element/structural/2D/quad4/CMakeLists.txt
+++ b/tests/element/structural/2D/quad4/CMakeLists.txt
@@ -1,69 +1,162 @@
 target_sources(mast_catch_tests
-               PRIVATE
-               ${CMAKE_CURRENT_LIST_DIR}/mast_quad4_structural_shape_functions.cpp
-               ${CMAKE_CURRENT_LIST_DIR}/mast_quad4_linear_structural_strain_displacement_matrix.cpp
-               ${CMAKE_CURRENT_LIST_DIR}/mast_quad4_linear_structural_extension_internal_jacobian.cpp
-               ${CMAKE_CURRENT_LIST_DIR}/mast_quad4_linear_structural_extension_bending_shear_internal_jacobian.cpp
-               ${CMAKE_CURRENT_LIST_DIR}/mast_quad4_linear_structural_extension_bending_coupling_internal_jacobian.cpp
-               ${CMAKE_CURRENT_LIST_DIR}/mast_quad4_linear_structural_internal_jacobian.cpp
-               ${CMAKE_CURRENT_LIST_DIR}/mast_quad4_linear_structural_inertial_jacobian.cpp)
+    PRIVATE
+        ${CMAKE_CURRENT_LIST_DIR}/mast_quad4_structural_shape_functions.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/mast_quad4_linear_structural_strain_displacement_matrix.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/mast_quad4_linear_structural_extension_internal_jacobian.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/mast_quad4_linear_structural_extension_bending_internal_jacobian.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/mast_quad4_linear_structural_extension_bending_shear_internal_jacobian.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/mast_quad4_linear_structural_extension_bending_coupling_internal_jacobian.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/mast_quad4_linear_structural_internal_jacobian.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/mast_quad4_linear_structural_inertial_jacobian.cpp)
                
 add_test(NAME Element_Quad4_Structural_Shape_Functions
-         COMMAND mast_catch_tests "quad4_structural_shape_functions")
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "quad4_structural_shape_functions")
 set_tests_properties(Element_Quad4_Structural_Shape_Functions
-                     PROPERTIES 
-                     FIXTURES_SETUP     Element_Quad4_Structural_Shape_Functions)
-                     
+    PROPERTIES
+        LABELS "SEQ"
+        FIXTURES_SETUP     Element_Quad4_Structural_Shape_Functions)
+
+add_test(NAME Element_Quad4_Structural_Shape_Functions_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "quad4_structural_shape_functions")
+set_tests_properties(Element_Quad4_Structural_Shape_Functions_mpi
+    PROPERTIES
+        LABELS "MPI"
+        FIXTURES_SETUP     Element_Quad4_Structural_Shape_Functions_mpi)
+
+
+
 add_test(NAME Element_Quad4_Linear_Structural_Strain_Displacement_Matrix
-         COMMAND mast_catch_tests "quad4_linear_structural_strain_displacement_matrix")
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "quad4_linear_structural_strain_displacement_matrix")
 set_tests_properties(Element_Quad4_Linear_Structural_Strain_Displacement_Matrix
-                     PROPERTIES
-                     FIXTURES_REQUIRED  Element_Quad4_Structural_Shape_Functions
-                     FIXTURES_SETUP     Element_Quad4_Linear_Structural_Strain_Displacement_Matrix)
+    PROPERTIES
+        LABELS "SEQ"
+        FIXTURES_REQUIRED  Element_Quad4_Structural_Shape_Functions
+        FIXTURES_SETUP     Element_Quad4_Linear_Structural_Strain_Displacement_Matrix)
+
+add_test(NAME Element_Quad4_Linear_Structural_Strain_Displacement_Matrix_mpi
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "quad4_linear_structural_strain_displacement_matrix")
+set_tests_properties(Element_Quad4_Linear_Structural_Strain_Displacement_Matrix_mpi
+    PROPERTIES
+        LABELS "MPI"
+        FIXTURES_REQUIRED  Element_Quad4_Structural_Shape_Functions_mpi
+        FIXTURES_SETUP     Element_Quad4_Linear_Structural_Strain_Displacement_Matrix_mpi)
+
+
 
 add_test(NAME Element_Quad4_Linear_Structural_Extension
-         COMMAND mast_catch_tests "quad4_linear_extension_structural")
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "quad4_linear_extension_structural")
 set_tests_properties(Element_Quad4_Linear_Structural_Extension
-                     PROPERTIES 
-                     FIXTURES_REQUIRED  Element_2D_Structural_Basic_Tests
-                     FIXTURES_SETUP     Element_Quad4_Linear_Structural_Extension)
-                     
+    PROPERTIES
+        LABELS "SEQ"
+        FIXTURES_REQUIRED  Element_2D_Structural_Basic_Tests
+        FIXTURES_SETUP     Element_Quad4_Linear_Structural_Extension)
+
+add_test(NAME Element_Quad4_Linear_Structural_Extension_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "quad4_linear_extension_structural")
+set_tests_properties(Element_Quad4_Linear_Structural_Extension_mpi
+    PROPERTIES
+        LABELS "MPI"
+        FIXTURES_REQUIRED  Element_2D_Structural_Basic_Tests_mpi
+        FIXTURES_SETUP     Element_Quad4_Linear_Structural_Extension_mpi)
+
+
+
 add_test(NAME Element_Quad4_Linear_Structural_Extension_Bending
-         COMMAND mast_catch_tests "quad4_linear_extension_bending_structural")
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "quad4_linear_extension_bending_structural")
 set_tests_properties(Element_Quad4_Linear_Structural_Extension_Bending
-                     PROPERTIES 
-                     FIXTURES_REQUIRED  Element_Quad4_Linear_Structural_Extension
-                     FIXTURES_SETUP     Element_Quad4_Linear_Structural_Extension_Bending)
-                     
+    PROPERTIES
+        LABELS "SEQ"
+        FIXTURES_REQUIRED  Element_Quad4_Linear_Structural_Extension
+        FIXTURES_SETUP     Element_Quad4_Linear_Structural_Extension_Bending)
+
+add_test(NAME Element_Quad4_Linear_Structural_Extension_Bending_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "quad4_linear_extension_bending_structural")
+set_tests_properties(Element_Quad4_Linear_Structural_Extension_Bending_mpi
+    PROPERTIES
+        LABELS "MPI"
+        FIXTURES_REQUIRED  Element_Quad4_Linear_Structural_Extension_mpi
+        FIXTURES_SETUP     Element_Quad4_Linear_Structural_Extension_Bending_mpi)
+
+
+
 add_test(NAME Element_Quad4_Linear_Structural_Extension_Bending_Shear
-         COMMAND mast_catch_tests "quad4_linear_extension_bending_shear_structural")
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "quad4_linear_extension_bending_shear_structural")
 set_tests_properties(Element_Quad4_Linear_Structural_Extension_Bending_Shear
-                     PROPERTIES 
-                     FIXTURES_REQUIRED  Element_Quad4_Linear_Structural_Extension_Bending
-                     FIXTURES_SETUP     Element_Quad4_Linear_Structural_Extension_Bending_Shear)
-                     
+    PROPERTIES
+        LABELS "SEQ"
+        FIXTURES_REQUIRED  Element_Quad4_Linear_Structural_Extension_Bending
+        FIXTURES_SETUP     Element_Quad4_Linear_Structural_Extension_Bending_Shear)
+
+add_test(NAME Element_Quad4_Linear_Structural_Extension_Bending_Shear_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "quad4_linear_extension_bending_shear_structural")
+set_tests_properties(Element_Quad4_Linear_Structural_Extension_Bending_Shear_mpi
+    PROPERTIES
+        LABELS "MPI"
+        FIXTURES_REQUIRED  Element_Quad4_Linear_Structural_Extension_Bending_mpi
+        FIXTURES_SETUP     Element_Quad4_Linear_Structural_Extension_Bending_Shear_mpi)
+
+
+
 add_test(NAME Element_Quad4_Linear_Structural_Extension_Bending_Coupling
-         COMMAND mast_catch_tests "quad4_linear_extension_bending_coupling_structural")
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "quad4_linear_extension_bending_coupling_structural")
 set_tests_properties(Element_Quad4_Linear_Structural_Extension_Bending_Coupling
-                     PROPERTIES 
-                     FIXTURES_REQUIRED  Element_Quad4_Linear_Structural_Extension_Bending
-                     FIXTURES_SETUP     Element_Quad4_Linear_Structural_Extension_Bending_Coupling)
-                     
+    PROPERTIES
+        LABELS "SEQ"
+        FIXTURES_REQUIRED  Element_Quad4_Linear_Structural_Extension_Bending
+        FIXTURES_SETUP     Element_Quad4_Linear_Structural_Extension_Bending_Coupling)
+
+add_test(NAME Element_Quad4_Linear_Structural_Extension_Bending_Coupling_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "quad4_linear_extension_bending_coupling_structural")
+set_tests_properties(Element_Quad4_Linear_Structural_Extension_Bending_Coupling_mpi
+    PROPERTIES
+        LABELS "MPI"
+        FIXTURES_REQUIRED  Element_Quad4_Linear_Structural_Extension_Bending_mpi
+        FIXTURES_SETUP     Element_Quad4_Linear_Structural_Extension_Bending_Coupling_mpi)
+
+
+
 add_test(NAME Element_Quad4_Linear_Structural_All
-         COMMAND mast_catch_tests "quad4_linear_structural")
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "quad4_linear_structural")
 set_tests_properties(Element_Quad4_Linear_Structural_All
-                     PROPERTIES 
-                     FIXTURES_REQUIRED "Element_Quad4_Linear_Structural_Extension_Bending_Shear;Element_Quad4_Linear_Structural_Extension_Bending_Coupling"
-                     )
-                     
+    PROPERTIES
+        LABELS "SEQ"
+        FIXTURES_REQUIRED "Element_Quad4_Linear_Structural_Extension_Bending_Shear;Element_Quad4_Linear_Structural_Extension_Bending_Coupling")
+
+add_test(NAME Element_Quad4_Linear_Structural_All_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "quad4_linear_structural")
+set_tests_properties(Element_Quad4_Linear_Structural_All_mpi
+    PROPERTIES
+        LABELS "MPI"
+        FIXTURES_REQUIRED "Element_Quad4_Linear_Structural_Extension_Bending_Shear_mpi;Element_Quad4_Linear_Structural_Extension_Bending_Coupling_mpi")
+
+
+
 add_test(NAME Element_Quad4_Linear_Structural_Inertial_Consistent
-         COMMAND mast_catch_tests "quad4_linear_structural_inertial_consistent")
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "quad4_linear_structural_inertial_consistent")
 set_tests_properties(Element_Quad4_Linear_Structural_Inertial_Consistent
-                     PROPERTIES
-                     FIXTURES_REQUIRED Element_2D_Structural_Basic_Tests)
-                     
+    PROPERTIES
+        LABELS "SEQ"
+        FIXTURES_REQUIRED Element_2D_Structural_Basic_Tests)
+
+add_test(NAME Element_Quad4_Linear_Structural_Inertial_Consistent_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "quad4_linear_structural_inertial_consistent")
+set_tests_properties(Element_Quad4_Linear_Structural_Inertial_Consistent_mpi
+    PROPERTIES
+        LABELS "MPI"
+        FIXTURES_REQUIRED Element_2D_Structural_Basic_Tests_mpi)
+
+
+
 add_test(NAME Element_Quad4_Linear_Structural_Inertial_Lumped
-         COMMAND mast_catch_tests "quad4_linear_structural_inertial_lumped")
+    COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "quad4_linear_structural_inertial_lumped")
 set_tests_properties(Element_Quad4_Linear_Structural_Inertial_Lumped
-                     PROPERTIES
-                     FIXTURES_REQUIRED Element_2D_Structural_Basic_Tests)
+    PROPERTIES
+        LABELS "SEQ"
+        FIXTURES_REQUIRED Element_2D_Structural_Basic_Tests)
+
+add_test(NAME Element_Quad4_Linear_Structural_Inertial_Lumped_mpi
+    COMMAND ${MPIEXEC_EXECUTABLE} -np 2 $<TARGET_FILE:mast_catch_tests> -w NoTests "quad4_linear_structural_inertial_lumped")
+set_tests_properties(Element_Quad4_Linear_Structural_Inertial_Lumped_mpi
+    PROPERTIES
+        LABELS "MPI"
+        FIXTURES_REQUIRED Element_2D_Structural_Basic_Tests_mpi)

--- a/tests/element/structural/2D/quad4/CMakeLists.txt
+++ b/tests/element/structural/2D/quad4/CMakeLists.txt
@@ -1,0 +1,69 @@
+target_sources(mast_catch_tests
+               PRIVATE
+               ${CMAKE_CURRENT_LIST_DIR}/mast_quad4_structural_shape_functions.cpp
+               ${CMAKE_CURRENT_LIST_DIR}/mast_quad4_linear_structural_strain_displacement_matrix.cpp
+               ${CMAKE_CURRENT_LIST_DIR}/mast_quad4_linear_structural_extension_internal_jacobian.cpp
+               ${CMAKE_CURRENT_LIST_DIR}/mast_quad4_linear_structural_extension_bending_shear_internal_jacobian.cpp
+               ${CMAKE_CURRENT_LIST_DIR}/mast_quad4_linear_structural_extension_bending_coupling_internal_jacobian.cpp
+               ${CMAKE_CURRENT_LIST_DIR}/mast_quad4_linear_structural_internal_jacobian.cpp
+               ${CMAKE_CURRENT_LIST_DIR}/mast_quad4_linear_structural_inertial_jacobian.cpp)
+               
+add_test(NAME Element_Quad4_Structural_Shape_Functions
+         COMMAND mast_catch_tests "quad4_structural_shape_functions")
+set_tests_properties(Element_Quad4_Structural_Shape_Functions
+                     PROPERTIES 
+                     FIXTURES_SETUP     Element_Quad4_Structural_Shape_Functions)
+                     
+add_test(NAME Element_Quad4_Linear_Structural_Strain_Displacement_Matrix
+         COMMAND mast_catch_tests "quad4_linear_structural_strain_displacement_matrix")
+set_tests_properties(Element_Quad4_Linear_Structural_Strain_Displacement_Matrix
+                     PROPERTIES
+                     FIXTURES_REQUIRED  Element_Quad4_Structural_Shape_Functions
+                     FIXTURES_SETUP     Element_Quad4_Linear_Structural_Strain_Displacement_Matrix)
+
+add_test(NAME Element_Quad4_Linear_Structural_Extension
+         COMMAND mast_catch_tests "quad4_linear_extension_structural")
+set_tests_properties(Element_Quad4_Linear_Structural_Extension
+                     PROPERTIES 
+                     FIXTURES_REQUIRED  Element_2D_Structural_Basic_Tests
+                     FIXTURES_SETUP     Element_Quad4_Linear_Structural_Extension)
+                     
+add_test(NAME Element_Quad4_Linear_Structural_Extension_Bending
+         COMMAND mast_catch_tests "quad4_linear_extension_bending_structural")
+set_tests_properties(Element_Quad4_Linear_Structural_Extension_Bending
+                     PROPERTIES 
+                     FIXTURES_REQUIRED  Element_Quad4_Linear_Structural_Extension
+                     FIXTURES_SETUP     Element_Quad4_Linear_Structural_Extension_Bending)
+                     
+add_test(NAME Element_Quad4_Linear_Structural_Extension_Bending_Shear
+         COMMAND mast_catch_tests "quad4_linear_extension_bending_shear_structural")
+set_tests_properties(Element_Quad4_Linear_Structural_Extension_Bending_Shear
+                     PROPERTIES 
+                     FIXTURES_REQUIRED  Element_Quad4_Linear_Structural_Extension_Bending
+                     FIXTURES_SETUP     Element_Quad4_Linear_Structural_Extension_Bending_Shear)
+                     
+add_test(NAME Element_Quad4_Linear_Structural_Extension_Bending_Coupling
+         COMMAND mast_catch_tests "quad4_linear_extension_bending_coupling_structural")
+set_tests_properties(Element_Quad4_Linear_Structural_Extension_Bending_Coupling
+                     PROPERTIES 
+                     FIXTURES_REQUIRED  Element_Quad4_Linear_Structural_Extension_Bending
+                     FIXTURES_SETUP     Element_Quad4_Linear_Structural_Extension_Bending_Coupling)
+                     
+add_test(NAME Element_Quad4_Linear_Structural_All
+         COMMAND mast_catch_tests "quad4_linear_structural")
+set_tests_properties(Element_Quad4_Linear_Structural_All
+                     PROPERTIES 
+                     FIXTURES_REQUIRED "Element_Quad4_Linear_Structural_Extension_Bending_Shear;Element_Quad4_Linear_Structural_Extension_Bending_Coupling"
+                     )
+                     
+add_test(NAME Element_Quad4_Linear_Structural_Inertial_Consistent
+         COMMAND mast_catch_tests "quad4_linear_structural_inertial_consistent")
+set_tests_properties(Element_Quad4_Linear_Structural_Inertial_Consistent
+                     PROPERTIES
+                     FIXTURES_REQUIRED Element_2D_Structural_Basic_Tests)
+                     
+add_test(NAME Element_Quad4_Linear_Structural_Inertial_Lumped
+         COMMAND mast_catch_tests "quad4_linear_structural_inertial_lumped")
+set_tests_properties(Element_Quad4_Linear_Structural_Inertial_Lumped
+                     PROPERTIES
+                     FIXTURES_REQUIRED Element_2D_Structural_Basic_Tests)

--- a/tests/element/structural/2D/quad4/mast_quad4_linear_structural_extension_bending_coupling_internal_jacobian.cpp
+++ b/tests/element/structural/2D/quad4/mast_quad4_linear_structural_extension_bending_coupling_internal_jacobian.cpp
@@ -1,0 +1,659 @@
+#include "catch.hpp"
+
+// libMesh includes
+#include "libmesh/libmesh.h"
+#include "libmesh/replicated_mesh.h"
+#include "libmesh/point.h"
+#include "libmesh/elem.h"
+#include "libmesh/face_quad4.h"
+#include "libmesh/equation_systems.h"
+#include "libmesh/dof_map.h"
+
+// MAST includes
+#include "base/parameter.h"
+#include "base/constant_field_function.h"
+#include "property_cards/isotropic_material_property_card.h"
+#include "property_cards/solid_2d_section_element_property_card.h"
+#include "elasticity/structural_element_2d.h"
+#include "elasticity/structural_system_initialization.h"
+#include "base/physics_discipline_base.h"
+#include "base/nonlinear_implicit_assembly.h"
+#include "elasticity/structural_nonlinear_assembly.h"
+#include "base/nonlinear_system.h"
+#include "elasticity/structural_element_base.h"
+#include "mesh/geom_elem.h"
+
+// Custom includes
+#include "test_helpers.h"
+
+#define pi 3.14159265358979323846
+
+extern libMesh::LibMeshInit* p_global_init;
+
+TEST_CASE("quad4_linear_extension_bending_coupling_structural", 
+          "[quad],[quad4],[linear],[structural],[2D],[element]")
+{
+    const int n_elems = 1;
+    const int n_nodes = 4;
+    
+    // Point Coordinates
+    RealMatrixX temp = RealMatrixX::Zero(3,4);
+    temp << -1.0,  1.0, 1.0, -1.0, 
+            -1.0, -1.0, 1.0,  1.0, 
+             0.0,  0.0, 0.0,  0.0;
+    const RealMatrixX X = temp;
+    
+    /**
+     *  First create the mesh with the one element we are testing.
+     */
+    // Setup the mesh properties
+    libMesh::ReplicatedMesh mesh(p_global_init->comm());
+    mesh.set_mesh_dimension(2);
+    mesh.set_spatial_dimension(2);
+    mesh.reserve_elem(n_elems);
+    mesh.reserve_nodes(n_nodes);
+    
+    // Add nodes to the mesh
+    for (uint i=0; i<n_nodes; i++)
+    {
+        mesh.add_point(libMesh::Point(X(0,i), X(1,i), X(2,i)));
+    }
+    
+    // Add the element to the mesh
+    libMesh::Elem *reference_elem = new libMesh::Quad4;
+    reference_elem->set_id(0);    
+    reference_elem->subdomain_id() = 0;
+    reference_elem = mesh.add_elem(reference_elem);
+    for (int i=0; i<n_nodes; i++)
+    {
+        reference_elem->set_node(i) = mesh.node_ptr(i);
+    }
+    
+    // Prepare the mesh for use
+    mesh.prepare_for_use();
+    //mesh.print_info();
+    
+    const Real elem_volume = reference_elem->volume();
+    // Calculate true volume using 2D shoelace formula
+    Real true_volume = get_shoelace_area(X);
+    
+    // Ensure the libMesh element has the expected volume
+    REQUIRE( elem_volume == true_volume );
+            
+    /**
+     *  Setup the material and section properties to be used in the element
+     */
+    
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
+    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
+    MAST::Parameter kappa("kappa_param", 5.0/6.0);    // Shear coefficient
+    
+    // Define Section Properties as MAST Parameters
+    MAST::Parameter thickness("th_param", 0.06);      // Section thickness
+    MAST::Parameter offset("off_param", 0.03);        // Section offset
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction E_f("E", E);
+    MAST::ConstantFieldFunction nu_f("nu", nu);
+    MAST::ConstantFieldFunction kappa_f("kappa", kappa);
+    MAST::ConstantFieldFunction thickness_f("h", thickness);
+    MAST::ConstantFieldFunction offset_f("off", offset);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(E_f);                                             
+    material.add(nu_f);
+    
+    // Initialize the section
+    MAST::Solid2DSectionElementPropertyCard section;
+    
+    // Add the section property constant field functions to the section card
+    section.add(thickness_f);
+    section.add(offset_f);
+    section.add(kappa_f);
+    
+    // Add the material card to the section card
+    section.set_material(material);
+    
+    
+    // Set the strain type to linear for the section
+    section.set_strain(MAST::LINEAR_STRAIN);
+    
+    /**
+     *  Now we setup the structural system we will be solving.
+     */
+    libMesh::EquationSystems equation_systems(mesh);
+    
+    MAST::NonlinearSystem& system = equation_systems.add_system<MAST::NonlinearSystem>("structural");
+    
+    libMesh::FEType fetype(libMesh::FIRST, libMesh::LAGRANGE);
+    
+    MAST::StructuralSystemInitialization structural_system(system, 
+                                                           system.name(), 
+                                                           fetype);
+    
+    MAST::PhysicsDisciplineBase discipline(equation_systems);
+    
+    discipline.set_property_for_subdomain(0, section);
+    
+    equation_systems.init();
+    //equation_systems.print_info();
+    
+    MAST::NonlinearImplicitAssembly assembly;
+    assembly.set_discipline_and_system(discipline, structural_system);
+    
+    // Create the MAST element from the libMesh reference element
+    MAST::GeomElem geom_elem;
+    geom_elem.init(*reference_elem, structural_system);
+    std::unique_ptr<MAST::StructuralElementBase> elem_base = build_structural_element(structural_system, geom_elem, section);
+    
+    // Cast the base structural element as a 2D structural element
+    MAST::StructuralElement2D* elem = (dynamic_cast<MAST::StructuralElement2D*>(elem_base.get()));
+    
+    // Get element DOFs
+    const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
+    std::vector<libMesh::dof_id_type> dof_indices;
+    dof_map.dof_indices (reference_elem, dof_indices);
+    uint n_dofs = uint(dof_indices.size());
+    
+    // Set element's initial solution and solution sensitivity to zero
+    RealVectorX elem_solution = RealVectorX::Zero(n_dofs);
+    elem->set_solution(elem_solution);
+    elem->set_solution(elem_solution, true);
+    
+    const Real V0 = reference_elem->volume();
+    
+    /**
+     *  Below, we start building the Jacobian up for a very basic element that 
+     *  is already in an isoparametric format.  The following four steps:
+     *      Extension Only Stiffness
+     *      Extension & Bending Stiffness
+     *      Extension, Bending, & Transverse Shear Stiffness
+     *      Extension, Bending, & Extension-Bending Coupling Stiffness
+     *      Extension, Bending, Transverse Shear & Extension-Bending Coupling Stiffness
+     * 
+     *  Testing the Jacobian incrementally this way allows errors in the
+     *  Jacobian to be located more precisely.
+     * 
+     *  It would probabyl be even better to test each stiffness contribution 
+     *  separately, but currently, we don't have a way to disable extension
+     *  stiffness and transverse shear stiffness doesn't exist without bending 
+     *  and extension-bending coupling stiffness don't make sense without both
+     *  extension and/or bending. 
+     */
+    
+    // Set shear coefficient to zero to disable transverse shear stiffness
+    // FIXME: In MAST, when kappa=0.0, this results in zero rows/columns in element stiffness matrix
+    kappa = 0.0;
+    
+    // Calculate residual and jacobian
+    RealVectorX residual = RealVectorX::Zero(n_dofs);
+    RealMatrixX jacobian0 = RealMatrixX::Zero(n_dofs, n_dofs);
+    elem->internal_residual(true, residual, jacobian0);
+            
+    double val_margin = (jacobian0.array().abs()).mean() * 1.490116119384766e-08;
+    
+    
+    SECTION("internal_jacobian_finite_difference_check")                   
+    {
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+    }
+    
+    SECTION("internal_jacobian_symmetry_check")
+    {
+        // Element stiffness matrix should be symmetric
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0.transpose());
+        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    SECTION("internal_jacobian_determinant_check")
+    {
+        // Determinant of undeformed element stiffness matrix should be zero
+        REQUIRE( jacobian0.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    
+    SECTION("internal_jacobian_displacement_invariant")
+    {
+        // Calculate residual and jacobian at arbitrary displacement
+        RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
+        elem_sol << -0.04384355,  0.03969142, -0.09470648, -0.05011107, 
+                    -0.02989082, -0.01205296,  0.08846868,  0.04522207,  
+                     0.06435953, -0.07282706,  0.09307561, -0.06250143,  
+                     0.03332844, -0.00040089, -0.00423108, -0.07258241,  
+                     0.06636534, -0.08421098, -0.0705489 , -0.06004976,
+                     0.03873095, -0.09194373,  0.00055061,  0.046831;
+        elem->set_solution(elem_sol);
+        
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+                
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
+
+        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+    }
+    
+    SECTION("internal_jacobian_shifted_x_invariant")
+    {
+        // Shifted in x-direction
+        transform_element(mesh, X, 5.2, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+                
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
+
+        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+    }
+    
+    SECTION("internal_jacobian_shifted_y_invariant")
+    {
+        // Shifted in y-direction
+        transform_element(mesh, X, 0.0, -11.5, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
+        
+        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+    }
+    
+    SECTION("internal_jacobian_rotated_about_z")
+    {
+        // Rotated 63.4 about z-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 63.4);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_rotated_about_y")
+    {
+        // Rotated 35.8 about y-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 35.8, 0.0);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_rotated_about_x")
+    {
+        // Rotated 15.8 about x-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 15.8, 0.0, 0.0);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_sheared_in_x")
+    {
+        // Rotated 63.4 about z-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 6.7, 0.0);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_sheared_in_y")
+    {
+        // Rotated 63.4 about z-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, -11.2);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_scaled_x")
+    {
+        // Rotated 63.4 about z-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 3.2, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_scaled_y")
+    {
+        // Rotated 63.4 about z-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 0.64, 0.0, 0.0, 0.0, 0.0, 0.0);
+        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_arbitrary_transformation")
+    {
+        // Arbitrary transformations applied to the element
+        transform_element(mesh, X, -5.0, 7.8, -13.1, 2.7, 6.4, 20.0, 47.8, 
+                          -70.1, 5.7, -6.3);
+        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_arbitrary_with_displacements")
+    {
+        RealMatrixX X = RealMatrixX::Zero(3,4);
+        X << -3.2,  2.4, 1.5, -2.1, 
+             -1.0, -0.2, 1.4,  0.8, 
+              0.0,  0.0, 0.0,  0.0;
+        // Update the element with the new node Coordinates
+        for (int i=0; i<X.cols(); i++)
+        {
+            (*mesh.node_ptr(i)) = libMesh::Point(X(0,i), X(1,i), X(2,i));
+        }
+        
+        // Arbitrary transformations applied to the element
+        transform_element(mesh, X, 4.1, -6.3, 7.5, 4.2, 1.5, -18.0, -24.8, 
+                          30.1, -3.2, 5.4);
+        
+        // Calculate residual and jacobian at arbitrary displacement
+        RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
+        elem_sol << -0.04384355,  0.03969142, -0.09470648, -0.05011107, 
+                    -0.02989082, -0.01205296,  0.08846868,  0.04522207,  
+                     0.06435953, -0.07282706,  0.09307561, -0.06250143,  
+                     0.03332844, -0.00040089, -0.00423108, -0.07258241,  
+                     0.06636534, -0.08421098, -0.0705489 , -0.06004976,
+                     0.03873095, -0.09194373,  0.00055061,  0.046831;
+        elem->set_solution(elem_sol);
+        
+        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+}

--- a/tests/element/structural/2D/quad4/mast_quad4_linear_structural_extension_bending_coupling_internal_jacobian.cpp
+++ b/tests/element/structural/2D/quad4/mast_quad4_linear_structural_extension_bending_coupling_internal_jacobian.cpp
@@ -1,12 +1,25 @@
-#include "catch.hpp"
+/*
+ * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
+ * Copyright (C) 2013-2020  Manav Bhatia and MAST authors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
 
 // libMesh includes
 #include "libmesh/libmesh.h"
-#include "libmesh/replicated_mesh.h"
-#include "libmesh/point.h"
 #include "libmesh/elem.h"
-#include "libmesh/face_quad4.h"
-#include "libmesh/equation_systems.h"
 #include "libmesh/dof_map.h"
 
 // MAST includes
@@ -16,644 +29,332 @@
 #include "property_cards/solid_2d_section_element_property_card.h"
 #include "elasticity/structural_element_2d.h"
 #include "elasticity/structural_system_initialization.h"
-#include "base/physics_discipline_base.h"
 #include "base/nonlinear_implicit_assembly.h"
 #include "elasticity/structural_nonlinear_assembly.h"
 #include "base/nonlinear_system.h"
-#include "elasticity/structural_element_base.h"
 #include "mesh/geom_elem.h"
 
-// Custom includes
+// Test includes
+#include "catch.hpp"
 #include "test_helpers.h"
-
-#define pi 3.14159265358979323846
+#include "element/structural/2D/mast_structural_element_2d.h"
 
 extern libMesh::LibMeshInit* p_global_init;
+
 
 TEST_CASE("quad4_linear_extension_bending_coupling_structural", 
           "[quad],[quad4],[linear],[structural],[2D],[element]")
 {
-    const int n_elems = 1;
-    const int n_nodes = 4;
-    
-    // Point Coordinates
-    RealMatrixX temp = RealMatrixX::Zero(3,4);
-    temp << -1.0,  1.0, 1.0, -1.0, 
-            -1.0, -1.0, 1.0,  1.0, 
-             0.0,  0.0, 0.0,  0.0;
-    const RealMatrixX X = temp;
-    
-    /**
-     *  First create the mesh with the one element we are testing.
-     */
-    // Setup the mesh properties
-    libMesh::ReplicatedMesh mesh(p_global_init->comm());
-    mesh.set_mesh_dimension(2);
-    mesh.set_spatial_dimension(2);
-    mesh.reserve_elem(n_elems);
-    mesh.reserve_nodes(n_nodes);
-    
-    // Add nodes to the mesh
-    for (uint i=0; i<n_nodes; i++)
-    {
-        mesh.add_point(libMesh::Point(X(0,i), X(1,i), X(2,i)));
-    }
-    
-    // Add the element to the mesh
-    libMesh::Elem *reference_elem = new libMesh::Quad4;
-    reference_elem->set_id(0);    
-    reference_elem->subdomain_id() = 0;
-    reference_elem = mesh.add_elem(reference_elem);
-    for (int i=0; i<n_nodes; i++)
-    {
-        reference_elem->set_node(i) = mesh.node_ptr(i);
-    }
-    
-    // Prepare the mesh for use
-    mesh.prepare_for_use();
-    //mesh.print_info();
-    
-    const Real elem_volume = reference_elem->volume();
-    // Calculate true volume using 2D shoelace formula
-    Real true_volume = get_shoelace_area(X);
-    
-    // Ensure the libMesh element has the expected volume
-    REQUIRE( elem_volume == true_volume );
-            
-    /**
-     *  Setup the material and section properties to be used in the element
-     */
-    
-    // Define Material Properties as MAST Parameters
-    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
-    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
-    MAST::Parameter kappa("kappa_param", 5.0/6.0);    // Shear coefficient
-    
-    // Define Section Properties as MAST Parameters
-    MAST::Parameter thickness("th_param", 0.06);      // Section thickness
-    MAST::Parameter offset("off_param", 0.03);        // Section offset
-    
-    // Create field functions to dsitribute these constant parameters throughout the model
-    MAST::ConstantFieldFunction E_f("E", E);
-    MAST::ConstantFieldFunction nu_f("nu", nu);
-    MAST::ConstantFieldFunction kappa_f("kappa", kappa);
-    MAST::ConstantFieldFunction thickness_f("h", thickness);
-    MAST::ConstantFieldFunction offset_f("off", offset);
-    
-    // Initialize the material
-    MAST::IsotropicMaterialPropertyCard material;                   
-    
-    // Add the material property constant field functions to the material card
-    material.add(E_f);                                             
-    material.add(nu_f);
-    
-    // Initialize the section
-    MAST::Solid2DSectionElementPropertyCard section;
-    
-    // Add the section property constant field functions to the section card
-    section.add(thickness_f);
-    section.add(offset_f);
-    section.add(kappa_f);
-    
-    // Add the material card to the section card
-    section.set_material(material);
-    
-    
+    RealMatrixX coords = RealMatrixX::Zero(3,4);
+    coords << -1.0,  1.0, 1.0, -1.0,
+              -1.0, -1.0, 1.0,  1.0,
+               0.0,  0.0, 0.0,  0.0;
+    TEST::TestStructuralSingleElement2D test_elem(libMesh::QUAD4, coords);
+
+    const Real V0 = test_elem.reference_elem->volume();
+    REQUIRE(test_elem.reference_elem->volume() == TEST::get_shoelace_area(coords));
+
     // Set the strain type to linear for the section
-    section.set_strain(MAST::LINEAR_STRAIN);
-    
-    /**
-     *  Now we setup the structural system we will be solving.
-     */
-    libMesh::EquationSystems equation_systems(mesh);
-    
-    MAST::NonlinearSystem& system = equation_systems.add_system<MAST::NonlinearSystem>("structural");
-    
-    libMesh::FEType fetype(libMesh::FIRST, libMesh::LAGRANGE);
-    
-    MAST::StructuralSystemInitialization structural_system(system, 
-                                                           system.name(), 
-                                                           fetype);
-    
-    MAST::PhysicsDisciplineBase discipline(equation_systems);
-    
-    discipline.set_property_for_subdomain(0, section);
-    
-    equation_systems.init();
-    //equation_systems.print_info();
-    
-    MAST::NonlinearImplicitAssembly assembly;
-    assembly.set_discipline_and_system(discipline, structural_system);
-    
-    // Create the MAST element from the libMesh reference element
-    MAST::GeomElem geom_elem;
-    geom_elem.init(*reference_elem, structural_system);
-    std::unique_ptr<MAST::StructuralElementBase> elem_base = build_structural_element(structural_system, geom_elem, section);
-    
-    // Cast the base structural element as a 2D structural element
-    MAST::StructuralElement2D* elem = (dynamic_cast<MAST::StructuralElement2D*>(elem_base.get()));
-    
-    // Get element DOFs
-    const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
-    std::vector<libMesh::dof_id_type> dof_indices;
-    dof_map.dof_indices (reference_elem, dof_indices);
-    uint n_dofs = uint(dof_indices.size());
-    
-    // Set element's initial solution and solution sensitivity to zero
-    RealVectorX elem_solution = RealVectorX::Zero(n_dofs);
-    elem->set_solution(elem_solution);
-    elem->set_solution(elem_solution, true);
-    
-    const Real V0 = reference_elem->volume();
-    
-    /**
-     *  Below, we start building the Jacobian up for a very basic element that 
-     *  is already in an isoparametric format.  The following four steps:
-     *      Extension Only Stiffness
-     *      Extension & Bending Stiffness
-     *      Extension, Bending, & Transverse Shear Stiffness
-     *      Extension, Bending, & Extension-Bending Coupling Stiffness
-     *      Extension, Bending, Transverse Shear & Extension-Bending Coupling Stiffness
-     * 
-     *  Testing the Jacobian incrementally this way allows errors in the
-     *  Jacobian to be located more precisely.
-     * 
-     *  It would probabyl be even better to test each stiffness contribution 
-     *  separately, but currently, we don't have a way to disable extension
-     *  stiffness and transverse shear stiffness doesn't exist without bending 
-     *  and extension-bending coupling stiffness don't make sense without both
-     *  extension and/or bending. 
-     */
-    
+    test_elem.section.set_strain(MAST::LINEAR_STRAIN);
+
     // Set shear coefficient to zero to disable transverse shear stiffness
-    // FIXME: In MAST, when kappa=0.0, this results in zero rows/columns in element stiffness matrix
-    kappa = 0.0;
-    
-    // Calculate residual and jacobian
-    RealVectorX residual = RealVectorX::Zero(n_dofs);
-    RealMatrixX jacobian0 = RealMatrixX::Zero(n_dofs, n_dofs);
-    elem->internal_residual(true, residual, jacobian0);
-            
-    double val_margin = (jacobian0.array().abs()).mean() * 1.490116119384766e-08;
-    
-    
-    SECTION("internal_jacobian_finite_difference_check")                   
+    test_elem.kappa = 0.0;
+
+    // Update residual and Jacobian storage since we have modified baseline test element properties.
+    test_elem.update_residual_and_jacobian0();
+
+    double val_margin = (test_elem.jacobian0.array().abs()).mean() * 1.490116119384766e-08;
+
+
+    SECTION("Internal Jacobian (stiffness matrix) finite difference check")
     {
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem,
+                                                                   test_elem.elem_solution, test_elem.jacobian_fd);
+
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
     }
-    
-    SECTION("internal_jacobian_symmetry_check")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) should be symmetric")
     {
-        // Element stiffness matrix should be symmetric
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0.transpose());
-        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0.transpose())));
     }
-    
-    SECTION("internal_jacobian_determinant_check")
+
+
+    SECTION("Determinant of undeformed internal Jacobian (stiffness matrix) should be zero")
     {
-        // Determinant of undeformed element stiffness matrix should be zero
-        REQUIRE( jacobian0.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian0.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    
-    SECTION("internal_jacobian_displacement_invariant")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to displacement solution")
     {
-        // Calculate residual and jacobian at arbitrary displacement
-        RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
-        elem_sol << -0.04384355,  0.03969142, -0.09470648, -0.05011107, 
-                    -0.02989082, -0.01205296,  0.08846868,  0.04522207,  
-                     0.06435953, -0.07282706,  0.09307561, -0.06250143,  
-                     0.03332844, -0.00040089, -0.00423108, -0.07258241,  
+        RealVectorX elem_sol = RealVectorX::Zero(test_elem.n_dofs);
+        elem_sol << -0.04384355,  0.03969142, -0.09470648, -0.05011107,
+                    -0.02989082, -0.01205296,  0.08846868,  0.04522207,
+                     0.06435953, -0.07282706,  0.09307561, -0.06250143,
+                     0.03332844, -0.00040089, -0.00423108, -0.07258241,
                      0.06636534, -0.08421098, -0.0705489 , -0.06004976,
                      0.03873095, -0.09194373,  0.00055061,  0.046831;
-        elem->set_solution(elem_sol);
-        
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-                
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
+        test_elem.elem->set_solution(elem_sol);
+        test_elem.update_residual_and_jacobian();
 
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
     }
-    
-    SECTION("internal_jacobian_shifted_x_invariant")
-    {
-        // Shifted in x-direction
-        transform_element(mesh, X, 5.2, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-                
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
 
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
-    }
-    
-    SECTION("internal_jacobian_shifted_y_invariant")
+
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to element x-location")
     {
-        // Shifted in y-direction
-        transform_element(mesh, X, 0.0, -11.5, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
-        
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        TEST::transform_element(test_elem.mesh, coords,5.2, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
     }
-    
-    SECTION("internal_jacobian_rotated_about_z")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to element y-location")
+    {
+        TEST::transform_element(test_elem.mesh, coords, 0.0, -11.5, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
+    }
+
+
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to element z-location")
+    {
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 7.6,
+                                1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
+    }
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element rotated about z-axis")
     {
         // Rotated 63.4 about z-axis at element's centroid
-        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 63.4);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 63.4);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_rotated_about_y")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element rotated about y-axis")
     {
         // Rotated 35.8 about y-axis at element's centroid
-        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 35.8, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 35.8, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_rotated_about_x")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element rotated about x-axis")
     {
         // Rotated 15.8 about x-axis at element's centroid
-        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 15.8, 0.0, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 1.0, 15.8, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_sheared_in_x")
+
+
+    SECTION("\"Internal Jacobian (stiffness matrix) checks for element sheared in x-direction\"")
     {
-        // Rotated 63.4 about z-axis at element's centroid
-        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 6.7, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        // Shear element in x-direction.
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 0.0, 6.7, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_sheared_in_y")
+
+
+    SECTION("\"Internal Jacobian (stiffness matrix) checks for element sheared in y-direction\"")
     {
-        // Rotated 63.4 about z-axis at element's centroid
-        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, -11.2);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        // Shear element in x-direction.
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 0.0, 0.0, -11.2);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_scaled_x")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element stretched in x-direction")
     {
-        // Rotated 63.4 about z-axis at element's centroid
-        transform_element(mesh, X, 0.0, 0.0, 0.0, 3.2, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                3.2, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_scaled_y")
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element stretched in y-direction")
     {
-        // Rotated 63.4 about z-axis at element's centroid
-        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 0.64, 0.0, 0.0, 0.0, 0.0, 0.0);
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 0.64, 0.0, 0.0, 0.0, 0.0, 0.0);
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_arbitrary_transformation")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element arbitrarily scaled, stretched, rotated, and sheared")
     {
-        // Arbitrary transformations applied to the element
-        transform_element(mesh, X, -5.0, 7.8, -13.1, 2.7, 6.4, 20.0, 47.8, 
-                          -70.1, 5.7, -6.3);
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        // Apply arbitrary transformation to the element
+        TEST::transform_element(test_elem.mesh, coords, -5.0, 7.8, -13.1,
+                                2.7, 6.4, 20.0, 47.8, -70.1, 5.7, -6.3);
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_arbitrary_with_displacements")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element arbitrarily scaled, stretched, rotated, and displaced")
     {
-        RealMatrixX X = RealMatrixX::Zero(3,4);
-        X << -3.2,  2.4, 1.5, -2.1, 
-             -1.0, -0.2, 1.4,  0.8, 
-              0.0,  0.0, 0.0,  0.0;
-        // Update the element with the new node Coordinates
-        for (int i=0; i<X.cols(); i++)
-        {
-            (*mesh.node_ptr(i)) = libMesh::Point(X(0,i), X(1,i), X(2,i));
-        }
-        
-        // Arbitrary transformations applied to the element
-        transform_element(mesh, X, 4.1, -6.3, 7.5, 4.2, 1.5, -18.0, -24.8, 
-                          30.1, -3.2, 5.4);
-        
-        // Calculate residual and jacobian at arbitrary displacement
-        RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
-        elem_sol << -0.04384355,  0.03969142, -0.09470648, -0.05011107, 
-                    -0.02989082, -0.01205296,  0.08846868,  0.04522207,  
-                     0.06435953, -0.07282706,  0.09307561, -0.06250143,  
-                     0.03332844, -0.00040089, -0.00423108, -0.07258241,  
+        // Apply arbitrary transformation to the element
+        TEST::transform_element(test_elem.mesh, coords, 4.1, -6.3, 7.5, 4.2, 1.5, -18.0, -24.8,
+                                30.1, -3.2, 5.4);
+
+        // Apply arbitrary displacement to the element
+        RealVectorX elem_sol = RealVectorX::Zero(test_elem.n_dofs);
+        elem_sol << -0.04384355,  0.03969142, -0.09470648, -0.05011107,
+                    -0.02989082, -0.01205296,  0.08846868,  0.04522207,
+                     0.06435953, -0.07282706,  0.09307561, -0.06250143,
+                     0.03332844, -0.00040089, -0.00423108, -0.07258241,
                      0.06636534, -0.08421098, -0.0705489 , -0.06004976,
                      0.03873095, -0.09194373,  0.00055061,  0.046831;
-        elem->set_solution(elem_sol);
-        
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        test_elem.elem->set_solution(elem_sol);
+
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
 }

--- a/tests/element/structural/2D/quad4/mast_quad4_linear_structural_extension_bending_internal_jacobian.cpp
+++ b/tests/element/structural/2D/quad4/mast_quad4_linear_structural_extension_bending_internal_jacobian.cpp
@@ -1,0 +1,662 @@
+#include "catch.hpp"
+
+// libMesh includes
+#include "libmesh/libmesh.h"
+#include "libmesh/replicated_mesh.h"
+#include "libmesh/point.h"
+#include "libmesh/elem.h"
+#include "libmesh/face_quad4.h"
+#include "libmesh/equation_systems.h"
+#include "libmesh/dof_map.h"
+
+// MAST includes
+#include "base/parameter.h"
+#include "base/constant_field_function.h"
+#include "property_cards/isotropic_material_property_card.h"
+#include "property_cards/solid_2d_section_element_property_card.h"
+#include "elasticity/structural_element_2d.h"
+#include "elasticity/structural_system_initialization.h"
+#include "base/physics_discipline_base.h"
+#include "base/nonlinear_implicit_assembly.h"
+#include "elasticity/structural_nonlinear_assembly.h"
+#include "base/nonlinear_system.h"
+#include "elasticity/structural_element_base.h"
+#include "mesh/geom_elem.h"
+
+// Custom includes
+#include "test_helpers.h"
+
+#define pi 3.14159265358979323846
+
+extern libMesh::LibMeshInit* p_global_init;
+
+TEST_CASE("quad4_linear_extension_bending_structural", 
+          "[quad],[quad4],[linear],[structural],[2D],[element]")
+{
+    const int n_elems = 1;
+    const int n_nodes = 4;
+    
+    // Point Coordinates
+    RealMatrixX temp = RealMatrixX::Zero(3,4);
+    temp << -1.0,  1.0, 1.0, -1.0, 
+            -1.0, -1.0, 1.0,  1.0, 
+             0.0,  0.0, 0.0,  0.0;
+    const RealMatrixX X = temp;
+    
+    /**
+     *  First create the mesh with the one element we are testing.
+     */
+    // Setup the mesh properties
+    libMesh::ReplicatedMesh mesh(p_global_init->comm());
+    mesh.set_mesh_dimension(2);
+    mesh.set_spatial_dimension(2);
+    mesh.reserve_elem(n_elems);
+    mesh.reserve_nodes(n_nodes);
+    
+    // Add nodes to the mesh
+    for (uint i=0; i<n_nodes; i++)
+    {
+        mesh.add_point(libMesh::Point(X(0,i), X(1,i), X(2,i)));
+    }
+    
+    // Add the element to the mesh
+    libMesh::Elem *reference_elem = new libMesh::Quad4;
+    reference_elem->set_id(0);    
+    reference_elem->subdomain_id() = 0;
+    reference_elem = mesh.add_elem(reference_elem);
+    for (int i=0; i<n_nodes; i++)
+    {
+        reference_elem->set_node(i) = mesh.node_ptr(i);
+    }
+    
+    // Prepare the mesh for use
+    mesh.prepare_for_use();
+    //mesh.print_info();
+    
+    const Real elem_volume = reference_elem->volume();
+    // Calculate true volume using 2D shoelace formula
+    Real true_volume = get_shoelace_area(X);
+    
+    // Ensure the libMesh element has the expected volume
+    REQUIRE( elem_volume == true_volume );
+            
+    /**
+     *  Setup the material and section properties to be used in the element
+     */
+    
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
+    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
+    MAST::Parameter kappa("kappa_param", 5.0/6.0);    // Shear coefficient
+    
+    // Define Section Properties as MAST Parameters
+    MAST::Parameter thickness("th_param", 0.06);      // Section thickness
+    MAST::Parameter offset("off_param", 0.03);        // Section offset
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction E_f("E", E);
+    MAST::ConstantFieldFunction nu_f("nu", nu);
+    MAST::ConstantFieldFunction kappa_f("kappa", kappa);
+    MAST::ConstantFieldFunction thickness_f("h", thickness);
+    MAST::ConstantFieldFunction offset_f("off", offset);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(E_f);                                             
+    material.add(nu_f);
+    
+    // Initialize the section
+    MAST::Solid2DSectionElementPropertyCard section;
+    
+    // Add the section property constant field functions to the section card
+    section.add(thickness_f);
+    section.add(offset_f);
+    section.add(kappa_f);
+    
+    // Add the material card to the section card
+    section.set_material(material);
+    
+    
+    // Set the strain type to linear for the section
+    section.set_strain(MAST::LINEAR_STRAIN);
+    
+    /**
+     *  Now we setup the structural system we will be solving.
+     */
+    libMesh::EquationSystems equation_systems(mesh);
+    
+    MAST::NonlinearSystem& system = equation_systems.add_system<MAST::NonlinearSystem>("structural");
+    
+    libMesh::FEType fetype(libMesh::FIRST, libMesh::LAGRANGE);
+    
+    MAST::StructuralSystemInitialization structural_system(system, 
+                                                           system.name(), 
+                                                           fetype);
+    
+    MAST::PhysicsDisciplineBase discipline(equation_systems);
+    
+    discipline.set_property_for_subdomain(0, section);
+    
+    equation_systems.init();
+    //equation_systems.print_info();
+    
+    MAST::NonlinearImplicitAssembly assembly;
+    assembly.set_discipline_and_system(discipline, structural_system);
+    
+    // Create the MAST element from the libMesh reference element
+    MAST::GeomElem geom_elem;
+    geom_elem.init(*reference_elem, structural_system);
+    std::unique_ptr<MAST::StructuralElementBase> elem_base = build_structural_element(structural_system, geom_elem, section);
+    
+    // Cast the base structural element as a 2D structural element
+    MAST::StructuralElement2D* elem = (dynamic_cast<MAST::StructuralElement2D*>(elem_base.get()));
+    
+    // Get element DOFs
+    const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
+    std::vector<libMesh::dof_id_type> dof_indices;
+    dof_map.dof_indices (reference_elem, dof_indices);
+    uint n_dofs = uint(dof_indices.size());
+    
+    // Set element's initial solution and solution sensitivity to zero
+    RealVectorX elem_solution = RealVectorX::Zero(n_dofs);
+    elem->set_solution(elem_solution);
+    elem->set_solution(elem_solution, true);
+    
+    const Real V0 = reference_elem->volume();
+    
+    /**
+     *  Below, we start building the Jacobian up for a very basic element that 
+     *  is already in an isoparametric format.  The following four steps:
+     *      Extension Only Stiffness
+     *      Extension & Bending Stiffness
+     *      Extension, Bending, & Transverse Shear Stiffness
+     *      Extension, Bending, & Extension-Bending Coupling Stiffness
+     *      Extension, Bending, Transverse Shear & Extension-Bending Coupling Stiffness
+     * 
+     *  Testing the Jacobian incrementally this way allows errors in the
+     *  Jacobian to be located more precisely.
+     * 
+     *  It would probabyl be even better to test each stiffness contribution 
+     *  separately, but currently, we don't have a way to disable extension
+     *  stiffness and transverse shear stiffness doesn't exist without bending 
+     *  and extension-bending coupling stiffness don't make sense without both
+     *  extension and/or bending. 
+     */
+    
+    // Set shear coefficient to zero to disable transverse shear stiffness
+    // FIXME: In MAST, when kappa=0.0, this results in zero rows/columns in element stiffness matrix
+    kappa = 0.0;
+    
+    // Set the offset to zero to disable extension-bending coupling
+    offset = 0.0;
+    
+    // Calculate residual and jacobian
+    RealVectorX residual = RealVectorX::Zero(n_dofs);
+    RealMatrixX jacobian0 = RealMatrixX::Zero(n_dofs, n_dofs);
+    elem->internal_residual(true, residual, jacobian0);
+            
+    double val_margin = (jacobian0.array().abs()).mean() * 1.490116119384766e-08;
+    
+    
+    SECTION("internal_jacobian_finite_difference_check")                   
+    {
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+    }
+    
+    SECTION("internal_jacobian_symmetry_check")
+    {
+        // Element stiffness matrix should be symmetric
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0.transpose());
+        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    SECTION("internal_jacobian_determinant_check")
+    {
+        // Determinant of undeformed element stiffness matrix should be zero
+        REQUIRE( jacobian0.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    
+    SECTION("internal_jacobian_displacement_invariant")
+    {
+        // Calculate residual and jacobian at arbitrary displacement
+        RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
+        elem_sol << -0.04384355,  0.03969142, -0.09470648, -0.05011107, 
+                    -0.02989082, -0.01205296,  0.08846868,  0.04522207,  
+                     0.06435953, -0.07282706,  0.09307561, -0.06250143,  
+                     0.03332844, -0.00040089, -0.00423108, -0.07258241,  
+                     0.06636534, -0.08421098, -0.0705489 , -0.06004976,
+                     0.03873095, -0.09194373,  0.00055061,  0.046831;
+        elem->set_solution(elem_sol);
+        
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+                
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
+
+        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+    }
+    
+    SECTION("internal_jacobian_shifted_x_invariant")
+    {
+        // Shifted in x-direction
+        transform_element(mesh, X, 5.2, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+                
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
+
+        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+    }
+    
+    SECTION("internal_jacobian_shifted_y_invariant")
+    {
+        // Shifted in y-direction
+        transform_element(mesh, X, 0.0, -11.5, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
+        
+        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+    }
+    
+    SECTION("internal_jacobian_rotated_about_z")
+    {
+        // Rotated 63.4 about z-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 63.4);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_rotated_about_y")
+    {
+        // Rotated 35.8 about y-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 35.8, 0.0);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_rotated_about_x")
+    {
+        // Rotated 15.8 about x-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 15.8, 0.0, 0.0);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_sheared_in_x")
+    {
+        // Rotated 63.4 about z-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 6.7, 0.0);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_sheared_in_y")
+    {
+        // Rotated 63.4 about z-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, -11.2);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_scaled_x")
+    {
+        // Rotated 63.4 about z-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 3.2, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_scaled_y")
+    {
+        // Rotated 63.4 about z-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 0.64, 0.0, 0.0, 0.0, 0.0, 0.0);
+        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_arbitrary_transformation")
+    {
+        // Arbitrary transformations applied to the element
+        transform_element(mesh, X, -5.0, 7.8, -13.1, 2.7, 6.4, 20.0, 47.8, 
+                          -70.1, 5.7, -6.3);
+        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_arbitrary_with_displacements")
+    {
+        RealMatrixX X = RealMatrixX::Zero(3,4);
+        X << -3.2,  2.4, 1.5, -2.1, 
+             -1.0, -0.2, 1.4,  0.8, 
+              0.0,  0.0, 0.0,  0.0;
+        // Update the element with the new node Coordinates
+        for (int i=0; i<X.cols(); i++)
+        {
+            (*mesh.node_ptr(i)) = libMesh::Point(X(0,i), X(1,i), X(2,i));
+        }
+        
+        // Arbitrary transformations applied to the element
+        transform_element(mesh, X, 4.1, -6.3, 7.5, 4.2, 1.5, -18.0, -24.8, 
+                          30.1, -3.2, 5.4);
+        
+        // Calculate residual and jacobian at arbitrary displacement
+        RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
+        elem_sol << -0.04384355,  0.03969142, -0.09470648, -0.05011107, 
+                    -0.02989082, -0.01205296,  0.08846868,  0.04522207,  
+                     0.06435953, -0.07282706,  0.09307561, -0.06250143,  
+                     0.03332844, -0.00040089, -0.00423108, -0.07258241,  
+                     0.06636534, -0.08421098, -0.0705489 , -0.06004976,
+                     0.03873095, -0.09194373,  0.00055061,  0.046831;
+        elem->set_solution(elem_sol);
+        
+        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+}

--- a/tests/element/structural/2D/quad4/mast_quad4_linear_structural_extension_bending_shear_internal_jacobian.cpp
+++ b/tests/element/structural/2D/quad4/mast_quad4_linear_structural_extension_bending_shear_internal_jacobian.cpp
@@ -1,0 +1,659 @@
+#include "catch.hpp"
+
+// libMesh includes
+#include "libmesh/libmesh.h"
+#include "libmesh/replicated_mesh.h"
+#include "libmesh/point.h"
+#include "libmesh/elem.h"
+#include "libmesh/face_quad4.h"
+#include "libmesh/equation_systems.h"
+#include "libmesh/dof_map.h"
+
+// MAST includes
+#include "base/parameter.h"
+#include "base/constant_field_function.h"
+#include "property_cards/isotropic_material_property_card.h"
+#include "property_cards/solid_2d_section_element_property_card.h"
+#include "elasticity/structural_element_2d.h"
+#include "elasticity/structural_system_initialization.h"
+#include "base/physics_discipline_base.h"
+#include "base/nonlinear_implicit_assembly.h"
+#include "elasticity/structural_nonlinear_assembly.h"
+#include "base/nonlinear_system.h"
+#include "elasticity/structural_element_base.h"
+#include "mesh/geom_elem.h"
+
+// Custom includes
+#include "test_helpers.h"
+
+#define pi 3.14159265358979323846
+
+extern libMesh::LibMeshInit* p_global_init;
+
+TEST_CASE("quad4_linear_extension_bending_shear_structural", 
+          "[quad],[quad4],[linear],[structural],[2D]")
+{
+    const int n_elems = 1;
+    const int n_nodes = 4;
+    
+    // Point Coordinates
+    RealMatrixX temp = RealMatrixX::Zero(3,4);
+    temp << -1.0,  1.0, 1.0, -1.0, 
+            -1.0, -1.0, 1.0,  1.0, 
+             0.0,  0.0, 0.0,  0.0;
+    const RealMatrixX X = temp;
+    
+    /**
+     *  First create the mesh with the one element we are testing.
+     */
+    // Setup the mesh properties
+    libMesh::ReplicatedMesh mesh(p_global_init->comm());
+    mesh.set_mesh_dimension(2);
+    mesh.set_spatial_dimension(2);
+    mesh.reserve_elem(n_elems);
+    mesh.reserve_nodes(n_nodes);
+    
+    // Add nodes to the mesh
+    for (uint i=0; i<n_nodes; i++)
+    {
+        mesh.add_point(libMesh::Point(X(0,i), X(1,i), X(2,i)));
+    }
+    
+    // Add the element to the mesh
+    libMesh::Elem *reference_elem = new libMesh::Quad4;
+    reference_elem->set_id(0);    
+    reference_elem->subdomain_id() = 0;
+    reference_elem = mesh.add_elem(reference_elem);
+    for (int i=0; i<n_nodes; i++)
+    {
+        reference_elem->set_node(i) = mesh.node_ptr(i);
+    }
+    
+    // Prepare the mesh for use
+    mesh.prepare_for_use();
+    //mesh.print_info();
+    
+    const Real elem_volume = reference_elem->volume();
+    // Calculate true volume using 2D shoelace formula
+    Real true_volume = get_shoelace_area(X);
+    
+    // Ensure the libMesh element has the expected volume
+    REQUIRE( elem_volume == true_volume );
+            
+    /**
+     *  Setup the material and section properties to be used in the element
+     */
+    
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
+    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
+    MAST::Parameter kappa("kappa_param", 5.0/6.0);    // Shear coefficient
+    
+    // Define Section Properties as MAST Parameters
+    MAST::Parameter thickness("th_param", 0.06);      // Section thickness
+    MAST::Parameter offset("off_param", 0.03);        // Section offset
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction E_f("E", E);
+    MAST::ConstantFieldFunction nu_f("nu", nu);
+    MAST::ConstantFieldFunction kappa_f("kappa", kappa);
+    MAST::ConstantFieldFunction thickness_f("h", thickness);
+    MAST::ConstantFieldFunction offset_f("off", offset);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(E_f);                                             
+    material.add(nu_f);
+    
+    
+    // Initialize the section
+    MAST::Solid2DSectionElementPropertyCard section;
+    
+    // Add the section property constant field functions to the section card
+    section.add(thickness_f);
+    section.add(offset_f);
+    section.add(kappa_f);
+    
+    // Add the material card to the section card
+    section.set_material(material);
+    
+    
+    // Set the strain type to linear for the section
+    section.set_strain(MAST::LINEAR_STRAIN);
+    
+    /**
+     *  Now we setup the structural system we will be solving.
+     */
+    libMesh::EquationSystems equation_systems(mesh);
+    
+    MAST::NonlinearSystem& system = equation_systems.add_system<MAST::NonlinearSystem>("structural");
+    
+    libMesh::FEType fetype(libMesh::FIRST, libMesh::LAGRANGE);
+    
+    MAST::StructuralSystemInitialization structural_system(system, 
+                                                           system.name(), 
+                                                           fetype);
+    
+    MAST::PhysicsDisciplineBase discipline(equation_systems);
+    
+    discipline.set_property_for_subdomain(0, section);
+    
+    equation_systems.init();
+    //equation_systems.print_info();
+    
+    MAST::NonlinearImplicitAssembly assembly;
+    assembly.set_discipline_and_system(discipline, structural_system);
+    
+    // Create the MAST element from the libMesh reference element
+    MAST::GeomElem geom_elem;
+    geom_elem.init(*reference_elem, structural_system);
+    std::unique_ptr<MAST::StructuralElementBase> elem_base = build_structural_element(structural_system, geom_elem, section);
+    
+    // Cast the base structural element as a 2D structural element
+    MAST::StructuralElement2D* elem = (dynamic_cast<MAST::StructuralElement2D*>(elem_base.get()));
+    
+    // Get element DOFs
+    const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
+    std::vector<libMesh::dof_id_type> dof_indices;
+    dof_map.dof_indices (reference_elem, dof_indices);
+    uint n_dofs = uint(dof_indices.size());
+    
+    // Set element's initial solution and solution sensitivity to zero
+    RealVectorX elem_solution = RealVectorX::Zero(n_dofs);
+    elem->set_solution(elem_solution);
+    elem->set_solution(elem_solution, true);
+    
+    const Real V0 = reference_elem->volume();
+    
+    /**
+     *  Below, we start building the Jacobian up for a very basic element that 
+     *  is already in an isoparametric format.  The following four steps:
+     *      Extension Only Stiffness
+     *      Extension & Bending Stiffness
+     *      Extension, Bending, & Transverse Shear Stiffness
+     *      Extension, Bending, & Extension-Bending Coupling Stiffness
+     *      Extension, Bending, Transverse Shear & Extension-Bending Coupling Stiffness
+     * 
+     *  Testing the Jacobian incrementally this way allows errors in the
+     *  Jacobian to be located more precisely.
+     * 
+     *  It would probabyl be even better to test each stiffness contribution 
+     *  separately, but currently, we don't have a way to disable extension
+     *  stiffness and transverse shear stiffness doesn't exist without bending 
+     *  and extension-bending coupling stiffness don't make sense without both
+     *  extension and/or bending. 
+     */
+    
+    // Set the offset to zero to disable extension-bending coupling
+    offset = 0.0;
+    
+    // Calculate residual and jacobian
+    RealVectorX residual = RealVectorX::Zero(n_dofs);
+    RealMatrixX jacobian0 = RealMatrixX::Zero(n_dofs, n_dofs);
+    elem->internal_residual(true, residual, jacobian0);
+            
+    double val_margin = (jacobian0.array().abs()).mean() * 1.490116119384766e-08;
+    
+    
+    SECTION("internal_jacobian_finite_difference_check")                   
+    {
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+    }
+    
+    SECTION("internal_jacobian_symmetry_check")
+    {
+        // Element stiffness matrix should be symmetric
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0.transpose());
+        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    SECTION("internal_jacobian_determinant_check")
+    {
+        // Determinant of undeformed element stiffness matrix should be zero
+        REQUIRE( jacobian0.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    
+    SECTION("internal_jacobian_displacement_invariant")
+    {
+        // Calculate residual and jacobian at arbitrary displacement
+        RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
+        elem_sol << -0.04384355,  0.03969142, -0.09470648, -0.05011107, 
+                    -0.02989082, -0.01205296,  0.08846868,  0.04522207,  
+                     0.06435953, -0.07282706,  0.09307561, -0.06250143,  
+                     0.03332844, -0.00040089, -0.00423108, -0.07258241,  
+                     0.06636534, -0.08421098, -0.0705489 , -0.06004976,
+                     0.03873095, -0.09194373,  0.00055061,  0.046831;
+        elem->set_solution(elem_sol);
+        
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+                
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
+
+        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+    }
+    
+    SECTION("internal_jacobian_shifted_x_invariant")
+    {
+        // Shifted in x-direction
+        transform_element(mesh, X, 5.2, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+                
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
+
+        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+    }
+    
+    SECTION("internal_jacobian_shifted_y_invariant")
+    {
+        // Shifted in y-direction
+        transform_element(mesh, X, 0.0, -11.5, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
+        
+        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+    }
+    
+    SECTION("internal_jacobian_rotated_about_z")
+    {
+        // Rotated 63.4 about z-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 63.4);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_rotated_about_y")
+    {
+        // Rotated 35.8 about y-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 35.8, 0.0);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_rotated_about_x")
+    {
+        // Rotated 15.8 about x-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 15.8, 0.0, 0.0);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_sheared_in_x")
+    {
+        // Rotated 63.4 about z-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 6.7, 0.0);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_sheared_in_y")
+    {
+        // Rotated 63.4 about z-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, -11.2);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_scaled_x")
+    {
+        // Rotated 63.4 about z-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 3.2, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_scaled_y")
+    {
+        // Rotated 63.4 about z-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 0.64, 0.0, 0.0, 0.0, 0.0, 0.0);
+        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_arbitrary_transformation")
+    {
+        // Arbitrary transformations applied to the element
+        transform_element(mesh, X, -5.0, 7.8, -13.1, 2.7, 6.4, 20.0, 47.8, 
+                          -70.1, 5.7, -6.3);
+        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_arbitrary_with_displacements")
+    {
+        RealMatrixX X = RealMatrixX::Zero(3,4);
+        X << -3.2,  2.4, 1.5, -2.1, 
+             -1.0, -0.2, 1.4,  0.8, 
+              0.0,  0.0, 0.0,  0.0;
+        // Update the element with the new node Coordinates
+        for (int i=0; i<X.cols(); i++)
+        {
+            (*mesh.node_ptr(i)) = libMesh::Point(X(0,i), X(1,i), X(2,i));
+        }
+        
+        // Arbitrary transformations applied to the element
+        transform_element(mesh, X, 4.1, -6.3, 7.5, 4.2, 1.5, -18.0, -24.8, 
+                          30.1, -3.2, 5.4);
+        
+        // Calculate residual and jacobian at arbitrary displacement
+        RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
+        elem_sol << -0.04384355,  0.03969142, -0.09470648, -0.05011107, 
+                    -0.02989082, -0.01205296,  0.08846868,  0.04522207,  
+                     0.06435953, -0.07282706,  0.09307561, -0.06250143,  
+                     0.03332844, -0.00040089, -0.00423108, -0.07258241,  
+                     0.06636534, -0.08421098, -0.0705489 , -0.06004976,
+                     0.03873095, -0.09194373,  0.00055061,  0.046831;
+        elem->set_solution(elem_sol);
+        
+        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+}

--- a/tests/element/structural/2D/quad4/mast_quad4_linear_structural_extension_bending_shear_internal_jacobian.cpp
+++ b/tests/element/structural/2D/quad4/mast_quad4_linear_structural_extension_bending_shear_internal_jacobian.cpp
@@ -1,12 +1,25 @@
-#include "catch.hpp"
+/*
+ * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
+ * Copyright (C) 2013-2020  Manav Bhatia and MAST authors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
 
 // libMesh includes
 #include "libmesh/libmesh.h"
-#include "libmesh/replicated_mesh.h"
-#include "libmesh/point.h"
 #include "libmesh/elem.h"
-#include "libmesh/face_quad4.h"
-#include "libmesh/equation_systems.h"
 #include "libmesh/dof_map.h"
 
 // MAST includes
@@ -16,644 +29,332 @@
 #include "property_cards/solid_2d_section_element_property_card.h"
 #include "elasticity/structural_element_2d.h"
 #include "elasticity/structural_system_initialization.h"
-#include "base/physics_discipline_base.h"
 #include "base/nonlinear_implicit_assembly.h"
 #include "elasticity/structural_nonlinear_assembly.h"
 #include "base/nonlinear_system.h"
-#include "elasticity/structural_element_base.h"
 #include "mesh/geom_elem.h"
 
-// Custom includes
+// Test includes
+#include "catch.hpp"
 #include "test_helpers.h"
-
-#define pi 3.14159265358979323846
+#include "element/structural/2D/mast_structural_element_2d.h"
 
 extern libMesh::LibMeshInit* p_global_init;
+
 
 TEST_CASE("quad4_linear_extension_bending_shear_structural", 
           "[quad],[quad4],[linear],[structural],[2D]")
 {
-    const int n_elems = 1;
-    const int n_nodes = 4;
-    
-    // Point Coordinates
-    RealMatrixX temp = RealMatrixX::Zero(3,4);
-    temp << -1.0,  1.0, 1.0, -1.0, 
-            -1.0, -1.0, 1.0,  1.0, 
-             0.0,  0.0, 0.0,  0.0;
-    const RealMatrixX X = temp;
-    
-    /**
-     *  First create the mesh with the one element we are testing.
-     */
-    // Setup the mesh properties
-    libMesh::ReplicatedMesh mesh(p_global_init->comm());
-    mesh.set_mesh_dimension(2);
-    mesh.set_spatial_dimension(2);
-    mesh.reserve_elem(n_elems);
-    mesh.reserve_nodes(n_nodes);
-    
-    // Add nodes to the mesh
-    for (uint i=0; i<n_nodes; i++)
-    {
-        mesh.add_point(libMesh::Point(X(0,i), X(1,i), X(2,i)));
-    }
-    
-    // Add the element to the mesh
-    libMesh::Elem *reference_elem = new libMesh::Quad4;
-    reference_elem->set_id(0);    
-    reference_elem->subdomain_id() = 0;
-    reference_elem = mesh.add_elem(reference_elem);
-    for (int i=0; i<n_nodes; i++)
-    {
-        reference_elem->set_node(i) = mesh.node_ptr(i);
-    }
-    
-    // Prepare the mesh for use
-    mesh.prepare_for_use();
-    //mesh.print_info();
-    
-    const Real elem_volume = reference_elem->volume();
-    // Calculate true volume using 2D shoelace formula
-    Real true_volume = get_shoelace_area(X);
-    
-    // Ensure the libMesh element has the expected volume
-    REQUIRE( elem_volume == true_volume );
-            
-    /**
-     *  Setup the material and section properties to be used in the element
-     */
-    
-    // Define Material Properties as MAST Parameters
-    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
-    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
-    MAST::Parameter kappa("kappa_param", 5.0/6.0);    // Shear coefficient
-    
-    // Define Section Properties as MAST Parameters
-    MAST::Parameter thickness("th_param", 0.06);      // Section thickness
-    MAST::Parameter offset("off_param", 0.03);        // Section offset
-    
-    // Create field functions to dsitribute these constant parameters throughout the model
-    MAST::ConstantFieldFunction E_f("E", E);
-    MAST::ConstantFieldFunction nu_f("nu", nu);
-    MAST::ConstantFieldFunction kappa_f("kappa", kappa);
-    MAST::ConstantFieldFunction thickness_f("h", thickness);
-    MAST::ConstantFieldFunction offset_f("off", offset);
-    
-    // Initialize the material
-    MAST::IsotropicMaterialPropertyCard material;                   
-    
-    // Add the material property constant field functions to the material card
-    material.add(E_f);                                             
-    material.add(nu_f);
-    
-    
-    // Initialize the section
-    MAST::Solid2DSectionElementPropertyCard section;
-    
-    // Add the section property constant field functions to the section card
-    section.add(thickness_f);
-    section.add(offset_f);
-    section.add(kappa_f);
-    
-    // Add the material card to the section card
-    section.set_material(material);
-    
-    
+    RealMatrixX coords = RealMatrixX::Zero(3,4);
+    coords << -1.0,  1.0, 1.0, -1.0,
+              -1.0, -1.0, 1.0,  1.0,
+               0.0,  0.0, 0.0,  0.0;
+    TEST::TestStructuralSingleElement2D test_elem(libMesh::QUAD4, coords);
+
+    const Real V0 = test_elem.reference_elem->volume();
+    REQUIRE(test_elem.reference_elem->volume() == TEST::get_shoelace_area(coords));
+
     // Set the strain type to linear for the section
-    section.set_strain(MAST::LINEAR_STRAIN);
-    
-    /**
-     *  Now we setup the structural system we will be solving.
-     */
-    libMesh::EquationSystems equation_systems(mesh);
-    
-    MAST::NonlinearSystem& system = equation_systems.add_system<MAST::NonlinearSystem>("structural");
-    
-    libMesh::FEType fetype(libMesh::FIRST, libMesh::LAGRANGE);
-    
-    MAST::StructuralSystemInitialization structural_system(system, 
-                                                           system.name(), 
-                                                           fetype);
-    
-    MAST::PhysicsDisciplineBase discipline(equation_systems);
-    
-    discipline.set_property_for_subdomain(0, section);
-    
-    equation_systems.init();
-    //equation_systems.print_info();
-    
-    MAST::NonlinearImplicitAssembly assembly;
-    assembly.set_discipline_and_system(discipline, structural_system);
-    
-    // Create the MAST element from the libMesh reference element
-    MAST::GeomElem geom_elem;
-    geom_elem.init(*reference_elem, structural_system);
-    std::unique_ptr<MAST::StructuralElementBase> elem_base = build_structural_element(structural_system, geom_elem, section);
-    
-    // Cast the base structural element as a 2D structural element
-    MAST::StructuralElement2D* elem = (dynamic_cast<MAST::StructuralElement2D*>(elem_base.get()));
-    
-    // Get element DOFs
-    const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
-    std::vector<libMesh::dof_id_type> dof_indices;
-    dof_map.dof_indices (reference_elem, dof_indices);
-    uint n_dofs = uint(dof_indices.size());
-    
-    // Set element's initial solution and solution sensitivity to zero
-    RealVectorX elem_solution = RealVectorX::Zero(n_dofs);
-    elem->set_solution(elem_solution);
-    elem->set_solution(elem_solution, true);
-    
-    const Real V0 = reference_elem->volume();
-    
-    /**
-     *  Below, we start building the Jacobian up for a very basic element that 
-     *  is already in an isoparametric format.  The following four steps:
-     *      Extension Only Stiffness
-     *      Extension & Bending Stiffness
-     *      Extension, Bending, & Transverse Shear Stiffness
-     *      Extension, Bending, & Extension-Bending Coupling Stiffness
-     *      Extension, Bending, Transverse Shear & Extension-Bending Coupling Stiffness
-     * 
-     *  Testing the Jacobian incrementally this way allows errors in the
-     *  Jacobian to be located more precisely.
-     * 
-     *  It would probabyl be even better to test each stiffness contribution 
-     *  separately, but currently, we don't have a way to disable extension
-     *  stiffness and transverse shear stiffness doesn't exist without bending 
-     *  and extension-bending coupling stiffness don't make sense without both
-     *  extension and/or bending. 
-     */
-    
+    test_elem.section.set_strain(MAST::LINEAR_STRAIN);
+
     // Set the offset to zero to disable extension-bending coupling
-    offset = 0.0;
-    
-    // Calculate residual and jacobian
-    RealVectorX residual = RealVectorX::Zero(n_dofs);
-    RealMatrixX jacobian0 = RealMatrixX::Zero(n_dofs, n_dofs);
-    elem->internal_residual(true, residual, jacobian0);
-            
-    double val_margin = (jacobian0.array().abs()).mean() * 1.490116119384766e-08;
-    
-    
-    SECTION("internal_jacobian_finite_difference_check")                   
+    test_elem.offset = 0.0;
+
+    // Update residual and Jacobian storage since we have modified baseline test element properties.
+    test_elem.update_residual_and_jacobian0();
+
+    double val_margin = (test_elem.jacobian0.array().abs()).mean() * 1.490116119384766e-08;
+
+
+    SECTION("Internal Jacobian (stiffness matrix) finite difference check")
     {
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem,
+                                                                   test_elem.elem_solution, test_elem.jacobian_fd);
+
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
     }
-    
-    SECTION("internal_jacobian_symmetry_check")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) should be symmetric")
     {
-        // Element stiffness matrix should be symmetric
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0.transpose());
-        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0.transpose())));
     }
-    
-    SECTION("internal_jacobian_determinant_check")
+
+
+    SECTION("Determinant of undeformed internal Jacobian (stiffness matrix) should be zero")
     {
-        // Determinant of undeformed element stiffness matrix should be zero
-        REQUIRE( jacobian0.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian0.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    
-    SECTION("internal_jacobian_displacement_invariant")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to displacement solution")
     {
-        // Calculate residual and jacobian at arbitrary displacement
-        RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
-        elem_sol << -0.04384355,  0.03969142, -0.09470648, -0.05011107, 
-                    -0.02989082, -0.01205296,  0.08846868,  0.04522207,  
-                     0.06435953, -0.07282706,  0.09307561, -0.06250143,  
-                     0.03332844, -0.00040089, -0.00423108, -0.07258241,  
+        RealVectorX elem_sol = RealVectorX::Zero(test_elem.n_dofs);
+        elem_sol << -0.04384355,  0.03969142, -0.09470648, -0.05011107,
+                    -0.02989082, -0.01205296,  0.08846868,  0.04522207,
+                     0.06435953, -0.07282706,  0.09307561, -0.06250143,
+                     0.03332844, -0.00040089, -0.00423108, -0.07258241,
                      0.06636534, -0.08421098, -0.0705489 , -0.06004976,
                      0.03873095, -0.09194373,  0.00055061,  0.046831;
-        elem->set_solution(elem_sol);
-        
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-                
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
+        test_elem.elem->set_solution(elem_sol);
+        test_elem.update_residual_and_jacobian();
 
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
     }
-    
-    SECTION("internal_jacobian_shifted_x_invariant")
-    {
-        // Shifted in x-direction
-        transform_element(mesh, X, 5.2, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-                
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
 
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
-    }
-    
-    SECTION("internal_jacobian_shifted_y_invariant")
+
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to element x-location")
     {
-        // Shifted in y-direction
-        transform_element(mesh, X, 0.0, -11.5, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
-        
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        TEST::transform_element(test_elem.mesh, coords,5.2, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
     }
-    
-    SECTION("internal_jacobian_rotated_about_z")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to element y-location")
+    {
+        TEST::transform_element(test_elem.mesh, coords, 0.0, -11.5, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
+    }
+
+
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to element z-location")
+    {
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 7.6,
+                                1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
+    }
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element rotated about z-axis")
     {
         // Rotated 63.4 about z-axis at element's centroid
-        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 63.4);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 63.4);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_rotated_about_y")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element rotated about y-axis")
     {
         // Rotated 35.8 about y-axis at element's centroid
-        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 35.8, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 35.8, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_rotated_about_x")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element rotated about x-axis")
     {
         // Rotated 15.8 about x-axis at element's centroid
-        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 15.8, 0.0, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 1.0, 15.8, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_sheared_in_x")
+
+
+    SECTION("\"Internal Jacobian (stiffness matrix) checks for element sheared in x-direction\"")
     {
-        // Rotated 63.4 about z-axis at element's centroid
-        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 6.7, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        // Shear element in x-direction.
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 0.0, 6.7, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_sheared_in_y")
+
+
+    SECTION("\"Internal Jacobian (stiffness matrix) checks for element sheared in y-direction\"")
     {
-        // Rotated 63.4 about z-axis at element's centroid
-        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, -11.2);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        // Shear element in x-direction.
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 0.0, 0.0, -11.2);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_scaled_x")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element stretched in x-direction")
     {
-        // Rotated 63.4 about z-axis at element's centroid
-        transform_element(mesh, X, 0.0, 0.0, 0.0, 3.2, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                3.2, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_scaled_y")
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element stretched in y-direction")
     {
-        // Rotated 63.4 about z-axis at element's centroid
-        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 0.64, 0.0, 0.0, 0.0, 0.0, 0.0);
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 0.64, 0.0, 0.0, 0.0, 0.0, 0.0);
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_arbitrary_transformation")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element arbitrarily scaled, stretched, rotated, and sheared")
     {
-        // Arbitrary transformations applied to the element
-        transform_element(mesh, X, -5.0, 7.8, -13.1, 2.7, 6.4, 20.0, 47.8, 
-                          -70.1, 5.7, -6.3);
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        // Apply arbitrary transformation to the element
+        TEST::transform_element(test_elem.mesh, coords, -5.0, 7.8, -13.1,
+                                2.7, 6.4, 20.0, 47.8, -70.1, 5.7, -6.3);
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_arbitrary_with_displacements")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element arbitrarily scaled, stretched, rotated, and displaced")
     {
-        RealMatrixX X = RealMatrixX::Zero(3,4);
-        X << -3.2,  2.4, 1.5, -2.1, 
-             -1.0, -0.2, 1.4,  0.8, 
-              0.0,  0.0, 0.0,  0.0;
-        // Update the element with the new node Coordinates
-        for (int i=0; i<X.cols(); i++)
-        {
-            (*mesh.node_ptr(i)) = libMesh::Point(X(0,i), X(1,i), X(2,i));
-        }
-        
-        // Arbitrary transformations applied to the element
-        transform_element(mesh, X, 4.1, -6.3, 7.5, 4.2, 1.5, -18.0, -24.8, 
-                          30.1, -3.2, 5.4);
-        
-        // Calculate residual and jacobian at arbitrary displacement
-        RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
-        elem_sol << -0.04384355,  0.03969142, -0.09470648, -0.05011107, 
-                    -0.02989082, -0.01205296,  0.08846868,  0.04522207,  
-                     0.06435953, -0.07282706,  0.09307561, -0.06250143,  
-                     0.03332844, -0.00040089, -0.00423108, -0.07258241,  
+        // Apply arbitrary transformation to the element
+        TEST::transform_element(test_elem.mesh, coords, 4.1, -6.3, 7.5, 4.2, 1.5, -18.0, -24.8,
+                                30.1, -3.2, 5.4);
+
+        // Apply arbitrary displacement to the element
+        RealVectorX elem_sol = RealVectorX::Zero(test_elem.n_dofs);
+        elem_sol << -0.04384355,  0.03969142, -0.09470648, -0.05011107,
+                    -0.02989082, -0.01205296,  0.08846868,  0.04522207,
+                     0.06435953, -0.07282706,  0.09307561, -0.06250143,
+                     0.03332844, -0.00040089, -0.00423108, -0.07258241,
                      0.06636534, -0.08421098, -0.0705489 , -0.06004976,
                      0.03873095, -0.09194373,  0.00055061,  0.046831;
-        elem->set_solution(elem_sol);
-        
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        test_elem.elem->set_solution(elem_sol);
+
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
 }

--- a/tests/element/structural/2D/quad4/mast_quad4_linear_structural_extension_internal_jacobian.cpp
+++ b/tests/element/structural/2D/quad4/mast_quad4_linear_structural_extension_internal_jacobian.cpp
@@ -1,0 +1,666 @@
+#include "catch.hpp"
+
+// libMesh includes
+#include "libmesh/libmesh.h"
+#include "libmesh/replicated_mesh.h"
+#include "libmesh/point.h"
+#include "libmesh/elem.h"
+#include "libmesh/face_quad4.h"
+#include "libmesh/equation_systems.h"
+#include "libmesh/dof_map.h"
+
+// MAST includes
+#include "base/parameter.h"
+#include "base/constant_field_function.h"
+#include "property_cards/isotropic_material_property_card.h"
+#include "property_cards/solid_2d_section_element_property_card.h"
+#include "elasticity/structural_element_2d.h"
+#include "elasticity/structural_system_initialization.h"
+#include "base/physics_discipline_base.h"
+#include "base/nonlinear_implicit_assembly.h"
+#include "elasticity/structural_nonlinear_assembly.h"
+#include "base/nonlinear_system.h"
+#include "elasticity/structural_element_base.h"
+#include "mesh/geom_elem.h"
+
+// Custom includes
+#include "test_helpers.h"
+
+#define pi 3.14159265358979323846
+
+extern libMesh::LibMeshInit* p_global_init;
+
+TEST_CASE("quad4_linear_extension_structural", 
+          "[quad],[quad4],[linear],[structural],[2D]")
+{
+    const int n_elems = 1;
+    const int n_nodes = 4;
+    
+    // Point Coordinates
+    RealMatrixX temp = RealMatrixX::Zero(3,4);
+    temp << -1.0,  1.0, 1.0, -1.0, 
+            -1.0, -1.0, 1.0,  1.0, 
+             0.0,  0.0, 0.0,  0.0;
+    const RealMatrixX X = temp;
+    
+    /**
+     *  First create the mesh with the one element we are testing.
+     */
+    // Setup the mesh properties
+    libMesh::ReplicatedMesh mesh(p_global_init->comm());
+    mesh.set_mesh_dimension(2);
+    mesh.set_spatial_dimension(2);
+    mesh.reserve_elem(n_elems);
+    mesh.reserve_nodes(n_nodes);
+    
+    // Add nodes to the mesh
+    for (uint i=0; i<n_nodes; i++)
+    {
+        mesh.add_point(libMesh::Point(X(0,i), X(1,i), X(2,i)));
+    }
+    
+    // Add the element to the mesh
+    libMesh::Elem *reference_elem = new libMesh::Quad4;
+    reference_elem->set_id(0);    
+    reference_elem->subdomain_id() = 0;
+    reference_elem = mesh.add_elem(reference_elem);
+    for (int i=0; i<n_nodes; i++)
+    {
+        reference_elem->set_node(i) = mesh.node_ptr(i);
+    }
+    
+    // Prepare the mesh for use
+    mesh.prepare_for_use();
+    //mesh.print_info();
+    
+    const Real elem_volume = reference_elem->volume();
+    // Calculate true volume using 2D shoelace formula
+    Real true_volume = get_shoelace_area(X);
+    
+    // Ensure the libMesh element has the expected volume
+    REQUIRE( elem_volume == true_volume );
+            
+    /**
+     *  Setup the material and section properties to be used in the element
+     */
+    
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
+    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
+    MAST::Parameter kappa("kappa_param", 5.0/6.0);    // Shear coefficient
+    
+    // Define Section Properties as MAST Parameters
+    MAST::Parameter thickness("th_param", 0.06);      // Section thickness
+    MAST::Parameter offset("off_param", 0.03);        // Section offset
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction E_f("E", E);
+    MAST::ConstantFieldFunction nu_f("nu", nu);
+    MAST::ConstantFieldFunction kappa_f("kappa", kappa);
+    MAST::ConstantFieldFunction thickness_f("h", thickness);
+    MAST::ConstantFieldFunction offset_f("off", offset);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(E_f);                                             
+    material.add(nu_f);
+    
+    // Initialize the section
+    MAST::Solid2DSectionElementPropertyCard section;
+    
+    // Add the section property constant field functions to the section card
+    section.add(thickness_f);
+    section.add(offset_f);
+    section.add(kappa_f);
+    
+    // Add the material card to the section card
+    section.set_material(material);
+    
+    
+    // Set the strain type to linear for the section
+    section.set_strain(MAST::LINEAR_STRAIN);
+    
+    /**
+     *  Now we setup the structural system we will be solving.
+     */
+    libMesh::EquationSystems equation_systems(mesh);
+    
+    MAST::NonlinearSystem& system = equation_systems.add_system<MAST::NonlinearSystem>("structural");
+    
+    libMesh::FEType fetype(libMesh::FIRST, libMesh::LAGRANGE);
+    
+    MAST::StructuralSystemInitialization structural_system(system, 
+                                                           system.name(), 
+                                                           fetype);
+    
+    MAST::PhysicsDisciplineBase discipline(equation_systems);
+    
+    discipline.set_property_for_subdomain(0, section);
+    
+    equation_systems.init();
+    //equation_systems.print_info();
+    
+    MAST::NonlinearImplicitAssembly assembly;
+    assembly.set_discipline_and_system(discipline, structural_system);
+    
+    // Create the MAST element from the libMesh reference element
+    MAST::GeomElem geom_elem;
+    geom_elem.init(*reference_elem, structural_system);
+    std::unique_ptr<MAST::StructuralElementBase> elem_base = build_structural_element(structural_system, geom_elem, section);
+    
+    // Cast the base structural element as a 2D structural element
+    MAST::StructuralElement2D* elem = (dynamic_cast<MAST::StructuralElement2D*>(elem_base.get()));
+    
+    // Get element DOFs
+    const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
+    std::vector<libMesh::dof_id_type> dof_indices;
+    dof_map.dof_indices (reference_elem, dof_indices);
+    uint n_dofs = uint(dof_indices.size());
+    
+    // Set element's initial solution and solution sensitivity to zero
+    RealVectorX elem_solution = RealVectorX::Zero(n_dofs);
+    elem->set_solution(elem_solution);
+    elem->set_solution(elem_solution, true);
+    
+    const Real V0 = reference_elem->volume();
+    
+    /**
+     *  Below, we start building the Jacobian up for a very basic element that 
+     *  is already in an isoparametric format.  The following four steps:
+     *      Extension Only Stiffness
+     *      Extension & Bending Stiffness
+     *      Extension, Bending, & Transverse Shear Stiffness
+     *      Extension, Bending, & Extension-Bending Coupling Stiffness
+     *      Extension, Bending, Transverse Shear & Extension-Bending Coupling Stiffness
+     * 
+     *  Testing the Jacobian incrementally this way allows errors in the
+     *  Jacobian to be located more precisely.
+     * 
+     *  It would probabyl be even better to test each stiffness contribution 
+     *  separately, but currently, we don't have a way to disable extension
+     *  stiffness and transverse shear stiffness doesn't exist without bending 
+     *  and extension-bending coupling stiffness don't make sense without both
+     *  extension and/or bending. 
+     */
+    
+    // Set shear coefficient to zero to disable transverse shear stiffness
+    // FIXME: In MAST, when kappa=0.0, this results in zero rows/columns in element stiffness matrix
+    kappa = 0.0;
+    
+    // Set the offset to zero to disable extension-bending coupling
+    offset = 0.0;
+    
+    // Set the bending operator to no_bending to disable bending stiffness
+    // NOTE: This also disables the transverse shear stiffness
+    section.set_bending_model(MAST::NO_BENDING);
+    
+    // Calculate residual and jacobian
+    RealVectorX residual = RealVectorX::Zero(n_dofs);
+    RealMatrixX jacobian0 = RealMatrixX::Zero(n_dofs, n_dofs);
+    elem->internal_residual(true, residual, jacobian0);
+            
+    double val_margin = (jacobian0.array().abs()).mean() * 1.490116119384766e-08;
+    
+    
+    SECTION("internal_jacobian_finite_difference_check")                   
+    {
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+    }
+    
+    SECTION("internal_jacobian_symmetry_check")
+    {
+        // Element stiffness matrix should be symmetric
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0.transpose());
+        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    SECTION("internal_jacobian_determinant_check")
+    {
+        // Determinant of undeformed element stiffness matrix should be zero
+        REQUIRE( jacobian0.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    
+    SECTION("internal_jacobian_displacement_invariant")
+    {
+        // Calculate residual and jacobian at arbitrary displacement
+        RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
+        elem_sol << -0.04384355,  0.03969142, -0.09470648, -0.05011107, 
+                    -0.02989082, -0.01205296,  0.08846868,  0.04522207,  
+                     0.06435953, -0.07282706,  0.09307561, -0.06250143,  
+                     0.03332844, -0.00040089, -0.00423108, -0.07258241,  
+                     0.06636534, -0.08421098, -0.0705489 , -0.06004976,
+                     0.03873095, -0.09194373,  0.00055061,  0.046831;
+        elem->set_solution(elem_sol);
+        
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+                
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
+
+        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+    }
+    
+    SECTION("internal_jacobian_shifted_x_invariant")
+    {
+        // Shifted in x-direction
+        transform_element(mesh, X, 5.2, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+                
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
+
+        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+    }
+    
+    SECTION("internal_jacobian_shifted_y_invariant")
+    {
+        // Shifted in y-direction
+        transform_element(mesh, X, 0.0, -11.5, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
+        
+        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+    }
+    
+    SECTION("internal_jacobian_rotated_about_z")
+    {
+        // Rotated 63.4 about z-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 63.4);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_rotated_about_y")
+    {
+        // Rotated 35.8 about y-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 35.8, 0.0);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_rotated_about_x")
+    {
+        // Rotated 15.8 about x-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 15.8, 0.0, 0.0);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_sheared_in_x")
+    {
+        // Rotated 63.4 about z-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 6.7, 0.0);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_sheared_in_y")
+    {
+        // Rotated 63.4 about z-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, -11.2);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_scaled_x")
+    {
+        // Rotated 63.4 about z-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 3.2, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_scaled_y")
+    {
+        // Rotated 63.4 about z-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 0.64, 0.0, 0.0, 0.0, 0.0, 0.0);
+        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_arbitrary_transformation")
+    {
+        // Arbitrary transformations applied to the element
+        transform_element(mesh, X, -5.0, 7.8, -13.1, 2.7, 6.4, 20.0, 47.8, 
+                          -70.1, 5.7, -6.3);
+        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_arbitrary_with_displacements")
+    {
+        RealMatrixX X = RealMatrixX::Zero(3,4);
+        X << -3.2,  2.4, 1.5, -2.1, 
+             -1.0, -0.2, 1.4,  0.8, 
+              0.0,  0.0, 0.0,  0.0;
+        // Update the element with the new node Coordinates
+        for (int i=0; i<X.cols(); i++)
+        {
+            (*mesh.node_ptr(i)) = libMesh::Point(X(0,i), X(1,i), X(2,i));
+        }
+        
+        // Arbitrary transformations applied to the element
+        transform_element(mesh, X, 4.1, -6.3, 7.5, 4.2, 1.5, -18.0, -24.8, 
+                          30.1, -3.2, 5.4);
+        
+        // Calculate residual and jacobian at arbitrary displacement
+        RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
+        elem_sol << -0.04384355,  0.03969142, -0.09470648, -0.05011107, 
+                    -0.02989082, -0.01205296,  0.08846868,  0.04522207,  
+                     0.06435953, -0.07282706,  0.09307561, -0.06250143,  
+                     0.03332844, -0.00040089, -0.00423108, -0.07258241,  
+                     0.06636534, -0.08421098, -0.0705489 , -0.06004976,
+                     0.03873095, -0.09194373,  0.00055061,  0.046831;
+        elem->set_solution(elem_sol);
+        
+        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+}

--- a/tests/element/structural/2D/quad4/mast_quad4_linear_structural_extension_internal_jacobian.cpp
+++ b/tests/element/structural/2D/quad4/mast_quad4_linear_structural_extension_internal_jacobian.cpp
@@ -1,12 +1,25 @@
-#include "catch.hpp"
+/*
+ * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
+ * Copyright (C) 2013-2020  Manav Bhatia and MAST authors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
 
 // libMesh includes
 #include "libmesh/libmesh.h"
-#include "libmesh/replicated_mesh.h"
-#include "libmesh/point.h"
 #include "libmesh/elem.h"
-#include "libmesh/face_quad4.h"
-#include "libmesh/equation_systems.h"
 #include "libmesh/dof_map.h"
 
 // MAST includes
@@ -16,651 +29,339 @@
 #include "property_cards/solid_2d_section_element_property_card.h"
 #include "elasticity/structural_element_2d.h"
 #include "elasticity/structural_system_initialization.h"
-#include "base/physics_discipline_base.h"
 #include "base/nonlinear_implicit_assembly.h"
 #include "elasticity/structural_nonlinear_assembly.h"
 #include "base/nonlinear_system.h"
-#include "elasticity/structural_element_base.h"
 #include "mesh/geom_elem.h"
 
-// Custom includes
+// Test includes
+#include "catch.hpp"
 #include "test_helpers.h"
-
-#define pi 3.14159265358979323846
+#include "element/structural/2D/mast_structural_element_2d.h"
 
 extern libMesh::LibMeshInit* p_global_init;
+
 
 TEST_CASE("quad4_linear_extension_structural", 
           "[quad],[quad4],[linear],[structural],[2D]")
 {
-    const int n_elems = 1;
-    const int n_nodes = 4;
-    
-    // Point Coordinates
-    RealMatrixX temp = RealMatrixX::Zero(3,4);
-    temp << -1.0,  1.0, 1.0, -1.0, 
-            -1.0, -1.0, 1.0,  1.0, 
-             0.0,  0.0, 0.0,  0.0;
-    const RealMatrixX X = temp;
-    
-    /**
-     *  First create the mesh with the one element we are testing.
-     */
-    // Setup the mesh properties
-    libMesh::ReplicatedMesh mesh(p_global_init->comm());
-    mesh.set_mesh_dimension(2);
-    mesh.set_spatial_dimension(2);
-    mesh.reserve_elem(n_elems);
-    mesh.reserve_nodes(n_nodes);
-    
-    // Add nodes to the mesh
-    for (uint i=0; i<n_nodes; i++)
-    {
-        mesh.add_point(libMesh::Point(X(0,i), X(1,i), X(2,i)));
-    }
-    
-    // Add the element to the mesh
-    libMesh::Elem *reference_elem = new libMesh::Quad4;
-    reference_elem->set_id(0);    
-    reference_elem->subdomain_id() = 0;
-    reference_elem = mesh.add_elem(reference_elem);
-    for (int i=0; i<n_nodes; i++)
-    {
-        reference_elem->set_node(i) = mesh.node_ptr(i);
-    }
-    
-    // Prepare the mesh for use
-    mesh.prepare_for_use();
-    //mesh.print_info();
-    
-    const Real elem_volume = reference_elem->volume();
-    // Calculate true volume using 2D shoelace formula
-    Real true_volume = get_shoelace_area(X);
-    
-    // Ensure the libMesh element has the expected volume
-    REQUIRE( elem_volume == true_volume );
-            
-    /**
-     *  Setup the material and section properties to be used in the element
-     */
-    
-    // Define Material Properties as MAST Parameters
-    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
-    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
-    MAST::Parameter kappa("kappa_param", 5.0/6.0);    // Shear coefficient
-    
-    // Define Section Properties as MAST Parameters
-    MAST::Parameter thickness("th_param", 0.06);      // Section thickness
-    MAST::Parameter offset("off_param", 0.03);        // Section offset
-    
-    // Create field functions to dsitribute these constant parameters throughout the model
-    MAST::ConstantFieldFunction E_f("E", E);
-    MAST::ConstantFieldFunction nu_f("nu", nu);
-    MAST::ConstantFieldFunction kappa_f("kappa", kappa);
-    MAST::ConstantFieldFunction thickness_f("h", thickness);
-    MAST::ConstantFieldFunction offset_f("off", offset);
-    
-    // Initialize the material
-    MAST::IsotropicMaterialPropertyCard material;                   
-    
-    // Add the material property constant field functions to the material card
-    material.add(E_f);                                             
-    material.add(nu_f);
-    
-    // Initialize the section
-    MAST::Solid2DSectionElementPropertyCard section;
-    
-    // Add the section property constant field functions to the section card
-    section.add(thickness_f);
-    section.add(offset_f);
-    section.add(kappa_f);
-    
-    // Add the material card to the section card
-    section.set_material(material);
-    
-    
+    RealMatrixX coords = RealMatrixX::Zero(3,4);
+    coords << -1.0,  1.0, 1.0, -1.0, 
+              -1.0, -1.0, 1.0,  1.0,
+               0.0,  0.0, 0.0,  0.0;
+    TEST::TestStructuralSingleElement2D test_elem(libMesh::QUAD4, coords);
+
+    const Real V0 = test_elem.reference_elem->volume();
+    REQUIRE(test_elem.reference_elem->volume() == TEST::get_shoelace_area(coords));
+
     // Set the strain type to linear for the section
-    section.set_strain(MAST::LINEAR_STRAIN);
-    
-    /**
-     *  Now we setup the structural system we will be solving.
-     */
-    libMesh::EquationSystems equation_systems(mesh);
-    
-    MAST::NonlinearSystem& system = equation_systems.add_system<MAST::NonlinearSystem>("structural");
-    
-    libMesh::FEType fetype(libMesh::FIRST, libMesh::LAGRANGE);
-    
-    MAST::StructuralSystemInitialization structural_system(system, 
-                                                           system.name(), 
-                                                           fetype);
-    
-    MAST::PhysicsDisciplineBase discipline(equation_systems);
-    
-    discipline.set_property_for_subdomain(0, section);
-    
-    equation_systems.init();
-    //equation_systems.print_info();
-    
-    MAST::NonlinearImplicitAssembly assembly;
-    assembly.set_discipline_and_system(discipline, structural_system);
-    
-    // Create the MAST element from the libMesh reference element
-    MAST::GeomElem geom_elem;
-    geom_elem.init(*reference_elem, structural_system);
-    std::unique_ptr<MAST::StructuralElementBase> elem_base = build_structural_element(structural_system, geom_elem, section);
-    
-    // Cast the base structural element as a 2D structural element
-    MAST::StructuralElement2D* elem = (dynamic_cast<MAST::StructuralElement2D*>(elem_base.get()));
-    
-    // Get element DOFs
-    const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
-    std::vector<libMesh::dof_id_type> dof_indices;
-    dof_map.dof_indices (reference_elem, dof_indices);
-    uint n_dofs = uint(dof_indices.size());
-    
-    // Set element's initial solution and solution sensitivity to zero
-    RealVectorX elem_solution = RealVectorX::Zero(n_dofs);
-    elem->set_solution(elem_solution);
-    elem->set_solution(elem_solution, true);
-    
-    const Real V0 = reference_elem->volume();
-    
-    /**
-     *  Below, we start building the Jacobian up for a very basic element that 
-     *  is already in an isoparametric format.  The following four steps:
-     *      Extension Only Stiffness
-     *      Extension & Bending Stiffness
-     *      Extension, Bending, & Transverse Shear Stiffness
-     *      Extension, Bending, & Extension-Bending Coupling Stiffness
-     *      Extension, Bending, Transverse Shear & Extension-Bending Coupling Stiffness
-     * 
-     *  Testing the Jacobian incrementally this way allows errors in the
-     *  Jacobian to be located more precisely.
-     * 
-     *  It would probabyl be even better to test each stiffness contribution 
-     *  separately, but currently, we don't have a way to disable extension
-     *  stiffness and transverse shear stiffness doesn't exist without bending 
-     *  and extension-bending coupling stiffness don't make sense without both
-     *  extension and/or bending. 
-     */
+    test_elem.section.set_strain(MAST::LINEAR_STRAIN);
     
     // Set shear coefficient to zero to disable transverse shear stiffness
-    // FIXME: In MAST, when kappa=0.0, this results in zero rows/columns in element stiffness matrix
-    kappa = 0.0;
+    test_elem.kappa = 0.0;
     
     // Set the offset to zero to disable extension-bending coupling
-    offset = 0.0;
+    test_elem.offset = 0.0;
+
+    // Set the bending operator to no_bending to disable bending stiffness. This also disables
+    // transverse shear stiffness.
+    test_elem.section.set_bending_model(MAST::NO_BENDING);
     
-    // Set the bending operator to no_bending to disable bending stiffness
-    // NOTE: This also disables the transverse shear stiffness
-    section.set_bending_model(MAST::NO_BENDING);
-    
-    // Calculate residual and jacobian
-    RealVectorX residual = RealVectorX::Zero(n_dofs);
-    RealMatrixX jacobian0 = RealMatrixX::Zero(n_dofs, n_dofs);
-    elem->internal_residual(true, residual, jacobian0);
-            
-    double val_margin = (jacobian0.array().abs()).mean() * 1.490116119384766e-08;
-    
-    
-    SECTION("internal_jacobian_finite_difference_check")                   
+    // Update residual and Jacobian storage since we have modified baseline test element properties.
+    test_elem.update_residual_and_jacobian0();
+
+    double val_margin = (test_elem.jacobian0.array().abs()).mean() * 1.490116119384766e-08;
+
+
+    SECTION("Internal Jacobian (stiffness matrix) finite difference check")
     {
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem,
+                                                                   test_elem.elem_solution, test_elem.jacobian_fd);
+
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
     }
-    
-    SECTION("internal_jacobian_symmetry_check")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) should be symmetric")
     {
-        // Element stiffness matrix should be symmetric
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0.transpose());
-        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0.transpose())));
     }
-    
-    SECTION("internal_jacobian_determinant_check")
+
+
+    SECTION("Determinant of undeformed internal Jacobian (stiffness matrix) should be zero")
     {
-        // Determinant of undeformed element stiffness matrix should be zero
-        REQUIRE( jacobian0.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian0.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    
-    SECTION("internal_jacobian_displacement_invariant")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to displacement solution")
     {
-        // Calculate residual and jacobian at arbitrary displacement
-        RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
-        elem_sol << -0.04384355,  0.03969142, -0.09470648, -0.05011107, 
-                    -0.02989082, -0.01205296,  0.08846868,  0.04522207,  
-                     0.06435953, -0.07282706,  0.09307561, -0.06250143,  
-                     0.03332844, -0.00040089, -0.00423108, -0.07258241,  
+        RealVectorX elem_sol = RealVectorX::Zero(test_elem.n_dofs);
+        elem_sol << -0.04384355,  0.03969142, -0.09470648, -0.05011107,
+                    -0.02989082, -0.01205296,  0.08846868,  0.04522207,
+                     0.06435953, -0.07282706,  0.09307561, -0.06250143,
+                     0.03332844, -0.00040089, -0.00423108, -0.07258241,
                      0.06636534, -0.08421098, -0.0705489 , -0.06004976,
                      0.03873095, -0.09194373,  0.00055061,  0.046831;
-        elem->set_solution(elem_sol);
-        
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-                
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
+        test_elem.elem->set_solution(elem_sol);
+        test_elem.update_residual_and_jacobian();
 
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
     }
-    
-    SECTION("internal_jacobian_shifted_x_invariant")
-    {
-        // Shifted in x-direction
-        transform_element(mesh, X, 5.2, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-                
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
 
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
-    }
-    
-    SECTION("internal_jacobian_shifted_y_invariant")
+
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to element x-location")
     {
-        // Shifted in y-direction
-        transform_element(mesh, X, 0.0, -11.5, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
-        
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        TEST::transform_element(test_elem.mesh, coords,5.2, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
     }
-    
-    SECTION("internal_jacobian_rotated_about_z")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to element y-location")
+    {
+        TEST::transform_element(test_elem.mesh, coords, 0.0, -11.5, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
+    }
+
+
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to element z-location")
+    {
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 7.6,
+                                1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
+    }
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element rotated about z-axis")
     {
         // Rotated 63.4 about z-axis at element's centroid
-        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 63.4);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 63.4);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_rotated_about_y")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element rotated about y-axis")
     {
         // Rotated 35.8 about y-axis at element's centroid
-        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 35.8, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 35.8, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_rotated_about_x")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element rotated about x-axis")
     {
         // Rotated 15.8 about x-axis at element's centroid
-        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 15.8, 0.0, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 1.0, 15.8, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_sheared_in_x")
+
+
+    SECTION("\"Internal Jacobian (stiffness matrix) checks for element sheared in x-direction\"")
     {
-        // Rotated 63.4 about z-axis at element's centroid
-        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 6.7, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        // Shear element in x-direction.
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 0.0, 6.7, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_sheared_in_y")
+
+
+    SECTION("\"Internal Jacobian (stiffness matrix) checks for element sheared in y-direction\"")
     {
-        // Rotated 63.4 about z-axis at element's centroid
-        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, -11.2);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        // Shear element in x-direction.
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 0.0, 0.0, -11.2);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_scaled_x")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element stretched in x-direction")
     {
-        // Rotated 63.4 about z-axis at element's centroid
-        transform_element(mesh, X, 0.0, 0.0, 0.0, 3.2, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                3.2, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_scaled_y")
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element stretched in y-direction")
     {
-        // Rotated 63.4 about z-axis at element's centroid
-        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 0.64, 0.0, 0.0, 0.0, 0.0, 0.0);
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 0.64, 0.0, 0.0, 0.0, 0.0, 0.0);
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_arbitrary_transformation")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element arbitrarily scaled, stretched, rotated, and sheared")
     {
-        // Arbitrary transformations applied to the element
-        transform_element(mesh, X, -5.0, 7.8, -13.1, 2.7, 6.4, 20.0, 47.8, 
-                          -70.1, 5.7, -6.3);
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        // Apply arbitrary transformation to the element
+        TEST::transform_element(test_elem.mesh, coords, -5.0, 7.8, -13.1,
+                                2.7, 6.4, 20.0, 47.8, -70.1, 5.7, -6.3);
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_arbitrary_with_displacements")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element arbitrarily scaled, stretched, rotated, and displaced")
     {
-        RealMatrixX X = RealMatrixX::Zero(3,4);
-        X << -3.2,  2.4, 1.5, -2.1, 
-             -1.0, -0.2, 1.4,  0.8, 
-              0.0,  0.0, 0.0,  0.0;
-        // Update the element with the new node Coordinates
-        for (int i=0; i<X.cols(); i++)
-        {
-            (*mesh.node_ptr(i)) = libMesh::Point(X(0,i), X(1,i), X(2,i));
-        }
-        
-        // Arbitrary transformations applied to the element
-        transform_element(mesh, X, 4.1, -6.3, 7.5, 4.2, 1.5, -18.0, -24.8, 
+        // Apply arbitrary transformation to the element
+        TEST::transform_element(test_elem.mesh, coords, 4.1, -6.3, 7.5, 4.2, 1.5, -18.0, -24.8,
                           30.1, -3.2, 5.4);
-        
-        // Calculate residual and jacobian at arbitrary displacement
-        RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
-        elem_sol << -0.04384355,  0.03969142, -0.09470648, -0.05011107, 
-                    -0.02989082, -0.01205296,  0.08846868,  0.04522207,  
-                     0.06435953, -0.07282706,  0.09307561, -0.06250143,  
-                     0.03332844, -0.00040089, -0.00423108, -0.07258241,  
+
+        // Apply arbitrary displacement to the element
+        RealVectorX elem_sol = RealVectorX::Zero(test_elem.n_dofs);
+        elem_sol << -0.04384355,  0.03969142, -0.09470648, -0.05011107,
+                    -0.02989082, -0.01205296,  0.08846868,  0.04522207,
+                     0.06435953, -0.07282706,  0.09307561, -0.06250143,
+                     0.03332844, -0.00040089, -0.00423108, -0.07258241,
                      0.06636534, -0.08421098, -0.0705489 , -0.06004976,
                      0.03873095, -0.09194373,  0.00055061,  0.046831;
-        elem->set_solution(elem_sol);
-        
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        test_elem.elem->set_solution(elem_sol);
+
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
 }

--- a/tests/element/structural/2D/quad4/mast_quad4_linear_structural_inertial_jacobian.cpp
+++ b/tests/element/structural/2D/quad4/mast_quad4_linear_structural_inertial_jacobian.cpp
@@ -1,0 +1,433 @@
+#include "catch.hpp"
+
+// libMesh includes
+#include "libmesh/libmesh.h"
+#include "libmesh/replicated_mesh.h"
+#include "libmesh/point.h"
+#include "libmesh/elem.h"
+#include "libmesh/face_quad4.h"
+#include "libmesh/equation_systems.h"
+#include "libmesh/dof_map.h"
+
+// MAST includes
+#include "base/parameter.h"
+#include "base/constant_field_function.h"
+#include "property_cards/isotropic_material_property_card.h"
+#include "property_cards/solid_2d_section_element_property_card.h"
+#include "elasticity/structural_element_2d.h"
+#include "elasticity/structural_system_initialization.h"
+#include "base/physics_discipline_base.h"
+#include "base/nonlinear_implicit_assembly.h"
+#include "elasticity/structural_nonlinear_assembly.h"
+#include "base/nonlinear_system.h"
+#include "elasticity/structural_element_base.h"
+#include "mesh/geom_elem.h"
+
+// Custom includes
+#include "test_helpers.h"
+
+#define pi 3.14159265358979323846
+
+extern libMesh::LibMeshInit* p_global_init;
+
+TEST_CASE("quad4_linear_structural_inertial_consistent", 
+          "[quad],[quad4],[dynamic],[2D],[element]")
+{
+    const int n_elems = 1;
+    const int n_nodes = 4;
+    
+    // Point Coordinates
+    RealMatrixX temp = RealMatrixX::Zero(3,4);
+    temp << -1.0,  1.0, 1.0, -1.0, 
+            -1.0, -1.0, 1.0,  1.0, 
+             0.0,  0.0, 0.0,  0.0;
+    const RealMatrixX X = temp;
+    
+    /**
+     *  First create the mesh with the one element we are testing.
+     */
+    // Setup the mesh properties
+    libMesh::ReplicatedMesh mesh(p_global_init->comm());
+    mesh.set_mesh_dimension(2);
+    mesh.set_spatial_dimension(2);
+    mesh.reserve_elem(n_elems);
+    mesh.reserve_nodes(n_nodes);
+    
+    // Add nodes to the mesh
+    for (uint i=0; i<n_nodes; i++)
+    {
+        mesh.add_point(libMesh::Point(X(0,i), X(1,i), X(2,i)));
+    }
+    
+    // Add the element to the mesh
+    libMesh::Elem *reference_elem = new libMesh::Quad4;
+    reference_elem->set_id(0);    
+    reference_elem->subdomain_id() = 0;
+    reference_elem = mesh.add_elem(reference_elem);
+    for (int i=0; i<n_nodes; i++)
+    {
+        reference_elem->set_node(i) = mesh.node_ptr(i);
+    }
+    
+    // Prepare the mesh for use
+    mesh.prepare_for_use();
+    //mesh.print_info();
+    
+    const Real elem_volume = reference_elem->volume();
+    // Calculate true volume using 2D shoelace formula
+    Real true_volume = get_shoelace_area(X);
+    
+    // Ensure the libMesh element has the expected volume
+    REQUIRE( elem_volume == true_volume );
+            
+    /**
+     *  Setup the material and section properties to be used in the element
+     */
+    
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
+    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
+    MAST::Parameter kappa("kappa_param", 5.0/6.0);    // Shear coefficient
+    MAST::Parameter rho("rho_param", 1420.5);         // Density
+    
+    // Define Section Properties as MAST Parameters
+    MAST::Parameter thickness("th_param", 0.06);      // Section thickness
+    MAST::Parameter offset("off_param", 0.03);        // Section offset
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction E_f("E", E);
+    MAST::ConstantFieldFunction nu_f("nu", nu);
+    MAST::ConstantFieldFunction kappa_f("kappa", kappa);
+    MAST::ConstantFieldFunction thickness_f("h", thickness);
+    MAST::ConstantFieldFunction offset_f("off", offset);
+    MAST::ConstantFieldFunction rho_f("rho", rho);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(E_f);                                             
+    material.add(nu_f);
+    material.add(rho_f);
+    
+    // Initialize the section
+    MAST::Solid2DSectionElementPropertyCard section;
+    
+    // Add the section property constant field functions to the section card
+    section.add(thickness_f);
+    section.add(offset_f);
+    section.add(kappa_f);
+    
+    // Add the material card to the section card
+    section.set_material(material);
+    
+    
+    // Set the strain type to linear for the section
+    section.set_strain(MAST::LINEAR_STRAIN);
+    
+    // Set the bending operator
+    section.set_bending_model(MAST::MINDLIN);
+    
+    // Set the mass matrix to be lumped as opposed to the default, consistent
+    section.set_diagonal_mass_matrix(false);
+    REQUIRE_FALSE( section.if_diagonal_mass_matrix() );
+    
+    /**
+     *  Now we setup the structural system we will be solving.
+     */
+    libMesh::EquationSystems equation_systems(mesh);
+    
+    MAST::NonlinearSystem& system = equation_systems.add_system<MAST::NonlinearSystem>("structural");
+    
+    libMesh::FEType fetype(libMesh::FIRST, libMesh::LAGRANGE);
+    
+    MAST::StructuralSystemInitialization structural_system(system, 
+                                                           system.name(), 
+                                                           fetype);
+    
+    MAST::PhysicsDisciplineBase discipline(equation_systems);
+    
+    discipline.set_property_for_subdomain(0, section);
+    
+    equation_systems.init();
+    //equation_systems.print_info();
+    
+    MAST::NonlinearImplicitAssembly assembly;
+    assembly.set_discipline_and_system(discipline, structural_system);
+    
+    // Create the MAST element from the libMesh reference element
+    MAST::GeomElem geom_elem;
+    geom_elem.init(*reference_elem, structural_system);
+    std::unique_ptr<MAST::StructuralElementBase> elem_base = build_structural_element(structural_system, geom_elem, section);
+    
+    // Cast the base structural element as a 2D structural element
+    MAST::StructuralElement2D* elem = (dynamic_cast<MAST::StructuralElement2D*>(elem_base.get()));
+    
+    // Get element DOFs
+    const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
+    std::vector<libMesh::dof_id_type> dof_indices;
+    dof_map.dof_indices (reference_elem, dof_indices);
+    uint n_dofs = uint(dof_indices.size());
+    
+    // Set element's initial solution and solution sensitivity to zero
+    RealVectorX elem_solution = RealVectorX::Zero(n_dofs);
+    elem->set_solution(elem_solution);
+    elem->set_solution(elem_solution, true);
+    
+    // Set element's initial acceleration and acceleration sensitivity to zero
+    RealVectorX elem_accel = RealVectorX::Zero(n_dofs);
+    elem->set_acceleration(elem_accel);
+    elem->set_acceleration(elem_accel, true);
+    
+    const Real V0 = reference_elem->volume();
+    
+    // Calculate inertial residual and jacobians
+    RealVectorX residual = RealVectorX::Zero(n_dofs);
+    RealMatrixX jac0 = RealMatrixX::Zero(n_dofs, n_dofs);
+    RealMatrixX jac_xddot0 = RealMatrixX::Zero(n_dofs, n_dofs);
+    RealMatrixX jac_xdot0 = RealMatrixX::Zero(n_dofs, n_dofs);
+    elem->inertial_residual(true, residual, jac_xddot0, jac_xdot0, jac0);
+            
+    double val_margin = (jac_xddot0.array().abs()).mean() * 1.490116119384766e-08;
+    
+    SECTION("inertial_jacobian_finite_difference_check")                   
+    {
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_inertial_jacobian_with_finite_difference(*elem, elem_accel, jacobian_fd);
+        
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        
+        std::vector<double> test =  eigen_matrix_to_std_vector(jac_xddot0);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+    }
+    
+    
+    SECTION("inertial_jacobian_symmetry_check")
+    {
+        // Element inertial jacobian should be symmetric
+        std::vector<double> test =  eigen_matrix_to_std_vector(jac_xddot0);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jac_xddot0.transpose());
+        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    
+    SECTION("inertial_jacobian_determinant_check")
+    {
+        // Determinant of inertial jacobian should be positive
+        REQUIRE( jac_xddot0.determinant() > 0.0 );
+    }
+    
+    
+    SECTION("inertial_jacobian_eigenvalue_check")
+    {
+        SelfAdjointEigenSolver<RealMatrixX> eigensolver(jac_xddot0, false);
+        RealVectorX eigenvalues = eigensolver.eigenvalues();
+        libMesh::out << "Eigenvalues are:\n" << eigenvalues << std::endl;
+        REQUIRE(eigenvalues.minCoeff()>0.0);
+    }
+}
+
+
+TEST_CASE("quad4_linear_structural_inertial_lumped", 
+          "[quad],[quad4],[dynamic],[2D],[element]")
+{
+    const int n_elems = 1;
+    const int n_nodes = 4;
+    
+    // Point Coordinates
+    RealMatrixX temp = RealMatrixX::Zero(3,4);
+    temp << -1.0,  1.0, 1.0, -1.0, 
+            -1.0, -1.0, 1.0,  1.0, 
+             0.0,  0.0, 0.0,  0.0;
+    const RealMatrixX X = temp;
+    
+    /**
+     *  First create the mesh with the one element we are testing.
+     */
+    // Setup the mesh properties
+    libMesh::ReplicatedMesh mesh(p_global_init->comm());
+    mesh.set_mesh_dimension(2);
+    mesh.set_spatial_dimension(2);
+    mesh.reserve_elem(n_elems);
+    mesh.reserve_nodes(n_nodes);
+    
+    // Add nodes to the mesh
+    for (uint i=0; i<n_nodes; i++)
+    {
+        mesh.add_point(libMesh::Point(X(0,i), X(1,i), X(2,i)));
+    }
+    
+    // Add the element to the mesh
+    libMesh::Elem *reference_elem = new libMesh::Quad4;
+    reference_elem->set_id(0);    
+    reference_elem->subdomain_id() = 0;
+    reference_elem = mesh.add_elem(reference_elem);
+    for (int i=0; i<n_nodes; i++)
+    {
+        reference_elem->set_node(i) = mesh.node_ptr(i);
+    }
+    
+    // Prepare the mesh for use
+    mesh.prepare_for_use();
+    //mesh.print_info();
+    
+    const Real elem_volume = reference_elem->volume();
+    // Calculate true volume using 2D shoelace formula
+    Real true_volume = get_shoelace_area(X);
+    
+    // Ensure the libMesh element has the expected volume
+    REQUIRE( elem_volume == true_volume );
+            
+    /**
+     *  Setup the material and section properties to be used in the element
+     */
+    
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
+    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
+    MAST::Parameter kappa("kappa_param", 5.0/6.0);    // Shear coefficient
+    MAST::Parameter rho("rho_param", 1420.5);         // Density
+    
+    // Define Section Properties as MAST Parameters
+    MAST::Parameter thickness("th_param", 0.06);      // Section thickness
+    MAST::Parameter offset("off_param", 0.03);        // Section offset
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction E_f("E", E);
+    MAST::ConstantFieldFunction nu_f("nu", nu);
+    MAST::ConstantFieldFunction kappa_f("kappa", kappa);
+    MAST::ConstantFieldFunction thickness_f("h", thickness);
+    MAST::ConstantFieldFunction offset_f("off", offset);
+    MAST::ConstantFieldFunction rho_f("rho", rho);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(E_f);                                             
+    material.add(nu_f);
+    material.add(rho_f);
+    
+    // Initialize the section
+    MAST::Solid2DSectionElementPropertyCard section;
+    
+    // Add the section property constant field functions to the section card
+    section.add(thickness_f);
+    section.add(offset_f);
+    section.add(kappa_f);
+    
+    // Add the material card to the section card
+    section.set_material(material);
+    
+    // Set the strain type to linear for the section
+    section.set_strain(MAST::LINEAR_STRAIN);
+    
+    // Set the bending operator
+    section.set_bending_model(MAST::MINDLIN);
+    
+    // Set the mass matrix to be lumped as opposed to the default, consistent
+    section.set_diagonal_mass_matrix(true);
+    REQUIRE( section.if_diagonal_mass_matrix() );
+    
+    /**
+     *  Now we setup the structural system we will be solving.
+     */
+    libMesh::EquationSystems equation_systems(mesh);
+    
+    MAST::NonlinearSystem& system = equation_systems.add_system<MAST::NonlinearSystem>("structural");
+    
+    libMesh::FEType fetype(libMesh::FIRST, libMesh::LAGRANGE);
+    
+    MAST::StructuralSystemInitialization structural_system(system, 
+                                                           system.name(), 
+                                                           fetype);
+    
+    MAST::PhysicsDisciplineBase discipline(equation_systems);
+    
+    discipline.set_property_for_subdomain(0, section);
+    
+    equation_systems.init();
+    //equation_systems.print_info();
+    
+    MAST::NonlinearImplicitAssembly assembly;
+    assembly.set_discipline_and_system(discipline, structural_system);
+    
+    // Create the MAST element from the libMesh reference element
+    MAST::GeomElem geom_elem;
+    geom_elem.init(*reference_elem, structural_system);
+    std::unique_ptr<MAST::StructuralElementBase> elem_base = build_structural_element(structural_system, geom_elem, section);
+    
+    // Cast the base structural element as a 2D structural element
+    MAST::StructuralElement2D* elem = (dynamic_cast<MAST::StructuralElement2D*>(elem_base.get()));
+    
+    // Get element DOFs
+    const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
+    std::vector<libMesh::dof_id_type> dof_indices;
+    dof_map.dof_indices (reference_elem, dof_indices);
+    uint n_dofs = uint(dof_indices.size());
+    
+    // Set element's initial solution and solution sensitivity to zero
+    RealVectorX elem_solution = RealVectorX::Zero(n_dofs);
+    elem->set_solution(elem_solution);
+    elem->set_solution(elem_solution, true);
+    
+    // Set element's initial acceleration and acceleration sensitivity to zero
+    RealVectorX elem_accel = RealVectorX::Zero(n_dofs);
+    elem->set_acceleration(elem_accel);
+    elem->set_acceleration(elem_accel, true);
+    
+    const Real V0 = reference_elem->volume();
+    
+    // Calculate inertial residual and jacobians
+    RealVectorX residual = RealVectorX::Zero(n_dofs);
+    RealMatrixX jac0 = RealMatrixX::Zero(n_dofs, n_dofs);
+    RealMatrixX jac_xddot0 = RealMatrixX::Zero(n_dofs, n_dofs);
+    RealMatrixX jac_xdot0 = RealMatrixX::Zero(n_dofs, n_dofs);
+    elem->inertial_residual(true, residual, jac_xddot0, jac_xdot0, jac0);
+            
+    double val_margin = (jac_xddot0.array().abs()).mean() * 1.490116119384766e-08;
+    
+    SECTION("inertial_jacobian_finite_difference_check")                   
+    {
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_inertial_jacobian_with_finite_difference(*elem, elem_accel, jacobian_fd);
+        
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        
+        std::vector<double> test =  eigen_matrix_to_std_vector(jac_xddot0);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+    }
+    
+    
+    SECTION("inertial_jacobian_symmetry_check")
+    {
+        // Element inertial jacobian should be symmetric
+        std::vector<double> test =  eigen_matrix_to_std_vector(jac_xddot0);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jac_xddot0.transpose());
+        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    
+    SECTION("inertial_jacobian_determinant_check")
+    {
+        // Determinant of inertial jacobian should be positive
+        REQUIRE( jac_xddot0.determinant() > 0.0 );
+    }
+    
+    
+    SECTION("inertial_jacobian_eigenvalue_check")
+    {
+        SelfAdjointEigenSolver<RealMatrixX> eigensolver(jac_xddot0, false);
+        RealVectorX eigenvalues = eigensolver.eigenvalues();
+        libMesh::out << "Eigenvalues are:\n" << eigenvalues << std::endl;
+        REQUIRE(eigenvalues.minCoeff()>0.0);
+    }
+}

--- a/tests/element/structural/2D/quad4/mast_quad4_linear_structural_inertial_jacobian.cpp
+++ b/tests/element/structural/2D/quad4/mast_quad4_linear_structural_inertial_jacobian.cpp
@@ -1,12 +1,25 @@
-#include "catch.hpp"
+/*
+ * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
+ * Copyright (C) 2013-2020  Manav Bhatia and MAST authors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
 
 // libMesh includes
 #include "libmesh/libmesh.h"
-#include "libmesh/replicated_mesh.h"
-#include "libmesh/point.h"
 #include "libmesh/elem.h"
-#include "libmesh/face_quad4.h"
-#include "libmesh/equation_systems.h"
 #include "libmesh/dof_map.h"
 
 // MAST includes
@@ -16,215 +29,75 @@
 #include "property_cards/solid_2d_section_element_property_card.h"
 #include "elasticity/structural_element_2d.h"
 #include "elasticity/structural_system_initialization.h"
-#include "base/physics_discipline_base.h"
 #include "base/nonlinear_implicit_assembly.h"
 #include "elasticity/structural_nonlinear_assembly.h"
 #include "base/nonlinear_system.h"
-#include "elasticity/structural_element_base.h"
 #include "mesh/geom_elem.h"
 
-// Custom includes
+// Test includes
+#include "catch.hpp"
 #include "test_helpers.h"
-
-#define pi 3.14159265358979323846
+#include "element/structural/2D/mast_structural_element_2d.h"
 
 extern libMesh::LibMeshInit* p_global_init;
+
 
 TEST_CASE("quad4_linear_structural_inertial_consistent", 
           "[quad],[quad4],[dynamic],[2D],[element]")
 {
-    const int n_elems = 1;
-    const int n_nodes = 4;
-    
-    // Point Coordinates
-    RealMatrixX temp = RealMatrixX::Zero(3,4);
-    temp << -1.0,  1.0, 1.0, -1.0, 
-            -1.0, -1.0, 1.0,  1.0, 
-             0.0,  0.0, 0.0,  0.0;
-    const RealMatrixX X = temp;
-    
-    /**
-     *  First create the mesh with the one element we are testing.
-     */
-    // Setup the mesh properties
-    libMesh::ReplicatedMesh mesh(p_global_init->comm());
-    mesh.set_mesh_dimension(2);
-    mesh.set_spatial_dimension(2);
-    mesh.reserve_elem(n_elems);
-    mesh.reserve_nodes(n_nodes);
-    
-    // Add nodes to the mesh
-    for (uint i=0; i<n_nodes; i++)
-    {
-        mesh.add_point(libMesh::Point(X(0,i), X(1,i), X(2,i)));
-    }
-    
-    // Add the element to the mesh
-    libMesh::Elem *reference_elem = new libMesh::Quad4;
-    reference_elem->set_id(0);    
-    reference_elem->subdomain_id() = 0;
-    reference_elem = mesh.add_elem(reference_elem);
-    for (int i=0; i<n_nodes; i++)
-    {
-        reference_elem->set_node(i) = mesh.node_ptr(i);
-    }
-    
-    // Prepare the mesh for use
-    mesh.prepare_for_use();
-    //mesh.print_info();
-    
-    const Real elem_volume = reference_elem->volume();
-    // Calculate true volume using 2D shoelace formula
-    Real true_volume = get_shoelace_area(X);
-    
-    // Ensure the libMesh element has the expected volume
-    REQUIRE( elem_volume == true_volume );
-            
-    /**
-     *  Setup the material and section properties to be used in the element
-     */
-    
-    // Define Material Properties as MAST Parameters
-    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
-    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
-    MAST::Parameter kappa("kappa_param", 5.0/6.0);    // Shear coefficient
-    MAST::Parameter rho("rho_param", 1420.5);         // Density
-    
-    // Define Section Properties as MAST Parameters
-    MAST::Parameter thickness("th_param", 0.06);      // Section thickness
-    MAST::Parameter offset("off_param", 0.03);        // Section offset
-    
-    // Create field functions to dsitribute these constant parameters throughout the model
-    MAST::ConstantFieldFunction E_f("E", E);
-    MAST::ConstantFieldFunction nu_f("nu", nu);
-    MAST::ConstantFieldFunction kappa_f("kappa", kappa);
-    MAST::ConstantFieldFunction thickness_f("h", thickness);
-    MAST::ConstantFieldFunction offset_f("off", offset);
-    MAST::ConstantFieldFunction rho_f("rho", rho);
-    
-    // Initialize the material
-    MAST::IsotropicMaterialPropertyCard material;                   
-    
-    // Add the material property constant field functions to the material card
-    material.add(E_f);                                             
-    material.add(nu_f);
-    material.add(rho_f);
-    
-    // Initialize the section
-    MAST::Solid2DSectionElementPropertyCard section;
-    
-    // Add the section property constant field functions to the section card
-    section.add(thickness_f);
-    section.add(offset_f);
-    section.add(kappa_f);
-    
-    // Add the material card to the section card
-    section.set_material(material);
-    
-    
+    RealMatrixX coords = RealMatrixX::Zero(3,4);
+    coords << -1.0,  1.0, 1.0, -1.0,
+              -1.0, -1.0, 1.0,  1.0,
+               0.0,  0.0, 0.0,  0.0;
+    TEST::TestStructuralSingleElement2D test_elem(libMesh::QUAD4, coords);
+
+    const Real V0 = test_elem.reference_elem->volume();
+    REQUIRE(test_elem.reference_elem->volume() == TEST::get_shoelace_area(coords));
+
     // Set the strain type to linear for the section
-    section.set_strain(MAST::LINEAR_STRAIN);
+    test_elem.section.set_strain(MAST::LINEAR_STRAIN);
     
     // Set the bending operator
-    section.set_bending_model(MAST::MINDLIN);
-    
-    // Set the mass matrix to be lumped as opposed to the default, consistent
-    section.set_diagonal_mass_matrix(false);
-    REQUIRE_FALSE( section.if_diagonal_mass_matrix() );
-    
-    /**
-     *  Now we setup the structural system we will be solving.
-     */
-    libMesh::EquationSystems equation_systems(mesh);
-    
-    MAST::NonlinearSystem& system = equation_systems.add_system<MAST::NonlinearSystem>("structural");
-    
-    libMesh::FEType fetype(libMesh::FIRST, libMesh::LAGRANGE);
-    
-    MAST::StructuralSystemInitialization structural_system(system, 
-                                                           system.name(), 
-                                                           fetype);
-    
-    MAST::PhysicsDisciplineBase discipline(equation_systems);
-    
-    discipline.set_property_for_subdomain(0, section);
-    
-    equation_systems.init();
-    //equation_systems.print_info();
-    
-    MAST::NonlinearImplicitAssembly assembly;
-    assembly.set_discipline_and_system(discipline, structural_system);
-    
-    // Create the MAST element from the libMesh reference element
-    MAST::GeomElem geom_elem;
-    geom_elem.init(*reference_elem, structural_system);
-    std::unique_ptr<MAST::StructuralElementBase> elem_base = build_structural_element(structural_system, geom_elem, section);
-    
-    // Cast the base structural element as a 2D structural element
-    MAST::StructuralElement2D* elem = (dynamic_cast<MAST::StructuralElement2D*>(elem_base.get()));
-    
-    // Get element DOFs
-    const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
-    std::vector<libMesh::dof_id_type> dof_indices;
-    dof_map.dof_indices (reference_elem, dof_indices);
-    uint n_dofs = uint(dof_indices.size());
-    
-    // Set element's initial solution and solution sensitivity to zero
-    RealVectorX elem_solution = RealVectorX::Zero(n_dofs);
-    elem->set_solution(elem_solution);
-    elem->set_solution(elem_solution, true);
-    
-    // Set element's initial acceleration and acceleration sensitivity to zero
-    RealVectorX elem_accel = RealVectorX::Zero(n_dofs);
-    elem->set_acceleration(elem_accel);
-    elem->set_acceleration(elem_accel, true);
-    
-    const Real V0 = reference_elem->volume();
-    
-    // Calculate inertial residual and jacobians
-    RealVectorX residual = RealVectorX::Zero(n_dofs);
-    RealMatrixX jac0 = RealMatrixX::Zero(n_dofs, n_dofs);
-    RealMatrixX jac_xddot0 = RealMatrixX::Zero(n_dofs, n_dofs);
-    RealMatrixX jac_xdot0 = RealMatrixX::Zero(n_dofs, n_dofs);
-    elem->inertial_residual(true, residual, jac_xddot0, jac_xdot0, jac0);
-            
-    double val_margin = (jac_xddot0.array().abs()).mean() * 1.490116119384766e-08;
-    
-    SECTION("inertial_jacobian_finite_difference_check")                   
+    test_elem.section.set_bending_model(MAST::MINDLIN);
+
+    // Set mass matrix to consistent & compute inertial residual and Jacobians.
+    test_elem.section.set_diagonal_mass_matrix(false);
+    REQUIRE_FALSE(test_elem.section.if_diagonal_mass_matrix());
+    test_elem.update_inertial_residual_and_jacobian0();
+
+    double val_margin = (test_elem.jacobian_xddot0.array().abs()).mean() * 1.490116119384766e-08;
+
+    libMesh::out << "Jac_xddot0:\n" << test_elem.jacobian_xddot0 << std::endl;
+
+
+    SECTION("Inertial Jacobian (mass matrix) finite difference check")
     {
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_inertial_jacobian_with_finite_difference(*elem, elem_accel, jacobian_fd);
-        
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        
-        std::vector<double> test =  eigen_matrix_to_std_vector(jac_xddot0);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        TEST::approximate_inertial_jacobian_with_finite_difference(*test_elem.elem,
+                                                                   test_elem.elem_solution, test_elem.jacobian_fd);
+
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_xddot0),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
     }
-    
-    
-    SECTION("inertial_jacobian_symmetry_check")
+
+
+    SECTION("Inertial Jacobian (mass matrix) should be symmetric")
     {
-        // Element inertial jacobian should be symmetric
-        std::vector<double> test =  eigen_matrix_to_std_vector(jac_xddot0);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jac_xddot0.transpose());
-        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_xddot0),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_xddot0.transpose())));
     }
-    
-    
-    SECTION("inertial_jacobian_determinant_check")
+
+
+    SECTION("Determinant of undeformed inertial Jacobian (mass matrix) should be zero")
     {
-        // Determinant of inertial jacobian should be positive
-        REQUIRE( jac_xddot0.determinant() > 0.0 );
+        REQUIRE(test_elem.jacobian_xddot0.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    
-    SECTION("inertial_jacobian_eigenvalue_check")
+
+
+    SECTION("Inertial Jacobian (mass matrix) eigenvalues should all be positive")
     {
-        SelfAdjointEigenSolver<RealMatrixX> eigensolver(jac_xddot0, false);
+        SelfAdjointEigenSolver<RealMatrixX> eigensolver(test_elem.jacobian_xddot0, false);
         RealVectorX eigenvalues = eigensolver.eigenvalues();
         libMesh::out << "Eigenvalues are:\n" << eigenvalues << std::endl;
         REQUIRE(eigenvalues.minCoeff()>0.0);
@@ -235,197 +108,59 @@ TEST_CASE("quad4_linear_structural_inertial_consistent",
 TEST_CASE("quad4_linear_structural_inertial_lumped", 
           "[quad],[quad4],[dynamic],[2D],[element]")
 {
-    const int n_elems = 1;
-    const int n_nodes = 4;
-    
-    // Point Coordinates
-    RealMatrixX temp = RealMatrixX::Zero(3,4);
-    temp << -1.0,  1.0, 1.0, -1.0, 
-            -1.0, -1.0, 1.0,  1.0, 
-             0.0,  0.0, 0.0,  0.0;
-    const RealMatrixX X = temp;
-    
-    /**
-     *  First create the mesh with the one element we are testing.
-     */
-    // Setup the mesh properties
-    libMesh::ReplicatedMesh mesh(p_global_init->comm());
-    mesh.set_mesh_dimension(2);
-    mesh.set_spatial_dimension(2);
-    mesh.reserve_elem(n_elems);
-    mesh.reserve_nodes(n_nodes);
-    
-    // Add nodes to the mesh
-    for (uint i=0; i<n_nodes; i++)
-    {
-        mesh.add_point(libMesh::Point(X(0,i), X(1,i), X(2,i)));
-    }
-    
-    // Add the element to the mesh
-    libMesh::Elem *reference_elem = new libMesh::Quad4;
-    reference_elem->set_id(0);    
-    reference_elem->subdomain_id() = 0;
-    reference_elem = mesh.add_elem(reference_elem);
-    for (int i=0; i<n_nodes; i++)
-    {
-        reference_elem->set_node(i) = mesh.node_ptr(i);
-    }
-    
-    // Prepare the mesh for use
-    mesh.prepare_for_use();
-    //mesh.print_info();
-    
-    const Real elem_volume = reference_elem->volume();
-    // Calculate true volume using 2D shoelace formula
-    Real true_volume = get_shoelace_area(X);
-    
-    // Ensure the libMesh element has the expected volume
-    REQUIRE( elem_volume == true_volume );
-            
-    /**
-     *  Setup the material and section properties to be used in the element
-     */
-    
-    // Define Material Properties as MAST Parameters
-    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
-    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
-    MAST::Parameter kappa("kappa_param", 5.0/6.0);    // Shear coefficient
-    MAST::Parameter rho("rho_param", 1420.5);         // Density
-    
-    // Define Section Properties as MAST Parameters
-    MAST::Parameter thickness("th_param", 0.06);      // Section thickness
-    MAST::Parameter offset("off_param", 0.03);        // Section offset
-    
-    // Create field functions to dsitribute these constant parameters throughout the model
-    MAST::ConstantFieldFunction E_f("E", E);
-    MAST::ConstantFieldFunction nu_f("nu", nu);
-    MAST::ConstantFieldFunction kappa_f("kappa", kappa);
-    MAST::ConstantFieldFunction thickness_f("h", thickness);
-    MAST::ConstantFieldFunction offset_f("off", offset);
-    MAST::ConstantFieldFunction rho_f("rho", rho);
-    
-    // Initialize the material
-    MAST::IsotropicMaterialPropertyCard material;                   
-    
-    // Add the material property constant field functions to the material card
-    material.add(E_f);                                             
-    material.add(nu_f);
-    material.add(rho_f);
-    
-    // Initialize the section
-    MAST::Solid2DSectionElementPropertyCard section;
-    
-    // Add the section property constant field functions to the section card
-    section.add(thickness_f);
-    section.add(offset_f);
-    section.add(kappa_f);
-    
-    // Add the material card to the section card
-    section.set_material(material);
-    
+    RealMatrixX coords = RealMatrixX::Zero(3,4);
+    coords << -1.0,  1.0, 1.0, -1.0,
+              -1.0, -1.0, 1.0,  1.0,
+               0.0,  0.0, 0.0,  0.0;
+    TEST::TestStructuralSingleElement2D test_elem(libMesh::QUAD4, coords);
+
+    const Real V0 = test_elem.reference_elem->volume();
+    REQUIRE(test_elem.reference_elem->volume() == TEST::get_shoelace_area(coords));
+
     // Set the strain type to linear for the section
-    section.set_strain(MAST::LINEAR_STRAIN);
-    
+    test_elem.section.set_strain(MAST::LINEAR_STRAIN);
+
     // Set the bending operator
-    section.set_bending_model(MAST::MINDLIN);
-    
-    // Set the mass matrix to be lumped as opposed to the default, consistent
-    section.set_diagonal_mass_matrix(true);
-    REQUIRE( section.if_diagonal_mass_matrix() );
-    
-    /**
-     *  Now we setup the structural system we will be solving.
-     */
-    libMesh::EquationSystems equation_systems(mesh);
-    
-    MAST::NonlinearSystem& system = equation_systems.add_system<MAST::NonlinearSystem>("structural");
-    
-    libMesh::FEType fetype(libMesh::FIRST, libMesh::LAGRANGE);
-    
-    MAST::StructuralSystemInitialization structural_system(system, 
-                                                           system.name(), 
-                                                           fetype);
-    
-    MAST::PhysicsDisciplineBase discipline(equation_systems);
-    
-    discipline.set_property_for_subdomain(0, section);
-    
-    equation_systems.init();
-    //equation_systems.print_info();
-    
-    MAST::NonlinearImplicitAssembly assembly;
-    assembly.set_discipline_and_system(discipline, structural_system);
-    
-    // Create the MAST element from the libMesh reference element
-    MAST::GeomElem geom_elem;
-    geom_elem.init(*reference_elem, structural_system);
-    std::unique_ptr<MAST::StructuralElementBase> elem_base = build_structural_element(structural_system, geom_elem, section);
-    
-    // Cast the base structural element as a 2D structural element
-    MAST::StructuralElement2D* elem = (dynamic_cast<MAST::StructuralElement2D*>(elem_base.get()));
-    
-    // Get element DOFs
-    const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
-    std::vector<libMesh::dof_id_type> dof_indices;
-    dof_map.dof_indices (reference_elem, dof_indices);
-    uint n_dofs = uint(dof_indices.size());
-    
-    // Set element's initial solution and solution sensitivity to zero
-    RealVectorX elem_solution = RealVectorX::Zero(n_dofs);
-    elem->set_solution(elem_solution);
-    elem->set_solution(elem_solution, true);
-    
-    // Set element's initial acceleration and acceleration sensitivity to zero
-    RealVectorX elem_accel = RealVectorX::Zero(n_dofs);
-    elem->set_acceleration(elem_accel);
-    elem->set_acceleration(elem_accel, true);
-    
-    const Real V0 = reference_elem->volume();
-    
-    // Calculate inertial residual and jacobians
-    RealVectorX residual = RealVectorX::Zero(n_dofs);
-    RealMatrixX jac0 = RealMatrixX::Zero(n_dofs, n_dofs);
-    RealMatrixX jac_xddot0 = RealMatrixX::Zero(n_dofs, n_dofs);
-    RealMatrixX jac_xdot0 = RealMatrixX::Zero(n_dofs, n_dofs);
-    elem->inertial_residual(true, residual, jac_xddot0, jac_xdot0, jac0);
-            
-    double val_margin = (jac_xddot0.array().abs()).mean() * 1.490116119384766e-08;
-    
-    SECTION("inertial_jacobian_finite_difference_check")                   
+    test_elem.section.set_bending_model(MAST::MINDLIN);
+
+    // Set mass matrix to lumped & compute inertial residual and Jacobians.
+    test_elem.section.set_diagonal_mass_matrix(true);
+    REQUIRE(test_elem.section.if_diagonal_mass_matrix());
+    test_elem.update_inertial_residual_and_jacobian0();
+
+    double val_margin = (test_elem.jacobian_xddot0.array().abs()).mean() * 1.490116119384766e-08;
+
+    libMesh::out << "Jac_xddot0:\n" << test_elem.jacobian_xddot0 << std::endl;
+
+
+    SECTION("Inertial Jacobian (mass matrix) finite difference check")
     {
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_inertial_jacobian_with_finite_difference(*elem, elem_accel, jacobian_fd);
-        
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        
-        std::vector<double> test =  eigen_matrix_to_std_vector(jac_xddot0);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        TEST::approximate_inertial_jacobian_with_finite_difference(*test_elem.elem,
+                                                                   test_elem.elem_solution, test_elem.jacobian_fd);
+
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_xddot0),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
     }
-    
-    
-    SECTION("inertial_jacobian_symmetry_check")
+
+
+    SECTION("Inertial Jacobian (mass matrix) should be symmetric")
     {
-        // Element inertial jacobian should be symmetric
-        std::vector<double> test =  eigen_matrix_to_std_vector(jac_xddot0);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jac_xddot0.transpose());
-        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_xddot0),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_xddot0.transpose())));
     }
-    
-    
-    SECTION("inertial_jacobian_determinant_check")
+
+
+    SECTION("Determinant of undeformed inertial Jacobian (mass matrix) should be zero")
     {
-        // Determinant of inertial jacobian should be positive
-        REQUIRE( jac_xddot0.determinant() > 0.0 );
+        REQUIRE(test_elem.jacobian_xddot0.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    
-    SECTION("inertial_jacobian_eigenvalue_check")
+
+
+    SECTION("Inertial Jacobian (mass matrix) eigenvalues should all be positive")
     {
-        SelfAdjointEigenSolver<RealMatrixX> eigensolver(jac_xddot0, false);
+        SelfAdjointEigenSolver<RealMatrixX> eigensolver(test_elem.jacobian_xddot0, false);
         RealVectorX eigenvalues = eigensolver.eigenvalues();
         libMesh::out << "Eigenvalues are:\n" << eigenvalues << std::endl;
         REQUIRE(eigenvalues.minCoeff()>0.0);

--- a/tests/element/structural/2D/quad4/mast_quad4_linear_structural_internal_jacobian.cpp
+++ b/tests/element/structural/2D/quad4/mast_quad4_linear_structural_internal_jacobian.cpp
@@ -1,0 +1,655 @@
+#include "catch.hpp"
+
+// libMesh includes
+#include "libmesh/libmesh.h"
+#include "libmesh/replicated_mesh.h"
+#include "libmesh/point.h"
+#include "libmesh/elem.h"
+#include "libmesh/face_quad4.h"
+#include "libmesh/equation_systems.h"
+#include "libmesh/dof_map.h"
+
+// MAST includes
+#include "base/parameter.h"
+#include "base/constant_field_function.h"
+#include "property_cards/isotropic_material_property_card.h"
+#include "property_cards/solid_2d_section_element_property_card.h"
+#include "elasticity/structural_element_2d.h"
+#include "elasticity/structural_system_initialization.h"
+#include "base/physics_discipline_base.h"
+#include "base/nonlinear_implicit_assembly.h"
+#include "elasticity/structural_nonlinear_assembly.h"
+#include "base/nonlinear_system.h"
+#include "elasticity/structural_element_base.h"
+#include "mesh/geom_elem.h"
+
+// Custom includes
+#include "test_helpers.h"
+
+#define pi 3.14159265358979323846
+
+extern libMesh::LibMeshInit* p_global_init;
+
+TEST_CASE("quad4_linear_structural", 
+          "[quad],[quad4],[linear],[structural],[2D],[element]")
+{
+    const int n_elems = 1;
+    const int n_nodes = 4;
+    
+    // Point Coordinates
+    RealMatrixX temp = RealMatrixX::Zero(3,4);
+    temp << -1.0,  1.0, 1.0, -1.0, 
+            -1.0, -1.0, 1.0,  1.0, 
+             0.0,  0.0, 0.0,  0.0;
+    const RealMatrixX X = temp;
+    
+    /**
+     *  First create the mesh with the one element we are testing.
+     */
+    // Setup the mesh properties
+    libMesh::ReplicatedMesh mesh(p_global_init->comm());
+    mesh.set_mesh_dimension(2);
+    mesh.set_spatial_dimension(2);
+    mesh.reserve_elem(n_elems);
+    mesh.reserve_nodes(n_nodes);
+    
+    // Add nodes to the mesh
+    for (uint i=0; i<n_nodes; i++)
+    {
+        mesh.add_point(libMesh::Point(X(0,i), X(1,i), X(2,i)));
+    }
+    
+    // Add the element to the mesh
+    libMesh::Elem *reference_elem = new libMesh::Quad4;
+    reference_elem->set_id(0);    
+    reference_elem->subdomain_id() = 0;
+    reference_elem = mesh.add_elem(reference_elem);
+    for (int i=0; i<n_nodes; i++)
+    {
+        reference_elem->set_node(i) = mesh.node_ptr(i);
+    }
+    
+    // Prepare the mesh for use
+    mesh.prepare_for_use();
+    //mesh.print_info();
+    
+    const Real elem_volume = reference_elem->volume();
+    // Calculate true volume using 2D shoelace formula
+    Real true_volume = get_shoelace_area(X);
+    
+    // Ensure the libMesh element has the expected volume
+    REQUIRE( elem_volume == true_volume );
+            
+    /**
+     *  Setup the material and section properties to be used in the element
+     */
+    
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
+    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
+    MAST::Parameter kappa("kappa_param", 5.0/6.0);    // Shear coefficient
+    
+    // Define Section Properties as MAST Parameters
+    MAST::Parameter thickness("th_param", 0.06);      // Section thickness
+    MAST::Parameter offset("off_param", 0.03);        // Section offset
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction E_f("E", E);
+    MAST::ConstantFieldFunction nu_f("nu", nu);
+    MAST::ConstantFieldFunction kappa_f("kappa", kappa);
+    MAST::ConstantFieldFunction thickness_f("h", thickness);
+    MAST::ConstantFieldFunction offset_f("off", offset);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(E_f);                                             
+    material.add(nu_f);
+    
+    // Initialize the section
+    MAST::Solid2DSectionElementPropertyCard section;
+    
+    // Add the section property constant field functions to the section card
+    section.add(thickness_f);
+    section.add(offset_f);
+    section.add(kappa_f);
+    
+    // Add the material card to the section card
+    section.set_material(material);
+    
+    
+    // Set the strain type to linear for the section
+    section.set_strain(MAST::LINEAR_STRAIN);
+    
+    /**
+     *  Now we setup the structural system we will be solving.
+     */
+    libMesh::EquationSystems equation_systems(mesh);
+    
+    MAST::NonlinearSystem& system = equation_systems.add_system<MAST::NonlinearSystem>("structural");
+    
+    libMesh::FEType fetype(libMesh::FIRST, libMesh::LAGRANGE);
+    
+    MAST::StructuralSystemInitialization structural_system(system, 
+                                                           system.name(), 
+                                                           fetype);
+    
+    MAST::PhysicsDisciplineBase discipline(equation_systems);
+    
+    discipline.set_property_for_subdomain(0, section);
+    
+    equation_systems.init();
+    //equation_systems.print_info();
+    
+    MAST::NonlinearImplicitAssembly assembly;
+    assembly.set_discipline_and_system(discipline, structural_system);
+    
+    // Create the MAST element from the libMesh reference element
+    MAST::GeomElem geom_elem;
+    geom_elem.init(*reference_elem, structural_system);
+    std::unique_ptr<MAST::StructuralElementBase> elem_base = build_structural_element(structural_system, geom_elem, section);
+    
+    // Cast the base structural element as a 2D structural element
+    MAST::StructuralElement2D* elem = (dynamic_cast<MAST::StructuralElement2D*>(elem_base.get()));
+    
+    // Get element DOFs
+    const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
+    std::vector<libMesh::dof_id_type> dof_indices;
+    dof_map.dof_indices (reference_elem, dof_indices);
+    uint n_dofs = uint(dof_indices.size());
+    
+    // Set element's initial solution and solution sensitivity to zero
+    RealVectorX elem_solution = RealVectorX::Zero(n_dofs);
+    elem->set_solution(elem_solution);
+    elem->set_solution(elem_solution, true);
+    
+    const Real V0 = reference_elem->volume();
+    
+    /**
+     *  Below, we start building the Jacobian up for a very basic element that 
+     *  is already in an isoparametric format.  The following four steps:
+     *      Extension Only Stiffness
+     *      Extension & Bending Stiffness
+     *      Extension, Bending, & Transverse Shear Stiffness
+     *      Extension, Bending, & Extension-Bending Coupling Stiffness
+     *      Extension, Bending, Transverse Shear & Extension-Bending Coupling Stiffness
+     * 
+     *  Testing the Jacobian incrementally this way allows errors in the
+     *  Jacobian to be located more precisely.
+     * 
+     *  It would probabyl be even better to test each stiffness contribution 
+     *  separately, but currently, we don't have a way to disable extension
+     *  stiffness and transverse shear stiffness doesn't exist without bending 
+     *  and extension-bending coupling stiffness don't make sense without both
+     *  extension and/or bending. 
+     */
+    
+    // Calculate residual and jacobian
+    RealVectorX residual = RealVectorX::Zero(n_dofs);
+    RealMatrixX jacobian0 = RealMatrixX::Zero(n_dofs, n_dofs);
+    elem->internal_residual(true, residual, jacobian0);
+            
+    double val_margin = (jacobian0.array().abs()).mean() * 1.490116119384766e-08;
+    
+    
+    SECTION("internal_jacobian_finite_difference_check")                   
+    {
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+    }
+    
+    SECTION("internal_jacobian_symmetry_check")
+    {
+        // Element stiffness matrix should be symmetric
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0.transpose());
+        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+    }
+    
+    SECTION("internal_jacobian_determinant_check")
+    {
+        // Determinant of undeformed element stiffness matrix should be zero
+        REQUIRE( jacobian0.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    
+    SECTION("internal_jacobian_displacement_invariant")
+    {
+        // Calculate residual and jacobian at arbitrary displacement
+        RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
+        elem_sol << -0.04384355,  0.03969142, -0.09470648, -0.05011107, 
+                    -0.02989082, -0.01205296,  0.08846868,  0.04522207,  
+                     0.06435953, -0.07282706,  0.09307561, -0.06250143,  
+                     0.03332844, -0.00040089, -0.00423108, -0.07258241,  
+                     0.06636534, -0.08421098, -0.0705489 , -0.06004976,
+                     0.03873095, -0.09194373,  0.00055061,  0.046831;
+        elem->set_solution(elem_sol);
+        
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+                
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
+
+        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+    }
+    
+    SECTION("internal_jacobian_shifted_x_invariant")
+    {
+        // Shifted in x-direction
+        transform_element(mesh, X, 5.2, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+                
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
+
+        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+    }
+    
+    SECTION("internal_jacobian_shifted_y_invariant")
+    {
+        // Shifted in y-direction
+        transform_element(mesh, X, 0.0, -11.5, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
+        
+        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+    }
+    
+    SECTION("internal_jacobian_rotated_about_z")
+    {
+        // Rotated 63.4 about z-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 63.4);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_rotated_about_y")
+    {
+        // Rotated 35.8 about y-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 35.8, 0.0);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_rotated_about_x")
+    {
+        // Rotated 15.8 about x-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 15.8, 0.0, 0.0);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_sheared_in_x")
+    {
+        // Rotated 63.4 about z-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 6.7, 0.0);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_sheared_in_y")
+    {
+        // Rotated 63.4 about z-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, -11.2);
+        REQUIRE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_scaled_x")
+    {
+        // Rotated 63.4 about z-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 3.2, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_scaled_y")
+    {
+        // Rotated 63.4 about z-axis at element's centroid
+        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 0.64, 0.0, 0.0, 0.0, 0.0, 0.0);
+        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_arbitrary_transformation")
+    {
+        // Arbitrary transformations applied to the element
+        transform_element(mesh, X, -5.0, 7.8, -13.1, 2.7, 6.4, 20.0, 47.8, 
+                          -70.1, 5.7, -6.3);
+        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+    
+    SECTION("internal_jacobian_arbitrary_with_displacements")
+    {
+        RealMatrixX X = RealMatrixX::Zero(3,4);
+        X << -3.2,  2.4, 1.5, -2.1, 
+             -1.0, -0.2, 1.4,  0.8, 
+              0.0,  0.0, 0.0,  0.0;
+        // Update the element with the new node Coordinates
+        for (int i=0; i<X.cols(); i++)
+        {
+            (*mesh.node_ptr(i)) = libMesh::Point(X(0,i), X(1,i), X(2,i));
+        }
+        
+        // Arbitrary transformations applied to the element
+        transform_element(mesh, X, 4.1, -6.3, 7.5, 4.2, 1.5, -18.0, -24.8, 
+                          30.1, -3.2, 5.4);
+        
+        // Calculate residual and jacobian at arbitrary displacement
+        RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
+        elem_sol << -0.04384355,  0.03969142, -0.09470648, -0.05011107, 
+                    -0.02989082, -0.01205296,  0.08846868,  0.04522207,  
+                     0.06435953, -0.07282706,  0.09307561, -0.06250143,  
+                     0.03332844, -0.00040089, -0.00423108, -0.07258241,  
+                     0.06636534, -0.08421098, -0.0705489 , -0.06004976,
+                     0.03873095, -0.09194373,  0.00055061,  0.046831;
+        elem->set_solution(elem_sol);
+        
+        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
+        
+        // Calculate residual and jacobian
+        RealVectorX residual = RealVectorX::Zero(n_dofs);
+        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+        elem->internal_residual(true, residual, jacobian);
+        
+        // Approximate Jacobian with Finite Difference
+        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
+        
+        // This is necessary because MAST manually (hard-coded) adds a small 
+        // value to the diagonal to prevent singularities at inactive DOFs
+        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
+        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        //std::cout << "val_margin = " << val_margin << std::endl;
+        
+        // Convert the test and truth Eigen::Matrix objects to std::vector
+        // since Catch2 has built in methods to compare vectors
+        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
+        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
+        
+        // Floating point approximations are diffcult to compare since the
+        // values typically aren't exactly equal due to numerical error.
+        // Therefore, we use the Approx comparison instead of Equals
+        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
+        
+        // Symmetry check
+        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
+        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
+        
+        // Determinant check
+        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+    }
+}

--- a/tests/element/structural/2D/quad4/mast_quad4_linear_structural_internal_jacobian.cpp
+++ b/tests/element/structural/2D/quad4/mast_quad4_linear_structural_internal_jacobian.cpp
@@ -1,12 +1,25 @@
-#include "catch.hpp"
+/*
+ * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
+ * Copyright (C) 2013-2020  Manav Bhatia and MAST authors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
 
 // libMesh includes
 #include "libmesh/libmesh.h"
-#include "libmesh/replicated_mesh.h"
-#include "libmesh/point.h"
 #include "libmesh/elem.h"
-#include "libmesh/face_quad4.h"
-#include "libmesh/equation_systems.h"
 #include "libmesh/dof_map.h"
 
 // MAST includes
@@ -16,640 +29,329 @@
 #include "property_cards/solid_2d_section_element_property_card.h"
 #include "elasticity/structural_element_2d.h"
 #include "elasticity/structural_system_initialization.h"
-#include "base/physics_discipline_base.h"
 #include "base/nonlinear_implicit_assembly.h"
 #include "elasticity/structural_nonlinear_assembly.h"
 #include "base/nonlinear_system.h"
-#include "elasticity/structural_element_base.h"
 #include "mesh/geom_elem.h"
 
-// Custom includes
+// Test includes
+#include "catch.hpp"
 #include "test_helpers.h"
-
-#define pi 3.14159265358979323846
+#include "element/structural/2D/mast_structural_element_2d.h"
 
 extern libMesh::LibMeshInit* p_global_init;
+
 
 TEST_CASE("quad4_linear_structural", 
           "[quad],[quad4],[linear],[structural],[2D],[element]")
 {
-    const int n_elems = 1;
-    const int n_nodes = 4;
-    
-    // Point Coordinates
-    RealMatrixX temp = RealMatrixX::Zero(3,4);
-    temp << -1.0,  1.0, 1.0, -1.0, 
-            -1.0, -1.0, 1.0,  1.0, 
-             0.0,  0.0, 0.0,  0.0;
-    const RealMatrixX X = temp;
-    
-    /**
-     *  First create the mesh with the one element we are testing.
-     */
-    // Setup the mesh properties
-    libMesh::ReplicatedMesh mesh(p_global_init->comm());
-    mesh.set_mesh_dimension(2);
-    mesh.set_spatial_dimension(2);
-    mesh.reserve_elem(n_elems);
-    mesh.reserve_nodes(n_nodes);
-    
-    // Add nodes to the mesh
-    for (uint i=0; i<n_nodes; i++)
-    {
-        mesh.add_point(libMesh::Point(X(0,i), X(1,i), X(2,i)));
-    }
-    
-    // Add the element to the mesh
-    libMesh::Elem *reference_elem = new libMesh::Quad4;
-    reference_elem->set_id(0);    
-    reference_elem->subdomain_id() = 0;
-    reference_elem = mesh.add_elem(reference_elem);
-    for (int i=0; i<n_nodes; i++)
-    {
-        reference_elem->set_node(i) = mesh.node_ptr(i);
-    }
-    
-    // Prepare the mesh for use
-    mesh.prepare_for_use();
-    //mesh.print_info();
-    
-    const Real elem_volume = reference_elem->volume();
-    // Calculate true volume using 2D shoelace formula
-    Real true_volume = get_shoelace_area(X);
-    
-    // Ensure the libMesh element has the expected volume
-    REQUIRE( elem_volume == true_volume );
-            
-    /**
-     *  Setup the material and section properties to be used in the element
-     */
-    
-    // Define Material Properties as MAST Parameters
-    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
-    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
-    MAST::Parameter kappa("kappa_param", 5.0/6.0);    // Shear coefficient
-    
-    // Define Section Properties as MAST Parameters
-    MAST::Parameter thickness("th_param", 0.06);      // Section thickness
-    MAST::Parameter offset("off_param", 0.03);        // Section offset
-    
-    // Create field functions to dsitribute these constant parameters throughout the model
-    MAST::ConstantFieldFunction E_f("E", E);
-    MAST::ConstantFieldFunction nu_f("nu", nu);
-    MAST::ConstantFieldFunction kappa_f("kappa", kappa);
-    MAST::ConstantFieldFunction thickness_f("h", thickness);
-    MAST::ConstantFieldFunction offset_f("off", offset);
-    
-    // Initialize the material
-    MAST::IsotropicMaterialPropertyCard material;                   
-    
-    // Add the material property constant field functions to the material card
-    material.add(E_f);                                             
-    material.add(nu_f);
-    
-    // Initialize the section
-    MAST::Solid2DSectionElementPropertyCard section;
-    
-    // Add the section property constant field functions to the section card
-    section.add(thickness_f);
-    section.add(offset_f);
-    section.add(kappa_f);
-    
-    // Add the material card to the section card
-    section.set_material(material);
-    
-    
+    RealMatrixX coords = RealMatrixX::Zero(3,4);
+    coords << -1.0,  1.0, 1.0, -1.0,
+            -1.0, -1.0, 1.0,  1.0,
+            0.0,  0.0, 0.0,  0.0;
+    TEST::TestStructuralSingleElement2D test_elem(libMesh::QUAD4, coords);
+
+    const Real V0 = test_elem.reference_elem->volume();
+    REQUIRE(test_elem.reference_elem->volume() == TEST::get_shoelace_area(coords));
+
     // Set the strain type to linear for the section
-    section.set_strain(MAST::LINEAR_STRAIN);
-    
-    /**
-     *  Now we setup the structural system we will be solving.
-     */
-    libMesh::EquationSystems equation_systems(mesh);
-    
-    MAST::NonlinearSystem& system = equation_systems.add_system<MAST::NonlinearSystem>("structural");
-    
-    libMesh::FEType fetype(libMesh::FIRST, libMesh::LAGRANGE);
-    
-    MAST::StructuralSystemInitialization structural_system(system, 
-                                                           system.name(), 
-                                                           fetype);
-    
-    MAST::PhysicsDisciplineBase discipline(equation_systems);
-    
-    discipline.set_property_for_subdomain(0, section);
-    
-    equation_systems.init();
-    //equation_systems.print_info();
-    
-    MAST::NonlinearImplicitAssembly assembly;
-    assembly.set_discipline_and_system(discipline, structural_system);
-    
-    // Create the MAST element from the libMesh reference element
-    MAST::GeomElem geom_elem;
-    geom_elem.init(*reference_elem, structural_system);
-    std::unique_ptr<MAST::StructuralElementBase> elem_base = build_structural_element(structural_system, geom_elem, section);
-    
-    // Cast the base structural element as a 2D structural element
-    MAST::StructuralElement2D* elem = (dynamic_cast<MAST::StructuralElement2D*>(elem_base.get()));
-    
-    // Get element DOFs
-    const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
-    std::vector<libMesh::dof_id_type> dof_indices;
-    dof_map.dof_indices (reference_elem, dof_indices);
-    uint n_dofs = uint(dof_indices.size());
-    
-    // Set element's initial solution and solution sensitivity to zero
-    RealVectorX elem_solution = RealVectorX::Zero(n_dofs);
-    elem->set_solution(elem_solution);
-    elem->set_solution(elem_solution, true);
-    
-    const Real V0 = reference_elem->volume();
-    
-    /**
-     *  Below, we start building the Jacobian up for a very basic element that 
-     *  is already in an isoparametric format.  The following four steps:
-     *      Extension Only Stiffness
-     *      Extension & Bending Stiffness
-     *      Extension, Bending, & Transverse Shear Stiffness
-     *      Extension, Bending, & Extension-Bending Coupling Stiffness
-     *      Extension, Bending, Transverse Shear & Extension-Bending Coupling Stiffness
-     * 
-     *  Testing the Jacobian incrementally this way allows errors in the
-     *  Jacobian to be located more precisely.
-     * 
-     *  It would probabyl be even better to test each stiffness contribution 
-     *  separately, but currently, we don't have a way to disable extension
-     *  stiffness and transverse shear stiffness doesn't exist without bending 
-     *  and extension-bending coupling stiffness don't make sense without both
-     *  extension and/or bending. 
-     */
-    
-    // Calculate residual and jacobian
-    RealVectorX residual = RealVectorX::Zero(n_dofs);
-    RealMatrixX jacobian0 = RealMatrixX::Zero(n_dofs, n_dofs);
-    elem->internal_residual(true, residual, jacobian0);
-            
-    double val_margin = (jacobian0.array().abs()).mean() * 1.490116119384766e-08;
-    
-    
-    SECTION("internal_jacobian_finite_difference_check")                   
-    {
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
-    }
-    
-    SECTION("internal_jacobian_symmetry_check")
-    {
-        // Element stiffness matrix should be symmetric
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0.transpose());
-        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
-    }
-    
-    SECTION("internal_jacobian_determinant_check")
-    {
-        // Determinant of undeformed element stiffness matrix should be zero
-        REQUIRE( jacobian0.determinant() == Approx(0.0).margin(1e-06) );
-    }
-    
-    
-    SECTION("internal_jacobian_displacement_invariant")
-    {
-        // Calculate residual and jacobian at arbitrary displacement
-        RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
-        elem_sol << -0.04384355,  0.03969142, -0.09470648, -0.05011107, 
-                    -0.02989082, -0.01205296,  0.08846868,  0.04522207,  
-                     0.06435953, -0.07282706,  0.09307561, -0.06250143,  
-                     0.03332844, -0.00040089, -0.00423108, -0.07258241,  
-                     0.06636534, -0.08421098, -0.0705489 , -0.06004976,
-                     0.03873095, -0.09194373,  0.00055061,  0.046831;
-        elem->set_solution(elem_sol);
-        
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-                
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
+    test_elem.section.set_strain(MAST::LINEAR_STRAIN);
 
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
-    }
-    
-    SECTION("internal_jacobian_shifted_x_invariant")
-    {
-        // Shifted in x-direction
-        transform_element(mesh, X, 5.2, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-                
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
+    // Update residual and Jacobian storage since we have modified baseline test element properties.
+    test_elem.update_residual_and_jacobian0();
 
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
-    }
-    
-    SECTION("internal_jacobian_shifted_y_invariant")
+    double val_margin = (test_elem.jacobian0.array().abs()).mean() * 1.490116119384766e-08;
+
+
+    SECTION("Internal Jacobian (stiffness matrix) finite difference check")
     {
-        // Shifted in y-direction
-        transform_element(mesh, X, 0.0, -11.5, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
-        
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem,
+                                                                   test_elem.elem_solution, test_elem.jacobian_fd);
+
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
     }
-    
-    SECTION("internal_jacobian_rotated_about_z")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) should be symmetric")
+    {
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0.transpose())));
+    }
+
+
+    SECTION("Determinant of undeformed internal Jacobian (stiffness matrix) should be zero")
+    {
+        REQUIRE(test_elem.jacobian0.determinant() == Approx(0.0).margin(1e-06));
+    }
+
+
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to displacement solution")
+    {
+        RealVectorX elem_sol = RealVectorX::Zero(test_elem.n_dofs);
+        elem_sol << -0.04384355,  0.03969142, -0.09470648, -0.05011107,
+                -0.02989082, -0.01205296,  0.08846868,  0.04522207,
+                0.06435953, -0.07282706,  0.09307561, -0.06250143,
+                0.03332844, -0.00040089, -0.00423108, -0.07258241,
+                0.06636534, -0.08421098, -0.0705489 , -0.06004976,
+                0.03873095, -0.09194373,  0.00055061,  0.046831;
+        test_elem.elem->set_solution(elem_sol);
+        test_elem.update_residual_and_jacobian();
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
+    }
+
+
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to element x-location")
+    {
+        TEST::transform_element(test_elem.mesh, coords,5.2, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
+    }
+
+
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to element y-location")
+    {
+        TEST::transform_element(test_elem.mesh, coords, 0.0, -11.5, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
+    }
+
+
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to element z-location")
+    {
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 7.6,
+                                1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
+    }
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element rotated about z-axis")
     {
         // Rotated 63.4 about z-axis at element's centroid
-        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 63.4);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 63.4);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_rotated_about_y")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element rotated about y-axis")
     {
         // Rotated 35.8 about y-axis at element's centroid
-        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 35.8, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 35.8, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_rotated_about_x")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element rotated about x-axis")
     {
         // Rotated 15.8 about x-axis at element's centroid
-        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 15.8, 0.0, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 1.0, 15.8, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_sheared_in_x")
+
+
+    SECTION("\"Internal Jacobian (stiffness matrix) checks for element sheared in x-direction\"")
     {
-        // Rotated 63.4 about z-axis at element's centroid
-        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 6.7, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        // Shear element in x-direction.
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 0.0, 6.7, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_sheared_in_y")
+
+
+    SECTION("\"Internal Jacobian (stiffness matrix) checks for element sheared in y-direction\"")
     {
-        // Rotated 63.4 about z-axis at element's centroid
-        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, -11.2);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        // Shear element in x-direction.
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 0.0, 0.0, -11.2);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_scaled_x")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element stretched in x-direction")
     {
-        // Rotated 63.4 about z-axis at element's centroid
-        transform_element(mesh, X, 0.0, 0.0, 0.0, 3.2, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                3.2, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_scaled_y")
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element stretched in y-direction")
     {
-        // Rotated 63.4 about z-axis at element's centroid
-        transform_element(mesh, X, 0.0, 0.0, 0.0, 1.0, 0.64, 0.0, 0.0, 0.0, 0.0, 0.0);
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 0.64, 0.0, 0.0, 0.0, 0.0, 0.0);
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_arbitrary_transformation")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element arbitrarily scaled, stretched, rotated, and sheared")
     {
-        // Arbitrary transformations applied to the element
-        transform_element(mesh, X, -5.0, 7.8, -13.1, 2.7, 6.4, 20.0, 47.8, 
-                          -70.1, 5.7, -6.3);
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        // Apply arbitrary transformation to the element
+        TEST::transform_element(test_elem.mesh, coords, -5.0, 7.8, -13.1,
+                                2.7, 6.4, 20.0, 47.8, -70.1, 5.7, -6.3);
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_arbitrary_with_displacements")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element arbitrarily scaled, stretched, rotated, and displaced")
     {
-        RealMatrixX X = RealMatrixX::Zero(3,4);
-        X << -3.2,  2.4, 1.5, -2.1, 
-             -1.0, -0.2, 1.4,  0.8, 
-              0.0,  0.0, 0.0,  0.0;
-        // Update the element with the new node Coordinates
-        for (int i=0; i<X.cols(); i++)
-        {
-            (*mesh.node_ptr(i)) = libMesh::Point(X(0,i), X(1,i), X(2,i));
-        }
-        
-        // Arbitrary transformations applied to the element
-        transform_element(mesh, X, 4.1, -6.3, 7.5, 4.2, 1.5, -18.0, -24.8, 
-                          30.1, -3.2, 5.4);
-        
-        // Calculate residual and jacobian at arbitrary displacement
-        RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
-        elem_sol << -0.04384355,  0.03969142, -0.09470648, -0.05011107, 
-                    -0.02989082, -0.01205296,  0.08846868,  0.04522207,  
-                     0.06435953, -0.07282706,  0.09307561, -0.06250143,  
-                     0.03332844, -0.00040089, -0.00423108, -0.07258241,  
-                     0.06636534, -0.08421098, -0.0705489 , -0.06004976,
-                     0.03873095, -0.09194373,  0.00055061,  0.046831;
-        elem->set_solution(elem_sol);
-        
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        // Apply arbitrary transformation to the element
+        TEST::transform_element(test_elem.mesh, coords, 4.1, -6.3, 7.5, 4.2, 1.5, -18.0, -24.8,
+                                30.1, -3.2, 5.4);
+
+        // Apply arbitrary displacement to the element
+        RealVectorX elem_sol = RealVectorX::Zero(test_elem.n_dofs);
+        elem_sol << -0.04384355,  0.03969142, -0.09470648, -0.05011107,
+                -0.02989082, -0.01205296,  0.08846868,  0.04522207,
+                0.06435953, -0.07282706,  0.09307561, -0.06250143,
+                0.03332844, -0.00040089, -0.00423108, -0.07258241,
+                0.06636534, -0.08421098, -0.0705489 , -0.06004976,
+                0.03873095, -0.09194373,  0.00055061,  0.046831;
+        test_elem.elem->set_solution(elem_sol);
+
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
 }

--- a/tests/element/structural/2D/quad4/mast_quad4_linear_structural_strain_displacement_matrix.cpp
+++ b/tests/element/structural/2D/quad4/mast_quad4_linear_structural_strain_displacement_matrix.cpp
@@ -1,0 +1,286 @@
+/** 
+ * define below is needed to be able to access the 
+ * initialize_green_lagrange_strain_operator which is protected. Be careful
+ * though as the line belong can cause unexpected issues.
+ */
+#define protected public
+
+#include "catch.hpp"
+
+// libMesh includes
+#include "libmesh/libmesh.h"
+#include "libmesh/replicated_mesh.h"
+#include "libmesh/point.h"
+#include "libmesh/elem.h"
+#include "libmesh/face_quad4.h"
+#include "libmesh/equation_systems.h"
+#include "libmesh/dof_map.h"
+
+// MAST includes
+#include "base/parameter.h"
+#include "base/constant_field_function.h"
+#include "property_cards/isotropic_material_property_card.h"
+#include "property_cards/solid_2d_section_element_property_card.h"
+#include "elasticity/structural_element_2d.h"
+#include "elasticity/structural_system_initialization.h"
+#include "base/physics_discipline_base.h"
+#include "base/nonlinear_implicit_assembly.h"
+#include "elasticity/structural_nonlinear_assembly.h"
+#include "base/nonlinear_system.h"
+#include "elasticity/structural_element_base.h"
+#include "mesh/geom_elem.h"
+#include "mesh/fe_base.h"
+#include "numerics/fem_operator_matrix.h"
+
+
+
+// Custom includes
+#include "test_helpers.h"
+
+#define pi 3.14159265358979323846
+
+extern libMesh::LibMeshInit* p_global_init;
+
+/**
+ * References
+ * ----------
+ * https://studiumbook.com/properties-of-shape-function-fea/
+ * https://www.ccg.msm.cam.ac.uk/images/FEMOR_Lecture_2.pdf
+ */
+TEST_CASE("quad4_linear_structural_strain_displacement_matrix", 
+          "[quad],[quad4],[linear],][structural],[2D],[element]")
+{
+    const int n_elems = 1;
+    const int n_nodes = 4;
+    const uint n_dofs_per_node = 6;
+    
+    // Point Coordinates
+    RealMatrixX temp = RealMatrixX::Zero(3,4);
+    temp << -1.0,  1.0, 1.0, -1.0, 
+            -1.0, -1.0, 1.0,  1.0, 
+             0.0,  0.0, 0.0,  0.0;
+    const RealMatrixX X = temp;
+    
+    /**
+     *  First create the mesh with the one element we are testing.
+     */
+    // Setup the mesh properties
+    libMesh::ReplicatedMesh mesh(p_global_init->comm());
+    mesh.set_mesh_dimension(2);
+    mesh.set_spatial_dimension(2);
+    mesh.reserve_elem(n_elems);
+    mesh.reserve_nodes(n_nodes);
+    
+    // Add nodes to the mesh
+    for (uint i=0; i<n_nodes; i++)
+    {
+        mesh.add_point(libMesh::Point(X(0,i), X(1,i), X(2,i)));
+    }
+    
+    // Add the element to the mesh
+    libMesh::Elem *reference_elem = new libMesh::Quad4;
+    reference_elem->set_id(0);    
+    reference_elem->subdomain_id() = 0;
+    reference_elem = mesh.add_elem(reference_elem);
+    for (int i=0; i<n_nodes; i++)
+    {
+        reference_elem->set_node(i) = mesh.node_ptr(i);
+    }
+    
+    // Prepare the mesh for use
+    mesh.prepare_for_use();
+    //mesh.print_info();
+    
+    const Real elem_volume = reference_elem->volume();
+    // Calculate true volume using 2D shoelace formula
+    Real true_volume = get_shoelace_area(X);
+    
+    // Ensure the libMesh element has the expected volume
+    REQUIRE( elem_volume == true_volume );
+            
+    /**
+     *  Setup the material and section properties to be used in the element
+     */
+    
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
+    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
+    MAST::Parameter kappa("kappa_param", 5.0/6.0);    // Shear coefficient
+    
+    // Define Section Properties as MAST Parameters
+    MAST::Parameter thickness("th_param", 0.06);      // Section thickness
+    MAST::Parameter offset("off_param", 0.03);        // Section offset
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction E_f("E", E);
+    MAST::ConstantFieldFunction nu_f("nu", nu);
+    MAST::ConstantFieldFunction kappa_f("kappa", kappa);
+    MAST::ConstantFieldFunction thickness_f("h", thickness);
+    MAST::ConstantFieldFunction offset_f("off", offset);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(E_f);                                             
+    material.add(nu_f);
+    
+    // Initialize the section
+    MAST::Solid2DSectionElementPropertyCard section;
+    
+    // Add the section property constant field functions to the section card
+    section.add(thickness_f);
+    section.add(offset_f);
+    section.add(kappa_f);
+    
+    // Add the material card to the section card
+    section.set_material(material);
+    
+    
+    // Set the strain type to linear for the section
+    section.set_strain(MAST::LINEAR_STRAIN);
+    
+    /**
+     *  Now we setup the structural system we will be solving.
+     */
+    libMesh::EquationSystems equation_systems(mesh);
+    
+    MAST::NonlinearSystem& system = equation_systems.add_system<MAST::NonlinearSystem>("structural");
+    
+    libMesh::FEType fetype(libMesh::FIRST, libMesh::LAGRANGE);
+    
+    MAST::StructuralSystemInitialization structural_system(system, 
+                                                           system.name(), 
+                                                           fetype);
+    
+    MAST::PhysicsDisciplineBase discipline(equation_systems);
+    
+    discipline.set_property_for_subdomain(0, section);
+    
+    equation_systems.init();
+    //equation_systems.print_info();
+    
+    MAST::NonlinearImplicitAssembly assembly;
+    assembly.set_discipline_and_system(discipline, structural_system);
+    
+    // Create the MAST element from the libMesh reference element
+    MAST::GeomElem geom_elem;
+    geom_elem.init(*reference_elem, structural_system);
+    std::unique_ptr<MAST::StructuralElementBase> elem_base = build_structural_element(structural_system, geom_elem, section);
+    
+    // Cast the base structural element as a 2D structural element
+    MAST::StructuralElement2D* elem = (dynamic_cast<MAST::StructuralElement2D*>(elem_base.get()));
+    
+    // Get element DOFs
+    const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
+    std::vector<libMesh::dof_id_type> dof_indices;
+    dof_map.dof_indices (reference_elem, dof_indices);
+    uint n_dofs = uint(dof_indices.size());
+    
+    // Set element's initial solution and solution sensitivity to zero
+    RealVectorX elem_solution = RealVectorX::Zero(n_dofs);
+    elem->set_solution(elem_solution);
+    elem->set_solution(elem_solution, true);
+    
+    std::unique_ptr<MAST::FEBase> fe(geom_elem.init_fe(true, false, 
+                                     section.extra_quadrature_order(geom_elem)));
+    
+    MAST::FEMOperatorMatrix
+        Bmat_lin,
+        Bmat_nl_x,
+        Bmat_nl_y,
+        Bmat_nl_u,
+        Bmat_nl_v,
+        Bmat_bend,
+        Bmat_vk;
+    
+    const uint n_phi = (unsigned int)fe->get_phi().size();
+    const uint n1 = elem->n_direct_strain_components();
+    const uint n2 = 6*n_phi;
+    const uint n3 = elem->n_von_karman_strain_components();
+    
+    RealMatrixX mat_x = RealMatrixX::Zero(3,2);
+    RealMatrixX mat_y = RealMatrixX::Zero(3,2);
+    
+    RealVectorX strain = RealVectorX::Zero(3);
+    
+    uint qp = 0;
+    
+    /**
+     * elem->initialize_green_lagrange_strain_operator method populates the
+     * Bmat_lin, Bmat_nl_x, Bmat_nl_y, Bmat_nl_u, and Bmat_nl_v matrices.
+     */
+    Bmat_lin.reinit(n1, structural_system.n_vars(), n_phi); // three stress-strain components
+    Bmat_nl_x.reinit(2, structural_system.n_vars(), n_phi);
+    Bmat_nl_y.reinit(2, structural_system.n_vars(), n_phi);
+    Bmat_nl_u.reinit(2, structural_system.n_vars(), n_phi);
+    Bmat_nl_v.reinit(2, structural_system.n_vars(), n_phi);
+    
+    elem->initialize_green_lagrange_strain_operator(qp, *fe, elem_solution,
+        strain, mat_x, mat_y, Bmat_lin, Bmat_nl_x, Bmat_nl_y, Bmat_nl_u,
+        Bmat_nl_v);
+    
+    /**
+     * std::unique_ptr<MAST::BendingOperator2D> bend;
+     * bend->initialize_bending_strain_operator method populates the Bmat_bend
+     * matrix. This part only exists if bending exists in the model.
+     */
+    Bmat_bend.reinit(n1, structural_system.n_vars(), n_phi);
+    
+    /**
+     * elem->initialize_von_karman_strain_operator method populates the Bmat_vk
+     * matrix. This part only exists if bending exists in the model AND 
+     * nonlinear strains exist in the model.
+     */
+    Bmat_vk.reinit(n3, structural_system.n_vars(), n_phi); // only dw/dx and dw/dy
+    
+    
+    const std::vector<std::vector<libMesh::RealVectorValue>>& dphi = fe->get_dphi();
+    
+    SECTION("Linear in-plane strain displacement matrix size")
+    {
+        REQUIRE( Bmat_lin.m() == 3 ); // three strains, e_xx, e_yy, e_xy
+        REQUIRE( Bmat_lin.n() == n_nodes * n_dofs_per_node);
+    }
+    
+    SECTION("Linear in-plane strain displacement matrix values")
+    {
+        // TODO: This requires the vector_mult method be working correctly. Is that ok?
+        
+        // First get a RealMatrixX representation of this matrix
+        uint m = Bmat_lin.m();
+        uint n = Bmat_lin.n();
+        RealMatrixX Bmat_lin_mat = RealMatrixX::Zero(m,n);
+        for (uint i=0; i<n; i++)
+        {
+            RealVectorX Ivec = RealVectorX::Zero(n);
+            RealVectorX result = RealVectorX::Zero(m);
+            Ivec(i) = 1.0;
+            Bmat_lin.vector_mult(result, Ivec);
+            Bmat_lin_mat.col(i) = result;
+        }
+        
+        /**
+         * Now compare the true values to the expected values
+         * 
+         * Expected format for Bmat_lin is...
+         * [dN1dx, dN2dx, dN3dx, dN4dx,   0,     0,     0,     0,   0, ..., 0;
+         *    0,     0,     0,     0,   dN1dy, dN2dy, dN3dy, dN4dy, 0, ..., 0;
+         *  dN1dy, dN2dy, dN3dy, dN4dy, dN1dx, dN2dx, dN3dx, dN4dx, 0, ..., 0]
+         */
+        RealMatrixX Bmat_lin_true = RealMatrixX::Zero(m,n);
+        for (uint i=0; i<n_nodes; i++)
+        {
+            Bmat_lin_true(0,i)          = dphi[i][qp](0);
+            Bmat_lin_true(2,i+n_nodes)  = dphi[i][qp](0);
+            
+            Bmat_lin_true(1,i+n_nodes)  = dphi[i][qp](1);
+            Bmat_lin_true(2,i)          = dphi[i][qp](1);
+        }
+                
+        std::vector<double> Bmat_lin_test =    eigen_matrix_to_std_vector(Bmat_lin_mat);
+        std::vector<double> Bmat_lin_required = eigen_matrix_to_std_vector(Bmat_lin_true);
+        
+        REQUIRE_THAT( Bmat_lin_test, Catch::Approx<double>(Bmat_lin_required) );
+    }
+}

--- a/tests/element/structural/2D/quad4/mast_quad4_structural_shape_functions.cpp
+++ b/tests/element/structural/2D/quad4/mast_quad4_structural_shape_functions.cpp
@@ -1,0 +1,418 @@
+#include "catch.hpp"
+
+// libMesh includes
+#include "libmesh/libmesh.h"
+#include "libmesh/replicated_mesh.h"
+#include "libmesh/point.h"
+#include "libmesh/elem.h"
+#include "libmesh/face_quad4.h"
+#include "libmesh/equation_systems.h"
+#include "libmesh/dof_map.h"
+
+// MAST includes
+#include "base/parameter.h"
+#include "base/constant_field_function.h"
+#include "property_cards/isotropic_material_property_card.h"
+#include "property_cards/solid_2d_section_element_property_card.h"
+#include "elasticity/structural_element_2d.h"
+#include "elasticity/structural_system_initialization.h"
+#include "base/physics_discipline_base.h"
+#include "base/nonlinear_implicit_assembly.h"
+#include "elasticity/structural_nonlinear_assembly.h"
+#include "base/nonlinear_system.h"
+#include "elasticity/structural_element_base.h"
+#include "mesh/geom_elem.h"
+#include "mesh/fe_base.h"
+
+
+// Custom includes
+#include "test_helpers.h"
+
+#define pi 3.14159265358979323846
+
+extern libMesh::LibMeshInit* p_global_init;
+
+/**
+ * References
+ * ----------
+ * https://studiumbook.com/properties-of-shape-function-fea/
+ * https://www.ccg.msm.cam.ac.uk/images/FEMOR_Lecture_2.pdf
+ */
+TEST_CASE("quad4_structural_shape_functions", 
+          "[quad],[quad4],[structural],[2D],[element]")
+{
+    const int n_elems = 1;
+    const int n_nodes = 4;
+    
+    // Point Coordinates
+    RealMatrixX temp = RealMatrixX::Zero(3,4);
+    temp << -1.0,  1.0, 1.0, -1.0, 
+            -1.0, -1.0, 1.0,  1.0, 
+             0.0,  0.0, 0.0,  0.0;
+    const RealMatrixX X = temp;
+    
+    /**
+     *  First create the mesh with the one element we are testing.
+     */
+    // Setup the mesh properties
+    libMesh::ReplicatedMesh mesh(p_global_init->comm());
+    mesh.set_mesh_dimension(2);
+    mesh.set_spatial_dimension(2);
+    mesh.reserve_elem(n_elems);
+    mesh.reserve_nodes(n_nodes);
+    
+    // Add nodes to the mesh
+    for (uint i=0; i<n_nodes; i++)
+    {
+        mesh.add_point(libMesh::Point(X(0,i), X(1,i), X(2,i)));
+    }
+    
+    // Add the element to the mesh
+    libMesh::Elem *reference_elem = new libMesh::Quad4;
+    reference_elem->set_id(0);    
+    reference_elem->subdomain_id() = 0;
+    reference_elem = mesh.add_elem(reference_elem);
+    for (int i=0; i<n_nodes; i++)
+    {
+        reference_elem->set_node(i) = mesh.node_ptr(i);
+    }
+    
+    // Prepare the mesh for use
+    mesh.prepare_for_use();
+    //mesh.print_info();
+    
+    const Real elem_volume = reference_elem->volume();
+    // Calculate true volume using 2D shoelace formula
+    Real true_volume = get_shoelace_area(X);
+    
+    // Ensure the libMesh element has the expected volume
+    REQUIRE( elem_volume == true_volume );
+            
+    /**
+     *  Setup the material and section properties to be used in the element
+     */
+    
+    // Define Material Properties as MAST Parameters
+    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
+    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
+    MAST::Parameter kappa("kappa_param", 5.0/6.0);    // Shear coefficient
+    
+    // Define Section Properties as MAST Parameters
+    MAST::Parameter thickness("th_param", 0.06);      // Section thickness
+    MAST::Parameter offset("off_param", 0.03);        // Section offset
+    
+    // Create field functions to dsitribute these constant parameters throughout the model
+    MAST::ConstantFieldFunction E_f("E", E);
+    MAST::ConstantFieldFunction nu_f("nu", nu);
+    MAST::ConstantFieldFunction kappa_f("kappa", kappa);
+    MAST::ConstantFieldFunction thickness_f("h", thickness);
+    MAST::ConstantFieldFunction offset_f("off", offset);
+    
+    // Initialize the material
+    MAST::IsotropicMaterialPropertyCard material;                   
+    
+    // Add the material property constant field functions to the material card
+    material.add(E_f);                                             
+    material.add(nu_f);
+    
+    // Initialize the section
+    MAST::Solid2DSectionElementPropertyCard section;
+    
+    // Add the section property constant field functions to the section card
+    section.add(thickness_f);
+    section.add(offset_f);
+    section.add(kappa_f);
+    
+    // Add the material card to the section card
+    section.set_material(material);
+    
+    
+    // Set the strain type to linear for the section
+    section.set_strain(MAST::LINEAR_STRAIN);
+    
+    /**
+     *  Now we setup the structural system we will be solving.
+     */
+    libMesh::EquationSystems equation_systems(mesh);
+    
+    MAST::NonlinearSystem& system = equation_systems.add_system<MAST::NonlinearSystem>("structural");
+    
+    libMesh::FEType fetype(libMesh::FIRST, libMesh::LAGRANGE);
+    
+    MAST::StructuralSystemInitialization structural_system(system, 
+                                                           system.name(), 
+                                                           fetype);
+    
+    MAST::PhysicsDisciplineBase discipline(equation_systems);
+    
+    discipline.set_property_for_subdomain(0, section);
+    
+    equation_systems.init();
+    //equation_systems.print_info();
+    
+    MAST::NonlinearImplicitAssembly assembly;
+    assembly.set_discipline_and_system(discipline, structural_system);
+    
+    // Create the MAST element from the libMesh reference element
+    MAST::GeomElem geom_elem;
+    geom_elem.init(*reference_elem, structural_system);
+    std::unique_ptr<MAST::StructuralElementBase> elem_base = build_structural_element(structural_system, geom_elem, section);
+    
+    // Cast the base structural element as a 2D structural element
+    MAST::StructuralElement2D* elem = (dynamic_cast<MAST::StructuralElement2D*>(elem_base.get()));
+    
+    // Get element DOFs
+    const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
+    std::vector<libMesh::dof_id_type> dof_indices;
+    dof_map.dof_indices (reference_elem, dof_indices);
+    uint n_dofs = uint(dof_indices.size());
+    
+    // Set element's initial solution and solution sensitivity to zero
+    RealVectorX elem_solution = RealVectorX::Zero(n_dofs);
+    elem->set_solution(elem_solution);
+    elem->set_solution(elem_solution, true);
+    
+    std::unique_ptr<MAST::FEBase> fe(geom_elem.init_fe(true, false, 
+                                     section.extra_quadrature_order(geom_elem)));
+    
+    
+    SECTION("number of shape functions equal number of nodes")
+    {
+        // Get the shape function values at the quadrature points
+        const std::vector<std::vector<Real>>& phi = fe->get_phi();
+        REQUIRE( phi.size() == n_nodes );
+    }
+    
+    
+    SECTION("shape function summation to one")                   
+    {
+        // Get the shape function values at the quadrature points
+        const std::vector<std::vector<Real>>& phi = fe->get_phi();
+        
+        uint n_qps = phi[0].size();
+        
+        for (uint i=0; i<n_qps; i++) // Iterate Over Quadrature Points
+        {
+            Real phi_j_sum = 0.0;
+            for (uint j=0; j<phi.size(); j++) // Iterative Over Shape Functions
+            {
+                //libMesh::out << "phi[" << j << "][" << i << "] = " << phi[j][i] << std::endl;
+                phi_j_sum += phi[j][i];
+            }
+            REQUIRE( phi_j_sum == Approx(1.0) );
+        }
+    }
+    
+    
+    /**
+     * Shape function value at each node is 1 for the shape function 
+     * associated with that node and zero for all other nodes.
+     */
+    SECTION("shape function value is 1 at shape function's node, zero at other nodes")
+    {
+        // Redfine the points where the shape functions are calculated
+        // Default value is the quadrature points
+        std::vector<libMesh::Point> pts;
+        pts.reserve(n_nodes);
+        for (uint i=0; i<n_nodes; i++)
+        {
+            pts.push_back(libMesh::Point(X(0,i), X(1,i), X(2,i)));
+        }
+        fe->init(geom_elem, true, &pts);  // FIXME: Causing a memory leak here?
+        
+        // Get the shape function values at the node points defined above
+        const std::vector<std::vector<Real>>& phi = fe->get_phi();
+        
+        uint n_qps = phi[0].size();
+        
+        for (uint i=0; i<n_qps; i++) // Iterate Over Node Points
+        {
+            for (uint j=0; j<phi.size(); j++) // Iterative Over Shape Functions
+            {
+                libMesh::out << "phi[" << j << "][" << i << "] = " << phi[j][i] << std::endl;
+                if (i==j)
+                {
+                    REQUIRE( phi[j][i] == Approx(1.0) );
+                }
+                else
+                {
+                    REQUIRE( phi[j][i] == Approx(0.0) );
+                }
+            }
+        }
+    }
+    
+    
+    SECTION("shape function derivative summation to zero")
+    {
+        // Get the shape function derivative values at the quadrature points
+        const std::vector<std::vector<libMesh::RealVectorValue>>& dphi = fe->get_dphi();
+        
+        uint n_qps = dphi[0].size();
+        
+        for (uint i=0; i<n_qps; i++) // Iterate Over Quadrature Points
+        {
+            Real dphi_i_dx_sum = 0.0;
+            Real dphi_i_dy_sum = 0.0;
+            for (uint j=0; j<dphi.size(); j++) // Iterative Over Shape Functions
+            {
+                dphi_i_dx_sum += dphi[j][i](0);
+                dphi_i_dy_sum += dphi[j][i](1);
+            }
+            REQUIRE( dphi_i_dx_sum == Approx(0.0) );
+            REQUIRE( dphi_i_dy_sum == Approx(0.0) );
+        }
+    }
+    
+
+    SECTION("shape function xi derivative finite difference check")
+    {
+        // Get the shape function derivative values at the quadrature points
+        const std::vector<std::vector<libMesh::RealVectorValue>>& dphi = fe->get_dphi();
+        
+        uint n_qps = dphi[0].size();
+        
+        RealMatrixX dphi_dxi_0 = RealMatrixX::Zero(n_nodes, n_qps);
+        RealMatrixX phi_xi_h = RealMatrixX::Zero(n_nodes, n_qps);
+        RealMatrixX phi_xi_n = RealMatrixX::Zero(n_nodes, n_qps);
+        
+        for (uint i=0; i<n_qps; i++)
+        {
+            for (uint j=0; j<n_nodes; j++)
+            {
+                dphi_dxi_0(j,i) = dphi[j][i](0);
+            }
+        }
+        
+        // Get the quadrature points
+        const std::vector<libMesh::Point>& q_pts = fe->get_qpoints();
+        
+        // Shift the Quadrature Points in the xi direction
+        Real delta = 0.0001220703125; // sqrt(sqrt(eps))
+        std::vector<libMesh::Point> pts;
+        pts.reserve(n_nodes);
+        
+        // Shift quadrature points in +xi direction
+        for (uint i=0; i<n_nodes; i++)
+        {
+            pts.push_back(libMesh::Point(q_pts[i](0)+delta, q_pts[i](1), q_pts[i](2)));
+        }
+        fe->init(geom_elem, true, &pts);  // FIXME: Causing a memory leak here?
+        const std::vector<std::vector<Real>>& phi_xih = fe->get_phi();
+        for (uint i=0; i<n_qps; i++)
+        {
+            for (uint j=0; j<n_nodes; j++)
+            {
+                phi_xi_h(j,i) = phi_xih[j][i];
+            }
+        }
+        
+        // Shift quadrature points in -xi direction
+        for (uint i=0; i<n_nodes; i++)
+        {
+            pts[i] = libMesh::Point(q_pts[i](0)-delta, q_pts[i](1), q_pts[i](2));
+        }
+        fe->init(geom_elem, true, &pts);  // FIXME: Causing a memory leak here?
+        const std::vector<std::vector<Real>>& phi_xin = fe->get_phi();
+        for (uint i=0; i<n_qps; i++)
+        {
+            for (uint j=0; j<n_nodes; j++)
+            {
+                phi_xi_n(j,i) = phi_xin[j][i];
+            }
+        }
+        
+        // Calculate second order central difference approximation to dphi_dxi
+        RealMatrixX dphi_dxi_fd = RealMatrixX::Zero(n_nodes, n_qps);
+        for (uint i=0; i<n_qps; i++) // Iterate Over Quadrature Points
+        {
+            for (uint j=0; j<n_nodes; j++) // Iterative Over Shape Functions
+            {
+                dphi_dxi_fd(j,i) = (phi_xi_h(j,i) - phi_xi_n(j,i))/(2.0*delta) ;
+            }
+        }
+        libMesh::out << "dphi_dxi:\n" << dphi_dxi_0 << std::endl;
+        libMesh::out << "dphi_dxi_fd:\n" << dphi_dxi_fd << std::endl;
+        
+        std::vector<double> dPhi_dxi =    eigen_matrix_to_std_vector(dphi_dxi_0);
+        std::vector<double> dPhi_dxi_fd = eigen_matrix_to_std_vector(dphi_dxi_fd);
+        
+        REQUIRE_THAT( dPhi_dxi, Catch::Approx<double>(dPhi_dxi_fd) );
+    }
+    
+    
+    SECTION("shape function eta derivative finite difference check")
+    {
+        // Get the shape function derivative values at the quadrature points
+        const std::vector<std::vector<libMesh::RealVectorValue>>& dphi = fe->get_dphi();
+        
+        uint n_qps = dphi[0].size();
+        
+        RealMatrixX dphi_deta_0 = RealMatrixX::Zero(n_nodes, n_qps);
+        RealMatrixX phi_eta_h = RealMatrixX::Zero(n_nodes, n_qps);
+        RealMatrixX phi_eta_n = RealMatrixX::Zero(n_nodes, n_qps);
+        
+        for (uint i=0; i<n_qps; i++)
+        {
+            for (uint j=0; j<n_nodes; j++)
+            {
+                dphi_deta_0(j,i) = dphi[j][i](1);
+            }
+        }
+        
+        // Get the quadrature points
+        const std::vector<libMesh::Point>& q_pts = fe->get_qpoints();
+        
+        // Shift the Quadrature Points in the xi direction
+        Real delta = 0.0001220703125; // sqrt(sqrt(eps))
+        std::vector<libMesh::Point> pts;
+        pts.reserve(n_nodes);
+        
+        // Shift quadrature points in +eta direction
+        for (uint i=0; i<n_nodes; i++)
+        {
+            pts.push_back(libMesh::Point(q_pts[i](0), q_pts[i](1)+delta, q_pts[i](2)));
+        }
+        fe->init(geom_elem, true, &pts);  // FIXME: Causing a memory leak here?
+        const std::vector<std::vector<Real>>& phi_etah = fe->get_phi();
+        for (uint i=0; i<n_qps; i++)
+        {
+            for (uint j=0; j<n_nodes; j++)
+            {
+                phi_eta_h(j,i) = phi_etah[j][i];
+            }
+        }
+        
+        // Shift quadrature points in -eta direction
+        for (uint i=0; i<n_nodes; i++)
+        {
+            pts[i] = libMesh::Point(q_pts[i](0), q_pts[i](1)-delta, q_pts[i](2));
+        }
+        fe->init(geom_elem, true, &pts);  // FIXME: Causing a memory leak here?
+        const std::vector<std::vector<Real>>& phi_etan = fe->get_phi();
+        for (uint i=0; i<n_qps; i++)
+        {
+            for (uint j=0; j<n_nodes; j++)
+            {
+                phi_eta_n(j,i) = phi_etan[j][i];
+            }
+        }
+        
+        // Calculate second order central difference approximation to dphi_dxi
+        RealMatrixX dphi_deta_fd = RealMatrixX::Zero(n_nodes, n_qps);
+        for (uint i=0; i<n_qps; i++) // Iterate Over Quadrature Points
+        {
+            for (uint j=0; j<n_nodes; j++) // Iterative Over Shape Functions
+            {
+                dphi_deta_fd(j,i) = (phi_eta_h(j,i) - phi_eta_n(j,i))/(2.0*delta) ;
+            }
+        }
+        libMesh::out << "dphi_deta:\n" << dphi_deta_0 << std::endl;
+        libMesh::out << "dphi_deta_fd:\n" << dphi_deta_fd << std::endl;
+        
+        std::vector<double> dPhi_deta =    eigen_matrix_to_std_vector(dphi_deta_0);
+        std::vector<double> dPhi_deta_fd = eigen_matrix_to_std_vector(dphi_deta_fd);
+        
+        REQUIRE_THAT( dPhi_deta, Catch::Approx<double>(dPhi_deta_fd) );
+    }
+}

--- a/tests/element/structural/2D/quad4/mast_quad4_structural_shape_functions.cpp
+++ b/tests/element/structural/2D/quad4/mast_quad4_structural_shape_functions.cpp
@@ -1,3 +1,7 @@
+// NOTE: Be careful with this, it could cause issues.  Needed to access
+// protected members to modify them for finite difference sensitivity check.
+#define protected public
+
 #include "catch.hpp"
 
 // libMesh includes
@@ -218,7 +222,10 @@ TEST_CASE("quad4_structural_shape_functions",
         {
             pts.push_back(libMesh::Point(X(0,i), X(1,i), X(2,i)));
         }
-        fe->init(geom_elem, true, &pts);  // FIXME: Causing a memory leak here?
+        delete fe->_fe;
+        fe->_fe = nullptr;
+        fe->_initialized = false;
+        fe->init(geom_elem, true, &pts);
         
         // Get the shape function values at the node points defined above
         const std::vector<std::vector<Real>>& phi = fe->get_phi();
@@ -229,7 +236,7 @@ TEST_CASE("quad4_structural_shape_functions",
         {
             for (uint j=0; j<phi.size(); j++) // Iterative Over Shape Functions
             {
-                libMesh::out << "phi[" << j << "][" << i << "] = " << phi[j][i] << std::endl;
+                //libMesh::out << "phi[" << j << "][" << i << "] = " << phi[j][i] << std::endl;
                 if (i==j)
                 {
                     REQUIRE( phi[j][i] == Approx(1.0) );
@@ -297,7 +304,10 @@ TEST_CASE("quad4_structural_shape_functions",
         {
             pts.push_back(libMesh::Point(q_pts[i](0)+delta, q_pts[i](1), q_pts[i](2)));
         }
-        fe->init(geom_elem, true, &pts);  // FIXME: Causing a memory leak here?
+        delete fe->_fe;
+        fe->_fe = nullptr;
+        fe->_initialized = false;
+        fe->init(geom_elem, true, &pts);
         const std::vector<std::vector<Real>>& phi_xih = fe->get_phi();
         for (uint i=0; i<n_qps; i++)
         {
@@ -312,7 +322,10 @@ TEST_CASE("quad4_structural_shape_functions",
         {
             pts[i] = libMesh::Point(q_pts[i](0)-delta, q_pts[i](1), q_pts[i](2));
         }
-        fe->init(geom_elem, true, &pts);  // FIXME: Causing a memory leak here?
+        delete fe->_fe;
+        fe->_fe = nullptr;
+        fe->_initialized = false;
+        fe->init(geom_elem, true, &pts);
         const std::vector<std::vector<Real>>& phi_xin = fe->get_phi();
         for (uint i=0; i<n_qps; i++)
         {
@@ -331,8 +344,8 @@ TEST_CASE("quad4_structural_shape_functions",
                 dphi_dxi_fd(j,i) = (phi_xi_h(j,i) - phi_xi_n(j,i))/(2.0*delta) ;
             }
         }
-        libMesh::out << "dphi_dxi:\n" << dphi_dxi_0 << std::endl;
-        libMesh::out << "dphi_dxi_fd:\n" << dphi_dxi_fd << std::endl;
+        //libMesh::out << "dphi_dxi:\n" << dphi_dxi_0 << std::endl;
+        //libMesh::out << "dphi_dxi_fd:\n" << dphi_dxi_fd << std::endl;
         
         std::vector<double> dPhi_dxi =    eigen_matrix_to_std_vector(dphi_dxi_0);
         std::vector<double> dPhi_dxi_fd = eigen_matrix_to_std_vector(dphi_dxi_fd);
@@ -373,7 +386,10 @@ TEST_CASE("quad4_structural_shape_functions",
         {
             pts.push_back(libMesh::Point(q_pts[i](0), q_pts[i](1)+delta, q_pts[i](2)));
         }
-        fe->init(geom_elem, true, &pts);  // FIXME: Causing a memory leak here?
+        delete fe->_fe;
+        fe->_fe = nullptr;
+        fe->_initialized = false;
+        fe->init(geom_elem, true, &pts);
         const std::vector<std::vector<Real>>& phi_etah = fe->get_phi();
         for (uint i=0; i<n_qps; i++)
         {
@@ -388,7 +404,10 @@ TEST_CASE("quad4_structural_shape_functions",
         {
             pts[i] = libMesh::Point(q_pts[i](0), q_pts[i](1)-delta, q_pts[i](2));
         }
-        fe->init(geom_elem, true, &pts);  // FIXME: Causing a memory leak here?
+        delete fe->_fe;
+        fe->_fe = nullptr;
+        fe->_initialized = false;
+        fe->init(geom_elem, true, &pts);
         const std::vector<std::vector<Real>>& phi_etan = fe->get_phi();
         for (uint i=0; i<n_qps; i++)
         {
@@ -407,8 +426,8 @@ TEST_CASE("quad4_structural_shape_functions",
                 dphi_deta_fd(j,i) = (phi_eta_h(j,i) - phi_eta_n(j,i))/(2.0*delta) ;
             }
         }
-        libMesh::out << "dphi_deta:\n" << dphi_deta_0 << std::endl;
-        libMesh::out << "dphi_deta_fd:\n" << dphi_deta_fd << std::endl;
+        //libMesh::out << "dphi_deta:\n" << dphi_deta_0 << std::endl;
+        //libMesh::out << "dphi_deta_fd:\n" << dphi_deta_fd << std::endl;
         
         std::vector<double> dPhi_deta =    eigen_matrix_to_std_vector(dphi_deta_0);
         std::vector<double> dPhi_deta_fd = eigen_matrix_to_std_vector(dphi_deta_fd);

--- a/tests/element/structural/2D/quad4/mast_quad4_structural_shape_functions.cpp
+++ b/tests/element/structural/2D/quad4/mast_quad4_structural_shape_functions.cpp
@@ -1,8 +1,25 @@
+/*
+ * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
+ * Copyright (C) 2013-2020  Manav Bhatia and MAST authors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
 // NOTE: Be careful with this, it could cause issues.  Needed to access
 // protected members to modify them for finite difference sensitivity check.
 #define protected public
-
-#include "catch.hpp"
 
 // libMesh includes
 #include "libmesh/libmesh.h"
@@ -28,11 +45,11 @@
 #include "mesh/geom_elem.h"
 #include "mesh/fe_base.h"
 
-
-// Custom includes
+// Test includes
+#include "catch.hpp"
 #include "test_helpers.h"
+#include "element/structural/2D/mast_structural_element_2d.h"
 
-#define pi 3.14159265358979323846
 
 extern libMesh::LibMeshInit* p_global_init;
 
@@ -45,150 +62,28 @@ extern libMesh::LibMeshInit* p_global_init;
 TEST_CASE("quad4_structural_shape_functions", 
           "[quad],[quad4],[structural],[2D],[element]")
 {
-    const int n_elems = 1;
-    const int n_nodes = 4;
-    
-    // Point Coordinates
-    RealMatrixX temp = RealMatrixX::Zero(3,4);
-    temp << -1.0,  1.0, 1.0, -1.0, 
-            -1.0, -1.0, 1.0,  1.0, 
-             0.0,  0.0, 0.0,  0.0;
-    const RealMatrixX X = temp;
-    
-    /**
-     *  First create the mesh with the one element we are testing.
-     */
-    // Setup the mesh properties
-    libMesh::ReplicatedMesh mesh(p_global_init->comm());
-    mesh.set_mesh_dimension(2);
-    mesh.set_spatial_dimension(2);
-    mesh.reserve_elem(n_elems);
-    mesh.reserve_nodes(n_nodes);
-    
-    // Add nodes to the mesh
-    for (uint i=0; i<n_nodes; i++)
-    {
-        mesh.add_point(libMesh::Point(X(0,i), X(1,i), X(2,i)));
-    }
-    
-    // Add the element to the mesh
-    libMesh::Elem *reference_elem = new libMesh::Quad4;
-    reference_elem->set_id(0);    
-    reference_elem->subdomain_id() = 0;
-    reference_elem = mesh.add_elem(reference_elem);
-    for (int i=0; i<n_nodes; i++)
-    {
-        reference_elem->set_node(i) = mesh.node_ptr(i);
-    }
-    
-    // Prepare the mesh for use
-    mesh.prepare_for_use();
-    //mesh.print_info();
-    
-    const Real elem_volume = reference_elem->volume();
-    // Calculate true volume using 2D shoelace formula
-    Real true_volume = get_shoelace_area(X);
-    
-    // Ensure the libMesh element has the expected volume
-    REQUIRE( elem_volume == true_volume );
-            
-    /**
-     *  Setup the material and section properties to be used in the element
-     */
-    
-    // Define Material Properties as MAST Parameters
-    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
-    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
-    MAST::Parameter kappa("kappa_param", 5.0/6.0);    // Shear coefficient
-    
-    // Define Section Properties as MAST Parameters
-    MAST::Parameter thickness("th_param", 0.06);      // Section thickness
-    MAST::Parameter offset("off_param", 0.03);        // Section offset
-    
-    // Create field functions to dsitribute these constant parameters throughout the model
-    MAST::ConstantFieldFunction E_f("E", E);
-    MAST::ConstantFieldFunction nu_f("nu", nu);
-    MAST::ConstantFieldFunction kappa_f("kappa", kappa);
-    MAST::ConstantFieldFunction thickness_f("h", thickness);
-    MAST::ConstantFieldFunction offset_f("off", offset);
-    
-    // Initialize the material
-    MAST::IsotropicMaterialPropertyCard material;                   
-    
-    // Add the material property constant field functions to the material card
-    material.add(E_f);                                             
-    material.add(nu_f);
-    
-    // Initialize the section
-    MAST::Solid2DSectionElementPropertyCard section;
-    
-    // Add the section property constant field functions to the section card
-    section.add(thickness_f);
-    section.add(offset_f);
-    section.add(kappa_f);
-    
-    // Add the material card to the section card
-    section.set_material(material);
-    
-    
+    RealMatrixX coords = RealMatrixX::Zero(3,4);
+    coords << -1.0,  1.0, 1.0, -1.0,
+              -1.0, -1.0, 1.0,  1.0,
+               0.0,  0.0, 0.0,  0.0;
+    TEST::TestStructuralSingleElement2D test_elem(libMesh::QUAD4, coords);
+
+    const Real V0 = test_elem.reference_elem->volume();
+    REQUIRE(test_elem.reference_elem->volume() == TEST::get_shoelace_area(coords));
+
     // Set the strain type to linear for the section
-    section.set_strain(MAST::LINEAR_STRAIN);
+    test_elem.section.set_strain(MAST::LINEAR_STRAIN);
+
+    std::unique_ptr<MAST::FEBase> fe(test_elem.geom_elem.init_fe(true, false,
+            test_elem.section.extra_quadrature_order(test_elem.geom_elem)));
     
-    /**
-     *  Now we setup the structural system we will be solving.
-     */
-    libMesh::EquationSystems equation_systems(mesh);
-    
-    MAST::NonlinearSystem& system = equation_systems.add_system<MAST::NonlinearSystem>("structural");
-    
-    libMesh::FEType fetype(libMesh::FIRST, libMesh::LAGRANGE);
-    
-    MAST::StructuralSystemInitialization structural_system(system, 
-                                                           system.name(), 
-                                                           fetype);
-    
-    MAST::PhysicsDisciplineBase discipline(equation_systems);
-    
-    discipline.set_property_for_subdomain(0, section);
-    
-    equation_systems.init();
-    //equation_systems.print_info();
-    
-    MAST::NonlinearImplicitAssembly assembly;
-    assembly.set_discipline_and_system(discipline, structural_system);
-    
-    // Create the MAST element from the libMesh reference element
-    MAST::GeomElem geom_elem;
-    geom_elem.init(*reference_elem, structural_system);
-    std::unique_ptr<MAST::StructuralElementBase> elem_base = build_structural_element(structural_system, geom_elem, section);
-    
-    // Cast the base structural element as a 2D structural element
-    MAST::StructuralElement2D* elem = (dynamic_cast<MAST::StructuralElement2D*>(elem_base.get()));
-    
-    // Get element DOFs
-    const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
-    std::vector<libMesh::dof_id_type> dof_indices;
-    dof_map.dof_indices (reference_elem, dof_indices);
-    uint n_dofs = uint(dof_indices.size());
-    
-    // Set element's initial solution and solution sensitivity to zero
-    RealVectorX elem_solution = RealVectorX::Zero(n_dofs);
-    elem->set_solution(elem_solution);
-    elem->set_solution(elem_solution, true);
-    
-    std::unique_ptr<MAST::FEBase> fe(geom_elem.init_fe(true, false, 
-                                     section.extra_quadrature_order(geom_elem)));
-    
-    
-    SECTION("number of shape functions equal number of nodes")
+    SECTION("Number of shape functions equal number of nodes")
     {
-        // Get the shape function values at the quadrature points
-        const std::vector<std::vector<Real>>& phi = fe->get_phi();
-        REQUIRE( phi.size() == n_nodes );
+        REQUIRE(fe->get_phi().size() == test_elem.n_nodes);
     }
-    
-    
-    SECTION("shape function summation to one")                   
+
+
+    SECTION("Shape functions sum to one at quadrature points")
     {
         // Get the shape function values at the quadrature points
         const std::vector<std::vector<Real>>& phi = fe->get_phi();
@@ -203,35 +98,31 @@ TEST_CASE("quad4_structural_shape_functions",
                 //libMesh::out << "phi[" << j << "][" << i << "] = " << phi[j][i] << std::endl;
                 phi_j_sum += phi[j][i];
             }
-            REQUIRE( phi_j_sum == Approx(1.0) );
+            REQUIRE(phi_j_sum == Approx(1.0));
         }
     }
-    
-    
-    /**
-     * Shape function value at each node is 1 for the shape function 
-     * associated with that node and zero for all other nodes.
-     */
-    SECTION("shape function value is 1 at shape function's node, zero at other nodes")
+
+
+    SECTION("Shape function value is 1 at it's node and zero at other nodes")
     {
         // Redfine the points where the shape functions are calculated
         // Default value is the quadrature points
         std::vector<libMesh::Point> pts;
-        pts.reserve(n_nodes);
-        for (uint i=0; i<n_nodes; i++)
+        pts.reserve(test_elem.n_nodes);
+        for (uint i=0; i<test_elem.n_nodes; i++)
         {
-            pts.push_back(libMesh::Point(X(0,i), X(1,i), X(2,i)));
+            pts.push_back(libMesh::Point(coords(0,i), coords(1,i), coords(2,i)));
         }
         delete fe->_fe;
         fe->_fe = nullptr;
         fe->_initialized = false;
-        fe->init(geom_elem, true, &pts);
-        
+        fe->init(test_elem.geom_elem, true, &pts);
+
         // Get the shape function values at the node points defined above
         const std::vector<std::vector<Real>>& phi = fe->get_phi();
-        
+
         uint n_qps = phi[0].size();
-        
+
         for (uint i=0; i<n_qps; i++) // Iterate Over Node Points
         {
             for (uint j=0; j<phi.size(); j++) // Iterative Over Shape Functions
@@ -239,24 +130,24 @@ TEST_CASE("quad4_structural_shape_functions",
                 //libMesh::out << "phi[" << j << "][" << i << "] = " << phi[j][i] << std::endl;
                 if (i==j)
                 {
-                    REQUIRE( phi[j][i] == Approx(1.0) );
+                    REQUIRE(phi[j][i] == Approx(1.0));
                 }
                 else
                 {
-                    REQUIRE( phi[j][i] == Approx(0.0) );
+                    REQUIRE(phi[j][i] == Approx(0.0));
                 }
             }
         }
     }
-    
-    
-    SECTION("shape function derivative summation to zero")
+
+
+    SECTION("Shape function derivatives sum to zero at quadrature points")
     {
         // Get the shape function derivative values at the quadrature points
         const std::vector<std::vector<libMesh::RealVectorValue>>& dphi = fe->get_dphi();
-        
+
         uint n_qps = dphi[0].size();
-        
+
         for (uint i=0; i<n_qps; i++) // Iterate Over Quadrature Points
         {
             Real dphi_i_dx_sum = 0.0;
@@ -266,172 +157,172 @@ TEST_CASE("quad4_structural_shape_functions",
                 dphi_i_dx_sum += dphi[j][i](0);
                 dphi_i_dy_sum += dphi[j][i](1);
             }
-            REQUIRE( dphi_i_dx_sum == Approx(0.0) );
-            REQUIRE( dphi_i_dy_sum == Approx(0.0) );
+            REQUIRE(dphi_i_dx_sum == Approx(0.0));
+            REQUIRE(dphi_i_dy_sum == Approx(0.0));
         }
     }
-    
 
-    SECTION("shape function xi derivative finite difference check")
+
+    SECTION("Shape function xi derivative finite difference check")
     {
         // Get the shape function derivative values at the quadrature points
         const std::vector<std::vector<libMesh::RealVectorValue>>& dphi = fe->get_dphi();
-        
+
         uint n_qps = dphi[0].size();
-        
-        RealMatrixX dphi_dxi_0 = RealMatrixX::Zero(n_nodes, n_qps);
-        RealMatrixX phi_xi_h = RealMatrixX::Zero(n_nodes, n_qps);
-        RealMatrixX phi_xi_n = RealMatrixX::Zero(n_nodes, n_qps);
-        
+
+        RealMatrixX dphi_dxi_0 = RealMatrixX::Zero(test_elem.n_nodes, n_qps);
+        RealMatrixX phi_xi_h = RealMatrixX::Zero(test_elem.n_nodes, n_qps);
+        RealMatrixX phi_xi_n = RealMatrixX::Zero(test_elem.n_nodes, n_qps);
+
         for (uint i=0; i<n_qps; i++)
         {
-            for (uint j=0; j<n_nodes; j++)
+            for (uint j=0; j<test_elem.n_nodes; j++)
             {
                 dphi_dxi_0(j,i) = dphi[j][i](0);
             }
         }
-        
+
         // Get the quadrature points
         const std::vector<libMesh::Point>& q_pts = fe->get_qpoints();
-        
+
         // Shift the Quadrature Points in the xi direction
         Real delta = 0.0001220703125; // sqrt(sqrt(eps))
         std::vector<libMesh::Point> pts;
-        pts.reserve(n_nodes);
-        
+        pts.reserve(test_elem.n_nodes);
+
         // Shift quadrature points in +xi direction
-        for (uint i=0; i<n_nodes; i++)
+        for (uint i=0; i<test_elem.n_nodes; i++)
         {
             pts.push_back(libMesh::Point(q_pts[i](0)+delta, q_pts[i](1), q_pts[i](2)));
         }
         delete fe->_fe;
         fe->_fe = nullptr;
         fe->_initialized = false;
-        fe->init(geom_elem, true, &pts);
+        fe->init(test_elem.geom_elem, true, &pts);
         const std::vector<std::vector<Real>>& phi_xih = fe->get_phi();
         for (uint i=0; i<n_qps; i++)
         {
-            for (uint j=0; j<n_nodes; j++)
+            for (uint j=0; j<test_elem.n_nodes; j++)
             {
                 phi_xi_h(j,i) = phi_xih[j][i];
             }
         }
-        
+
         // Shift quadrature points in -xi direction
-        for (uint i=0; i<n_nodes; i++)
+        for (uint i=0; i<test_elem.n_nodes; i++)
         {
             pts[i] = libMesh::Point(q_pts[i](0)-delta, q_pts[i](1), q_pts[i](2));
         }
         delete fe->_fe;
         fe->_fe = nullptr;
         fe->_initialized = false;
-        fe->init(geom_elem, true, &pts);
+        fe->init(test_elem.geom_elem, true, &pts);
         const std::vector<std::vector<Real>>& phi_xin = fe->get_phi();
         for (uint i=0; i<n_qps; i++)
         {
-            for (uint j=0; j<n_nodes; j++)
+            for (uint j=0; j<test_elem.n_nodes; j++)
             {
                 phi_xi_n(j,i) = phi_xin[j][i];
             }
         }
-        
+
         // Calculate second order central difference approximation to dphi_dxi
-        RealMatrixX dphi_dxi_fd = RealMatrixX::Zero(n_nodes, n_qps);
+        RealMatrixX dphi_dxi_fd = RealMatrixX::Zero(test_elem.n_nodes, n_qps);
         for (uint i=0; i<n_qps; i++) // Iterate Over Quadrature Points
         {
-            for (uint j=0; j<n_nodes; j++) // Iterative Over Shape Functions
+            for (uint j=0; j<test_elem.n_nodes; j++) // Iterative Over Shape Functions
             {
                 dphi_dxi_fd(j,i) = (phi_xi_h(j,i) - phi_xi_n(j,i))/(2.0*delta) ;
             }
         }
         //libMesh::out << "dphi_dxi:\n" << dphi_dxi_0 << std::endl;
         //libMesh::out << "dphi_dxi_fd:\n" << dphi_dxi_fd << std::endl;
-        
-        std::vector<double> dPhi_dxi =    eigen_matrix_to_std_vector(dphi_dxi_0);
-        std::vector<double> dPhi_dxi_fd = eigen_matrix_to_std_vector(dphi_dxi_fd);
-        
+
+        std::vector<double> dPhi_dxi =    TEST::eigen_matrix_to_std_vector(dphi_dxi_0);
+        std::vector<double> dPhi_dxi_fd = TEST::eigen_matrix_to_std_vector(dphi_dxi_fd);
+
         REQUIRE_THAT( dPhi_dxi, Catch::Approx<double>(dPhi_dxi_fd) );
     }
-    
-    
-    SECTION("shape function eta derivative finite difference check")
+
+
+    SECTION("Shape function eta derivative finite difference check")
     {
         // Get the shape function derivative values at the quadrature points
         const std::vector<std::vector<libMesh::RealVectorValue>>& dphi = fe->get_dphi();
-        
+
         uint n_qps = dphi[0].size();
-        
-        RealMatrixX dphi_deta_0 = RealMatrixX::Zero(n_nodes, n_qps);
-        RealMatrixX phi_eta_h = RealMatrixX::Zero(n_nodes, n_qps);
-        RealMatrixX phi_eta_n = RealMatrixX::Zero(n_nodes, n_qps);
-        
+
+        RealMatrixX dphi_deta_0 = RealMatrixX::Zero(test_elem.n_nodes, n_qps);
+        RealMatrixX phi_eta_h = RealMatrixX::Zero(test_elem.n_nodes, n_qps);
+        RealMatrixX phi_eta_n = RealMatrixX::Zero(test_elem.n_nodes, n_qps);
+
         for (uint i=0; i<n_qps; i++)
         {
-            for (uint j=0; j<n_nodes; j++)
+            for (uint j=0; j<test_elem.n_nodes; j++)
             {
                 dphi_deta_0(j,i) = dphi[j][i](1);
             }
         }
-        
+
         // Get the quadrature points
         const std::vector<libMesh::Point>& q_pts = fe->get_qpoints();
-        
+
         // Shift the Quadrature Points in the xi direction
         Real delta = 0.0001220703125; // sqrt(sqrt(eps))
         std::vector<libMesh::Point> pts;
-        pts.reserve(n_nodes);
-        
+        pts.reserve(test_elem.n_nodes);
+
         // Shift quadrature points in +eta direction
-        for (uint i=0; i<n_nodes; i++)
+        for (uint i=0; i<test_elem.n_nodes; i++)
         {
             pts.push_back(libMesh::Point(q_pts[i](0), q_pts[i](1)+delta, q_pts[i](2)));
         }
         delete fe->_fe;
         fe->_fe = nullptr;
         fe->_initialized = false;
-        fe->init(geom_elem, true, &pts);
+        fe->init(test_elem.geom_elem, true, &pts);
         const std::vector<std::vector<Real>>& phi_etah = fe->get_phi();
         for (uint i=0; i<n_qps; i++)
         {
-            for (uint j=0; j<n_nodes; j++)
+            for (uint j=0; j<test_elem.n_nodes; j++)
             {
                 phi_eta_h(j,i) = phi_etah[j][i];
             }
         }
-        
+
         // Shift quadrature points in -eta direction
-        for (uint i=0; i<n_nodes; i++)
+        for (uint i=0; i<test_elem.n_nodes; i++)
         {
             pts[i] = libMesh::Point(q_pts[i](0), q_pts[i](1)-delta, q_pts[i](2));
         }
         delete fe->_fe;
         fe->_fe = nullptr;
         fe->_initialized = false;
-        fe->init(geom_elem, true, &pts);
+        fe->init(test_elem.geom_elem, true, &pts);
         const std::vector<std::vector<Real>>& phi_etan = fe->get_phi();
         for (uint i=0; i<n_qps; i++)
         {
-            for (uint j=0; j<n_nodes; j++)
+            for (uint j=0; j<test_elem.n_nodes; j++)
             {
                 phi_eta_n(j,i) = phi_etan[j][i];
             }
         }
-        
+
         // Calculate second order central difference approximation to dphi_dxi
-        RealMatrixX dphi_deta_fd = RealMatrixX::Zero(n_nodes, n_qps);
+        RealMatrixX dphi_deta_fd = RealMatrixX::Zero(test_elem.n_nodes, n_qps);
         for (uint i=0; i<n_qps; i++) // Iterate Over Quadrature Points
         {
-            for (uint j=0; j<n_nodes; j++) // Iterative Over Shape Functions
+            for (uint j=0; j<test_elem.n_nodes; j++) // Iterative Over Shape Functions
             {
                 dphi_deta_fd(j,i) = (phi_eta_h(j,i) - phi_eta_n(j,i))/(2.0*delta) ;
             }
         }
         //libMesh::out << "dphi_deta:\n" << dphi_deta_0 << std::endl;
         //libMesh::out << "dphi_deta_fd:\n" << dphi_deta_fd << std::endl;
-        
-        std::vector<double> dPhi_deta =    eigen_matrix_to_std_vector(dphi_deta_0);
-        std::vector<double> dPhi_deta_fd = eigen_matrix_to_std_vector(dphi_deta_fd);
-        
+
+        std::vector<double> dPhi_deta =    TEST::eigen_matrix_to_std_vector(dphi_deta_0);
+        std::vector<double> dPhi_deta_fd = TEST::eigen_matrix_to_std_vector(dphi_deta_fd);
+
         REQUIRE_THAT( dPhi_deta, Catch::Approx<double>(dPhi_deta_fd) );
     }
 }

--- a/tests/element/structural/CMakeLists.txt
+++ b/tests/element/structural/CMakeLists.txt
@@ -1,2 +1,3 @@
-#add_subdirectory(2D)
 add_subdirectory(1D)
+add_subdirectory(2D)
+


### PR DESCRIPTION
This PR *completes* the chain of additions of Catch2 tests (#60, #70, #79) for existing MAST library capability that was originally primarily implemented by @JohnDN90. The additions here are related to 2D structural elements.

Below is a checklist of commits implemented by @JohnDN90 in his `add_catch2_tests` branch the whose contents/functionality need rolled in. The checklist ones will be covered in this PR:
- Added catch2 header file for upcoming new tests. (#60)
- Bug fixes and enhancements to CMake files. (#60)
- Added option to use libmesh_devel (development) version. (#60)
- Added catch2 tests for some MAST base functions. (#60)
- Added catch2 test for TEMPERATURE boundary condition. (#70)
- Added catch2 tests for mast_boundary_condition_base (#70)
- Removed shear coefficient (kappa) from isotropic material. Added plane strain support to isotropic material. (#60)
- Added catch2 tests for mast_isotropic_material. (#60)
- Multiple changes to orthotropic material, including added plane strain support. (#60)
- Added catch2 tests for orthotropic_material_property_card. (#60)
- Moved shear coefficient (kappa) to 2D section card and added overloaded functions to 2D section card. (#60)
- Added catch2 tests for solid_2d_section_element_property_card. (#70)
- Added overloaded functions to isotropic 3D section property card. (#70)
- Added catch2 tests for isotropic_element_property_card_3D. (#70)
- Added new public release statement to README. (addressing later)
- Add overloaded functions to solid_1d_section_element_property_card. (#70)
- Formatting for README.md (addressing later)
- Multiple changes to 1d_solid_section_element_property_card. (#70)
- Added catch2 tests for solid_1d_section_element_property_card. (#70)
- Added basic catch2 tests for generic 1D structural elements. (#79)
- Fixed bug in GitHub Issue #41 where NO_BENDING incorrectly called TIMOSHENKO. (#79)
- Added catch2 tests for 1D structural element with extension and torsion. (#79)
- Fixed bug in GitHub issue #43, where incorrect I value was being used for bending about y-axis. (#75)
- Added many for tests for 1D structural 2-noded (edge2) element. (#79)
- [x] Added generic catch2 tests for 2D structrual elements. (THIS PR)
- [x] Added many catch2 tests for 4-node quadrilaterial 2D element (quad4). (THIS PR)
- UPDATE EXAMPLES MOVING KAPPA FROM MATERIAL TO SECTION CARD (#60)
- [x] Fixed bugs in catch2 tests which caused some to fail when run with a debug version of MAST. (#79, completed in this PR)
- Necessary tweak to tests for zero and negative eigenvalues. (#79)