### PR TITLE
Refactor 1D tests to reduce repetitive code

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -790,7 +790,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = @CMAKE_SOURCE_DIR@/doc @CMAKE_SOURCE_DIR@/src
+INPUT                  = @CMAKE_SOURCE_DIR@/doc @CMAKE_SOURCE_DIR@/src @CMAKE_SOURCE_DIR@/tests
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/tests/base/mast_mesh.cpp
+++ b/tests/base/mast_mesh.cpp
@@ -17,70 +17,27 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+// MAST includes
+#include "base/mast_data_types.h"
 #include "catch.hpp"
 
-// libMesh includes
-#include "libmesh/libmesh.h"
-#include "libmesh/replicated_mesh.h"
-#include "libmesh/distributed_mesh.h"
-#include "libmesh/face_quad4.h"
-#include "libmesh/edge_edge2.h"
-
-// Custom includes
+// Test includes
 #include "test_helpers.h"
+#include "base/mast_mesh.h"
 
-extern libMesh::LibMeshInit* p_global_init;
 
 TEST_CASE("libmesh_mesh_generation_1d",
           "[mesh][1D]")
 {
-    const int n_elems = 1;
-    const int n_nodes = 2;
-    const int n_dim = 1;
-    
-    RealMatrixX temp = RealMatrixX::Zero(3,n_nodes);
-    temp << -1.0, 1.0, 0.0, 0.0, 0.0, 0.0;
-    const RealMatrixX X = temp;
-    
+    RealMatrixX coords = RealMatrixX::Zero(3, 2);
+    coords << -1.0, 1.0, 0.0,
+               0.0, 0.0, 0.0;
+
     SECTION("replicated_mesh_1d")
     {
-        /**
-        *  First create the mesh with the one element we are testing.
-        */
-        // Setup the mesh properties
-        libMesh::ReplicatedMesh mesh(p_global_init->comm());
-        mesh.set_mesh_dimension(n_dim);
-        mesh.set_spatial_dimension(n_dim);
-        mesh.reserve_elem(n_elems);
-        mesh.reserve_nodes(n_nodes);
-        
-        // Add nodes to the mesh
-        for (uint i=0; i<n_nodes; i++)
-        {
-            mesh.add_point(libMesh::Point(X(0,i), X(1,i), X(2,i)));
-        }
-        
-        // Add the element to the mesh
-        libMesh::Elem *reference_elem = new libMesh::Edge2;
-        reference_elem->set_id(0);    
-        reference_elem->subdomain_id() = 0;
-        reference_elem = mesh.add_elem(reference_elem);
-        for (int i=0; i<n_nodes; i++)
-        {
-            reference_elem->set_node(i) = mesh.node_ptr(i);
-        }
-        
-        // Prepare the mesh for use
-        mesh.prepare_for_use();
-        
-        // Get the volume calculated by libMesh (actually length for 1D elements)
-        const Real elem_volume = reference_elem->volume();
-        
-        // Set the true length
-        const Real true_volume = 2.0;
-        
-        // Ensure the libMesh element has the expected volume
-        REQUIRE( elem_volume == true_volume );
+        TEST::TestMeshSingleElement test_mesh(libMesh::EDGE2, coords);
+        // Compare element against true volume (actually length for 1D elements)
+        REQUIRE(test_mesh.reference_elem->volume() == 2.0);
     }
 }
 
@@ -88,57 +45,20 @@ TEST_CASE("libmesh_mesh_generation_1d",
 TEST_CASE("libmesh_mesh_generation_2d",
           "[mesh],[2D]")
 {
-    const int n_elems = 1;
-    const int n_nodes = 4;
-    const int n_dim = 2;
-    
-    // Point Coordinates
-    RealMatrixX temp = RealMatrixX::Zero(3,4);
-    temp << -1.0,  1.0, 1.0, -1.0, 
-            -1.0, -1.0, 1.0,  1.0, 
-             0.0,  0.0, 0.0,  0.0;
-    const RealMatrixX X = temp;
-    
-    SECTION("replicated_mesh")
+    RealMatrixX coords = RealMatrixX::Zero(3,4);
+    coords << -1.0,  1.0, 1.0, -1.0,
+              -1.0, -1.0, 1.0,  1.0,
+               0.0,  0.0, 0.0,  0.0;
+
+    SECTION("replicated_mesh_2d")
     {
-        /**
-        *  First create the mesh with the one element we are testing.
-        */
-        // Setup the mesh properties
-        libMesh::ReplicatedMesh mesh(p_global_init->comm());
-        mesh.set_mesh_dimension(n_dim);
-        mesh.set_spatial_dimension(n_dim);
-        mesh.reserve_elem(n_elems);
-        mesh.reserve_nodes(n_nodes);
-        
-        // Add nodes to the mesh
-        for (uint i=0; i<n_nodes; i++)
-        {
-            mesh.add_point(libMesh::Point(X(0,i), X(1,i), X(2,i)));
-        }
-        
-        // Add the element to the mesh
-        libMesh::Elem *reference_elem = new libMesh::Quad4;
-        reference_elem->set_id(0);    
-        reference_elem->subdomain_id() = 0;
-        reference_elem = mesh.add_elem(reference_elem);
-        for (int i=0; i<n_nodes; i++)
-        {
-            reference_elem->set_node(i) = mesh.node_ptr(i);
-        }
-        
-        // Prepare the mesh for use
-        mesh.prepare_for_use();
-        
-        // Get the volume calculated by libMesh (actually area for 2D elements)
-        const Real elem_volume = reference_elem->volume();
-        
-        // Calculate true area using 2D shoelace formula
-        const Real true_volume = get_shoelace_area(X);
-        
-        // Ensure the libMesh element has the expected volume
-        REQUIRE( elem_volume == true_volume );
+        TEST::TestMeshSingleElement test_mesh(libMesh::QUAD4, coords);
+        // Compare element against true volume (actually area for 2D elements)
+        const Real true_volume = TEST::get_shoelace_area(coords);
+        REQUIRE(test_mesh.reference_elem->volume() == true_volume);
     }
     
-   // TODO Need to test distributed mesh generation as well
+   // TODO Need to test distributed mesh generation as well.
+   //   Note this will require some special consideration to account for actual
+   //   parallel nature of the mesh.
 }

--- a/tests/base/mast_mesh.h
+++ b/tests/base/mast_mesh.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 #ifndef __test__mast_mesh__
@@ -22,7 +22,6 @@
 
 // MAST includes
 #include "base/mast_data_types.h"
-#include "catch.hpp"
 
 // libMesh includes
 #include "libmesh/libmesh.h"
@@ -32,6 +31,7 @@
 #include "libmesh/edge_edge2.h"
 
 // Test includes
+#include "catch.hpp"
 #include "test_helpers.h"
 
 extern libMesh::LibMeshInit* p_global_init;
@@ -50,7 +50,7 @@ namespace TEST {
         // ---> currently can't run this with DistributedMesh. On second processor this.reference_elem doesn't exist!
 
         TestMeshSingleElement(libMesh::ElemType e_type, RealMatrixX& coordinates):
-                mesh(p_global_init->comm()) {
+            mesh(p_global_init->comm()) {
             n_elems = 1;
             n_nodes = coordinates.cols();
 
@@ -86,6 +86,13 @@ namespace TEST {
             }
 
             mesh.prepare_for_use();
+        };
+
+        void update_coordinates(RealMatrixX& new_coordinates) {
+            for (int i=0; i<n_nodes; i++)
+            {
+                *mesh.node_ptr(i) = libMesh::Point(new_coordinates(0,i), new_coordinates(1,i), new_coordinates(2,i));
+            }
         };
     };
 } // TEST namespace

--- a/tests/base/mast_mesh.h
+++ b/tests/base/mast_mesh.h
@@ -1,0 +1,93 @@
+/*
+ * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
+ * Copyright (C) 2013-2020  Manav Bhatia and MAST authors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef __test__mast_mesh__
+#define __test__mast_mesh__
+
+// MAST includes
+#include "base/mast_data_types.h"
+#include "catch.hpp"
+
+// libMesh includes
+#include "libmesh/libmesh.h"
+#include "libmesh/replicated_mesh.h"
+#include "libmesh/distributed_mesh.h"
+#include "libmesh/face_quad4.h"
+#include "libmesh/edge_edge2.h"
+
+// Test includes
+#include "test_helpers.h"
+
+extern libMesh::LibMeshInit* p_global_init;
+
+namespace TEST {
+
+    class TestMeshSingleElement {
+    public:
+        int n_elems;
+        int n_nodes;
+        int n_dim;
+        libMesh::Elem* reference_elem;
+        libMesh::ReplicatedMesh mesh;
+        // Convert this to pointer to enable both Replicated/Distributed Mesh
+        // libMesh::UnstructuredMesh* mesh;
+        // ---> currently can't run this with DistributedMesh. On second processor this.reference_elem doesn't exist!
+
+        TestMeshSingleElement(libMesh::ElemType e_type, RealMatrixX& coordinates):
+                mesh(p_global_init->comm()) {
+            n_elems = 1;
+            n_nodes = coordinates.cols();
+
+            mesh.reserve_elem(n_elems);
+            mesh.reserve_nodes(n_nodes);
+            mesh.set_spatial_dimension(3);
+
+            for (auto i = 0; i < n_nodes; i++) {
+                mesh.add_point(libMesh::Point(coordinates(0,i),coordinates(1,i), coordinates(2,i)), i, 0);
+            }
+
+            switch (e_type) {
+                case libMesh::EDGE2:
+                    n_dim = 1;
+                    reference_elem = new libMesh::Edge2;
+                    break;
+                case libMesh::QUAD4:
+                    n_dim = 2;
+                    reference_elem = new libMesh::Quad4;
+                    break;
+                default:
+                    libmesh_error_msg("Invalid element type; " << __PRETTY_FUNCTION__
+                                                               << " in " << __FILE__ << " at line number " << __LINE__);
+            }
+
+            mesh.set_mesh_dimension(n_dim);
+            reference_elem->set_id(0);
+            reference_elem->subdomain_id() = 0;
+            reference_elem = mesh.add_elem(reference_elem);
+
+            for (int i=0; i<n_nodes; i++) {
+                reference_elem->set_node(i) = mesh.node_ptr(i);
+            }
+
+            mesh.prepare_for_use();
+        };
+    };
+} // TEST namespace
+
+#endif // __test__mast_mesh__

--- a/tests/element/structural/1D/edge2/mast_edge2_linear_structural_extension_bending_coupling_internal_jacobian.cpp
+++ b/tests/element/structural/1D/edge2/mast_edge2_linear_structural_extension_bending_coupling_internal_jacobian.cpp
@@ -1,16 +1,25 @@
-// C++ Stanard Includes
-#include <math.h>
-
-// Catch2 includes
-#include "catch.hpp"
+/*
+ * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
+ * Copyright (C) 2013-2020  Manav Bhatia and MAST authors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
 
 // libMesh includes
 #include "libmesh/libmesh.h"
-#include "libmesh/replicated_mesh.h"
-#include "libmesh/point.h"
 #include "libmesh/elem.h"
-#include "libmesh/edge_edge2.h"
-#include "libmesh/equation_systems.h"
 #include "libmesh/dof_map.h"
 
 // MAST includes
@@ -20,15 +29,15 @@
 #include "property_cards/solid_1d_section_element_property_card.h"
 #include "elasticity/structural_element_1d.h"
 #include "elasticity/structural_system_initialization.h"
-#include "base/physics_discipline_base.h"
 #include "base/nonlinear_implicit_assembly.h"
 #include "elasticity/structural_nonlinear_assembly.h"
 #include "base/nonlinear_system.h"
-#include "elasticity/structural_element_base.h"
 #include "mesh/geom_elem.h"
 
-// Custom includes
+// Test includes
+#include "catch.hpp"
 #include "test_helpers.h"
+#include "element/structural/1D/mast_structural_element_1d.h"
 
 #define pi 3.14159265358979323846
 
@@ -38,228 +47,53 @@ extern libMesh::LibMeshInit* p_global_init;
 TEST_CASE("edge2_linear_extension_bending_coupling_structural",
           "[1D],[structural],[edge],[edge2],[linear]")
 {
-    const int n_elems = 1;
-    const int n_nodes = 2;
-    
-    RealMatrixX temp = RealMatrixX::Zero(3,n_nodes);
-    temp << -1.0, 1.0, 0.0, 0.0, 0.0, 0.0;
-    const RealMatrixX X0 = temp;
-    
-    /**
-     * Create the mesh with the one element we are testing
-     */
-    libMesh::ReplicatedMesh mesh(p_global_init->comm());
-    mesh.set_mesh_dimension(1);
-    mesh.set_spatial_dimension(3);
-    mesh.reserve_elem(n_elems);
-    mesh.reserve_nodes(n_nodes);
-    
-    // Add nodes to the mesh
-    for (uint i=0; i<n_nodes; i++)
-    {
-        mesh.add_point(libMesh::Point(X0(0,i), X0(1,i), X0(2,i)));
-    }
-    
-    // Add the element to the mesh
-    libMesh::Elem *reference_elem = new libMesh::Edge2;
-    reference_elem->set_id(0);    
-    reference_elem->subdomain_id() = 0;
-    reference_elem = mesh.add_elem(reference_elem);
-    for (int i=0; i<n_nodes; i++)
-    {
-        reference_elem->set_node(i) = mesh.node_ptr(i);
-    }
-    
-    // Prepare the mesh for use
-    mesh.prepare_for_use();
-    
-    // Ensure the libMesh element has the expected volume
-    const Real elem_volume = reference_elem->volume();
-    Real true_volume = 2.0;
-    REQUIRE( elem_volume == true_volume );
-    
-    // Define Material Properties as MAST Parameters
-    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
-    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
-    MAST::Parameter rho("rho_param", 1420.5);         // Density
-    MAST::Parameter alpha("alpha_param", 5.43e-05);   // Coefficient of thermal expansion
-    MAST::Parameter cp("cp_param",   908.0);          // Specific Heat Capacity
-    MAST::Parameter k("k_param",     237.0);          // Thermal Conductivity
-    
-    // Define Section Properties as MAST Parameters
-    MAST::Parameter thickness_y("thy_param", 0.06);   // Section thickness in y-direction
-    MAST::Parameter thickness_z("thz_param", 0.04);   // Section thickness in z-direction
-    MAST::Parameter offset_y("offy_param", 0.035);    // Section offset in y-direction
-    MAST::Parameter offset_z("offz_param", 0.026);    // Section offset in z-direction
-    MAST::Parameter kappa_zz("kappa_zz", 5.0/6.0);    // Shear coefficient
-    MAST::Parameter kappa_yy("kappa_yy", 2.0/6.0);    // Shear coefficient
-    
-    // Create field functions to dsitribute these constant parameters throughout the model
-    MAST::ConstantFieldFunction E_f("E", E);
-    MAST::ConstantFieldFunction nu_f("nu", nu);
+    RealMatrixX coords = RealMatrixX::Zero(3, 2);
+    coords << -1.0, 1.0, 0.0,
+               0.0, 0.0, 0.0;
+    TEST::TestStructuralSingleElement1D test_elem(libMesh::EDGE2, coords);
 
-    MAST::ConstantFieldFunction rho_f("rho", rho);
-    MAST::ConstantFieldFunction alpha_f("alpha_expansion", alpha);
-    MAST::ConstantFieldFunction cp_f("cp", cp);
-    MAST::ConstantFieldFunction k_f("k_th", k);
-    MAST::ConstantFieldFunction thicknessy_f("hy", thickness_y);
-    MAST::ConstantFieldFunction offsety_f("hy_off", offset_y);
-    MAST::ConstantFieldFunction thicknessz_f("hz", thickness_z);
-    MAST::ConstantFieldFunction offsetz_f("hz_off", offset_z);
-    MAST::ConstantFieldFunction kappa_zz_f("Kappazz", kappa_zz);
-    MAST::ConstantFieldFunction kappa_yy_f("Kappayy", kappa_yy);
-    
-    // Initialize the material
-    MAST::IsotropicMaterialPropertyCard material;                   
-    
-    // Add the material property constant field functions to the material card
-    material.add(E_f);
-    material.add(nu_f);
-    material.add(rho_f);
-    material.add(alpha_f);
-    material.add(k_f);
-    material.add(cp_f);
-    
-    // Initialize the section
-    MAST::Solid1DSectionElementPropertyCard section;
-    
-    // Add the section property constant field functions to the section card
-    section.add(thicknessy_f);
-    section.add(offsety_f);
-    section.add(thicknessz_f);
-    section.add(offsetz_f);
-    section.add(kappa_zz_f);
-    section.add(kappa_yy_f);
-    
-    // Add the material card to the section card
-    section.set_material(material);
-    
-    // Specify a section orientation point and add it to the section.
-    // FIXME: Orientation isn't affecting the element's jacobian for some reason
-    RealVectorX orientation = RealVectorX::Zero(3);
-    orientation(2) = 1.0;
-    section.y_vector() = orientation;
-    
-    // Set the strain type to linear for the section
-    section.set_strain(MAST::LINEAR_STRAIN);
-    
-    // Set the bending operator to Euler-Bernoulli
-    section.set_bending_model(MAST::BERNOULLI);
-    
-    // Now initialize the section
-    section.init();
-    
-    /**
-     *  Now we setup the structural system we will be solving.
-     */
-    libMesh::EquationSystems equation_systems(mesh);
-    
-    MAST::NonlinearSystem& system = equation_systems.add_system<MAST::NonlinearSystem>("structural");
-    
-    libMesh::FEType fetype(libMesh::FIRST, libMesh::LAGRANGE);
-    
-    MAST::StructuralSystemInitialization structural_system(system, 
-                                                           system.name(), 
-                                                           fetype);
-    
-    MAST::PhysicsDisciplineBase discipline(equation_systems);
-    
-    discipline.set_property_for_subdomain(0, section);
-    
-    equation_systems.init();
-    //equation_systems.print_info();
-    
-    MAST::NonlinearImplicitAssembly assembly;
-    assembly.set_discipline_and_system(discipline, structural_system);
-    
-    // Create the MAST element from the libMesh reference element
-    MAST::GeomElem geom_elem;
-    geom_elem.init(*reference_elem, structural_system);
-    std::unique_ptr<MAST::StructuralElementBase> elem_base = build_structural_element(structural_system, geom_elem, section);
-    
-    // Cast the base structural element as a 2D structural element
-    MAST::StructuralElement1D* elem = (dynamic_cast<MAST::StructuralElement1D*>(elem_base.get()));
-    
-    // Get element DOFs
-    const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
-    std::vector<libMesh::dof_id_type> dof_indices;
-    dof_map.dof_indices (reference_elem, dof_indices);
-    uint n_dofs = uint(dof_indices.size());
-    
-    // Set element's initial solution and solution sensitivity to zero
-    RealVectorX elem_solution = RealVectorX::Zero(n_dofs);
-    elem->set_solution(elem_solution);
-    elem->set_solution(elem_solution, true);
-    
-    const Real V0 = reference_elem->volume();
-    
-    /**
-     *  Below, we start building the Jacobian up for a very basic element that 
-     *  is already in an isoparametric format.  The following four steps:
-     *      Extension Only Stiffness
-     *      Extension & Bending Stiffness
-     *      Extension, Bending, & Transverse Shear Stiffness
-     *      Extension, Bending, & Extension-Bending Coupling Stiffness
-     *      Extension, Bending, Transverse Shear & Extension-Bending Coupling Stiffness
-     * 
-     *  Testing the Jacobian incrementally this way allows errors in the
-     *  Jacobian to be located more precisely.
-     * 
-     *  It would probably be even better to test each stiffness contribution 
-     *  separately, but currently, we don't have a way to disable extension
-     *  stiffness and transverse shear stiffness doesn't exist without bending 
-     *  and extension-bending coupling stiffness don't make sense without both
-     *  extension and/or bending. 
-     */
-    
+    const Real V0 = test_elem.reference_elem->volume();
+
     // Set shear coefficient to zero to disable transverse shear stiffness
-    kappa_yy = 0.0;
-    kappa_zz = 0.0;
-    
-    // Calculate residual and jacobian
-    RealVectorX residual = RealVectorX::Zero(n_dofs);
-    RealMatrixX jacobian0 = RealMatrixX::Zero(n_dofs, n_dofs);
-    elem->internal_residual(true, residual, jacobian0);
+    test_elem.kappa_yy = 0.0;
+    test_elem.kappa_zz = 0.0;
+
+    // Update residual and Jacobian storage since we have modified baseline test element properties.
+    test_elem.update_residual_and_jacobian0();
             
-    double val_margin = (jacobian0.array().abs()).mean() * 1.490116119384766e-08;
+    double val_margin = (test_elem.jacobian0.array().abs()).mean() * 1.490116119384766e-08;
     
-    libMesh::out << "J =\n" << jacobian0 << std::endl;
-    
-    SECTION("internal_jacobian_finite_difference_check")                   
+    libMesh::out << "J =\n" << test_elem.jacobian0 << std::endl;
+
+
+    SECTION("Internal Jacobian (stiffness matrix) finite difference check")
     {
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem,
+                                                                   test_elem.elem_solution, test_elem.jacobian_fd);
+
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
     }
-    
-    
-    SECTION("internal_jacobian_symmetry_check")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) should be symmetric")
     {
-        // Element stiffness matrix should be symmetric
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0.transpose());
-        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0.transpose())));
     }
-    
-    
-    SECTION("internal_jacobian_determinant_check")
+
+
+    SECTION("Determinant of undeformed internal Jacobian (stiffness matrix) should be zero")
     {
-        // Determinant of undeformed element stiffness matrix should be zero
-        REQUIRE( jacobian0.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian0.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    
-    SECTION("internal_jacobian_eigenvalue_check")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) eigenvalue check")
     {
-        /**
+        /*
          * Number of zero eigenvalues should equal the number of rigid body
          * modes.  With extension (including torsion) and bending about y and 
          * z axes, we have 6 rigid body modes (3 translations, 3 rotations).
@@ -268,7 +102,7 @@ TEST_CASE("edge2_linear_extension_bending_coupling_structural",
          * body modes than expected.
          */
         Real eps = 1.4901161193847656e-07;
-        SelfAdjointEigenSolver<RealMatrixX> eigensolver(jacobian0, false);
+        SelfAdjointEigenSolver<RealMatrixX> eigensolver(test_elem.jacobian0, false);
         RealVectorX eigenvalues = eigensolver.eigenvalues();
         libMesh::out << "Eigenvalues are:\n" << eigenvalues << std::endl;
         uint nz = 0;
@@ -282,402 +116,252 @@ TEST_CASE("edge2_linear_extension_bending_coupling_structural",
         libMesh::out << "Eigenvalues:\n" << eigenvalues << std::endl;
         REQUIRE( nz == 6);
         
-        /**
+        /*
          * All non-zero eigenvalues should be positive.
          */
         REQUIRE(eigenvalues.minCoeff()>(-eps));
     }
     
     
-    SECTION("internal_jacobian_orientation_invariant")
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to section orientation")
     {
-        section.clear();
+        test_elem.section.clear();
         RealVectorX orientation = RealVectorX::Zero(3);
         orientation(2) = 1.0;
-        section.y_vector() = orientation;
-        section.init();
-        
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-                
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
+        test_elem.section.y_vector() = orientation;
+        test_elem.section.init();
+        test_elem.update_residual_and_jacobian();
 
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
     }
-    
-    
-    SECTION("internal_jacobian_displacement_invariant")
-    {
-        // Calculate residual and jacobian at arbitrary displacement
-        RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
-        elem_sol << 0.05727841,  0.08896581,  0.09541619, -0.03774913,  
-                    0.07510557, -0.07122266, -0.00979117, -0.08300009, 
-                    -0.03453369, -0.05487761, -0.01407677, -0.09268421;
-        elem->set_solution(elem_sol);
-        
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-                
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
 
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
-    }
-    
-    SECTION("internal_jacobian_shifted_x_invariant")
-    {
-        // Shifted in x-direction
-        transform_element(mesh, X0, 5.2, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-                
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
 
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
-    }
-    
-    SECTION("internal_jacobian_shifted_y_invariant")
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to displacement solution")
     {
-        // Shifted in y-direction
-        transform_element(mesh, X0, 0.0, -11.5, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
-        
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        RealVectorX elem_sol = RealVectorX::Zero(test_elem.n_dofs);
+        elem_sol << 0.05727841,  0.08896581,  0.09541619, -0.03774913,
+                    0.07510557, -0.07122266, -0.00979117, -0.08300009,
+                   -0.03453369, -0.05487761, -0.01407677, -0.09268421;
+        test_elem.elem->set_solution(elem_sol);
+        test_elem.update_residual_and_jacobian();
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
     }
-    
-    SECTION("internal_jacobian_shifted_z_invariant")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to element x-location")
     {
-        // Shifted in y-direction
-        transform_element(mesh, X0, 0.0, 0.0, 7.6, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
-        
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        TEST::transform_element(test_elem.mesh, coords,5.2, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
     }
-    
-    
-    SECTION("internal_jacobian_aligned_y")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to element y-location")
+    {
+        TEST::transform_element(test_elem.mesh, coords, 0.0, -11.5, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
+    }
+
+
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to element z-location")
+    {
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 7.6,
+                                1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
+    }
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element aligned along y-axis")
     {
         /*
          * NOTE: We could try to use the transform_element method here, but the
          * issue is that if the sin and cos calculations are not exact, then we
          * may not be perfectly aligned along the y axis like we want.
          */
-        RealMatrixX X= RealMatrixX::Zero(3,n_nodes);
-        X << 0.0, 0.0, -1.0, 1.0, 0.0, 0.0;
-        for (int i=0; i<n_nodes; i++)
-        {
-            (*mesh.node_ptr(i)) = libMesh::Point(X(0,i), X(1,i), X(2,i));
-        }
-        
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        RealMatrixX new_coordinates = RealMatrixX::Zero(3,test_elem.n_nodes);
+        new_coordinates << 0.0, 0.0, -1.0, 1.0, 0.0, 0.0;
+        test_elem.update_coordinates(new_coordinates);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_aligned_z")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element aligned along z-axis")
     {
         /*
          * NOTE: We could try to use the transform_element method here, but the
          * issue is that if the sin and cos calculations are not exact, then we
          * may not be perfectly aligned along the z axis like we want.
          */
-        RealMatrixX X= RealMatrixX::Zero(3,n_nodes);
-        X << 0.0, 0.0, 0.0, 0.0, -1.0, 1.0;
-        for (int i=0; i<n_nodes; i++)
-        {
-            (*mesh.node_ptr(i)) = libMesh::Point(X(0,i), X(1,i), X(2,i));
-        }
-        
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        RealMatrixX new_coordinates = RealMatrixX::Zero(3,test_elem.n_nodes);
+        new_coordinates << 0.0, 0.0, 0.0, 0.0, -1.0, 1.0;
+        test_elem.update_coordinates(new_coordinates);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_rotated_about_z")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element rotated about z-axis")
     {
         // Rotated 63.4 about z-axis at element's centroid
-        transform_element(mesh, X0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 63.4);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 63.4);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_rotated_about_y")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element rotated about y-axis")
     {
         // Rotated 35.8 about y-axis at element's centroid
-        transform_element(mesh, X0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 35.8, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 35.8, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_scaled_x")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element stretched in x-direction")
     {
-        // Rotated 63.4 about z-axis at element's centroid
-        transform_element(mesh, X0, 0.0, 0.0, 0.0, 3.2, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                3.2, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_arbitrary_transformation")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element arbitrarily scaled, stretched, and rotated")
     {
-        // Arbitrary transformations applied to the element
-        transform_element(mesh, X0, -5.0, 7.8, -13.1, 2.7, 6.4, 20.0, 47.8, -70.1);
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        // Apply arbitrary transformation to the element
+        TEST::transform_element(test_elem.mesh, coords, -5.0, 7.8, -13.1,
+                                2.7, 6.4, 20.0, 47.8, -70.1);
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_arbitrary_with_displacements")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element arbitrarily scaled, stretched, rotated, and displaced")
     {
-        // Arbitrary transformations applied to the element
-        transform_element(mesh, X0, 4.1, -6.3, 7.5, 4.2, 1.5, -18.0, -24.8, 
-                          30.1);
-        
-        // Calculate residual and jacobian at arbitrary displacement
-        RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
-        elem_sol << 0.08158724,  0.07991906, -0.00719128,  0.02025461, 
-                    -0.04602193, 0.05280159,  0.03700081,  0.04636344,  
-                    0.05559377,  0.06448206, 0.08919238, -0.03079122;
-        elem->set_solution(elem_sol);
-        
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        // Apply arbitrary transformation to the element
+        TEST::transform_element(test_elem.mesh, coords, 4.1, -6.3, 7.5,
+                                4.2, 1.5, -18.0, -24.8, 30.1);
+
+        // Apply arbitrary displacement to the element
+        RealVectorX elem_sol = RealVectorX::Zero(test_elem.n_dofs);
+        elem_sol << 0.08158724,  0.07991906, -0.00719128,  0.02025461,
+                   -0.04602193,  0.05280159,  0.03700081,  0.04636344,
+                    0.05559377,  0.06448206,  0.08919238, -0.03079122;
+        test_elem.elem->set_solution(elem_sol);
+
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
 }

--- a/tests/element/structural/1D/edge2/mast_edge2_linear_structural_extension_bending_internal_jacobian.cpp
+++ b/tests/element/structural/1D/edge2/mast_edge2_linear_structural_extension_bending_internal_jacobian.cpp
@@ -1,16 +1,25 @@
-// C++ Stanard Includes
-#include <math.h>
-
-// Catch2 includes
-#include "catch.hpp"
+/*
+ * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
+ * Copyright (C) 2013-2020  Manav Bhatia and MAST authors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
 
 // libMesh includes
 #include "libmesh/libmesh.h"
-#include "libmesh/replicated_mesh.h"
-#include "libmesh/point.h"
 #include "libmesh/elem.h"
-#include "libmesh/edge_edge2.h"
-#include "libmesh/equation_systems.h"
 #include "libmesh/dof_map.h"
 
 // MAST includes
@@ -20,665 +29,342 @@
 #include "property_cards/solid_1d_section_element_property_card.h"
 #include "elasticity/structural_element_1d.h"
 #include "elasticity/structural_system_initialization.h"
-#include "base/physics_discipline_base.h"
 #include "base/nonlinear_implicit_assembly.h"
 #include "elasticity/structural_nonlinear_assembly.h"
 #include "base/nonlinear_system.h"
-#include "elasticity/structural_element_base.h"
 #include "mesh/geom_elem.h"
 
-// Custom includes
+// Test includes
+#include "catch.hpp"
 #include "test_helpers.h"
-
+#include "element/structural/1D/mast_structural_element_1d.h"
 #define pi 3.14159265358979323846
 
 extern libMesh::LibMeshInit* p_global_init;
 
 
 TEST_CASE("edge2_linear_extension_bending_structural",
-          "[1D],[structural],[edge],[edge2],[linear]")
+          "[1D][structural][edge][edge2][linear]")
 {
-    const int n_elems = 1;
-    const int n_nodes = 2;
-    
-    RealMatrixX temp = RealMatrixX::Zero(3,n_nodes);
-    temp << -1.0, 1.0, 0.0, 0.0, 0.0, 0.0;
-    const RealMatrixX X0 = temp;
-    
-    /**
-     * Create the mesh with the one element we are testing
-     */
-    libMesh::ReplicatedMesh mesh(p_global_init->comm());
-    mesh.set_mesh_dimension(1);
-    mesh.set_spatial_dimension(3);
-    mesh.reserve_elem(n_elems);
-    mesh.reserve_nodes(n_nodes);
-    
-    // Add nodes to the mesh
-    for (uint i=0; i<n_nodes; i++)
-    {
-        mesh.add_point(libMesh::Point(X0(0,i), X0(1,i), X0(2,i)));
-    }
-    
-    // Add the element to the mesh
-    libMesh::Elem *reference_elem = new libMesh::Edge2;
-    reference_elem->set_id(0);    
-    reference_elem->subdomain_id() = 0;
-    reference_elem = mesh.add_elem(reference_elem);
-    for (int i=0; i<n_nodes; i++)
-    {
-        reference_elem->set_node(i) = mesh.node_ptr(i);
-    }
-    
-    // Prepare the mesh for use
-    mesh.prepare_for_use();
-    
-    // Ensure the libMesh element has the expected volume
-    const Real elem_volume = reference_elem->volume();
-    Real true_volume = 2.0;
-    REQUIRE( elem_volume == true_volume );
-    
-    // Define Material Properties as MAST Parameters
-    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
-    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
-    MAST::Parameter rho("rho_param", 1420.5);         // Density
-    MAST::Parameter alpha("alpha_param", 5.43e-05);   // Coefficient of thermal expansion
-    MAST::Parameter cp("cp_param",   908.0);          // Specific Heat Capacity
-    MAST::Parameter k("k_param",     237.0);          // Thermal Conductivity
-    
-    // Define Section Properties as MAST Parameters
-    MAST::Parameter thickness_y("thy_param", 0.06);   // Section thickness in y-direction
-    MAST::Parameter thickness_z("thz_param", 0.04);   // Section thickness in z-direction
-    MAST::Parameter offset_y("offy_param", 0.035);    // Section offset in y-direction
-    MAST::Parameter offset_z("offz_param", 0.026);    // Section offset in z-direction
-    MAST::Parameter kappa_zz("kappa_zz", 5.0/6.0);    // Shear coefficient
-    MAST::Parameter kappa_yy("kappa_yy", 2.0/6.0);    // Shear coefficient
-    
-    // Create field functions to dsitribute these constant parameters throughout the model
-    MAST::ConstantFieldFunction E_f("E", E);
-    MAST::ConstantFieldFunction nu_f("nu", nu);
-    MAST::ConstantFieldFunction rho_f("rho", rho);
-    MAST::ConstantFieldFunction alpha_f("alpha_expansion", alpha);
-    MAST::ConstantFieldFunction cp_f("cp", cp);
-    MAST::ConstantFieldFunction k_f("k_th", k);
-    MAST::ConstantFieldFunction thicknessy_f("hy", thickness_y);
-    MAST::ConstantFieldFunction offsety_f("hy_off", offset_y);
-    MAST::ConstantFieldFunction thicknessz_f("hz", thickness_z);
-    MAST::ConstantFieldFunction offsetz_f("hz_off", offset_z);
-    MAST::ConstantFieldFunction kappa_zz_f("Kappazz", kappa_zz);
-    MAST::ConstantFieldFunction kappa_yy_f("Kappayy", kappa_yy);
-    
-    // Initialize the material
-    MAST::IsotropicMaterialPropertyCard material;                   
-    
-    // Add the material property constant field functions to the material card
-    material.add(E_f);
-    material.add(nu_f);
-    material.add(rho_f);
-    material.add(alpha_f);
-    material.add(k_f);
-    material.add(cp_f);
-    
-    // Initialize the section
-    MAST::Solid1DSectionElementPropertyCard section;
-    
-    // Add the section property constant field functions to the section card
-    section.add(thicknessy_f);
-    section.add(offsety_f);
-    section.add(thicknessz_f);
-    section.add(offsetz_f);
-    section.add(kappa_zz_f);
-    section.add(kappa_yy_f);
-    
-    // Add the material card to the section card
-    section.set_material(material);
-    
-    // Specify a section orientation point and add it to the section.
-    // FIXME: Orientation isn't affecting the element's jacobian for some reason
-    RealVectorX orientation = RealVectorX::Zero(3);
-    orientation(2) = 1.0;
-    section.y_vector() = orientation;
-    
-    // Set the strain type to linear for the section
-    section.set_strain(MAST::LINEAR_STRAIN);
-    
-    // Set the bending operator to Euler-Bernoulli
-    section.set_bending_model(MAST::BERNOULLI);
-    
-    // Now initialize the section
-    section.init();
-    
-    /**
-     *  Now we setup the structural system we will be solving.
-     */
-    libMesh::EquationSystems equation_systems(mesh);
-    
-    MAST::NonlinearSystem& system = equation_systems.add_system<MAST::NonlinearSystem>("structural");
-    
-    libMesh::FEType fetype(libMesh::FIRST, libMesh::LAGRANGE);
-    
-    MAST::StructuralSystemInitialization structural_system(system, 
-                                                           system.name(), 
-                                                           fetype);
-    
-    MAST::PhysicsDisciplineBase discipline(equation_systems);
-    
-    discipline.set_property_for_subdomain(0, section);
-    
-    equation_systems.init();
-    //equation_systems.print_info();
-    
-    MAST::NonlinearImplicitAssembly assembly;
-    assembly.set_discipline_and_system(discipline, structural_system);
-    
-    // Create the MAST element from the libMesh reference element
-    MAST::GeomElem geom_elem;
-    geom_elem.init(*reference_elem, structural_system);
-    std::unique_ptr<MAST::StructuralElementBase> elem_base = build_structural_element(structural_system, geom_elem, section);
-    
-    // Cast the base structural element as a 2D structural element
-    MAST::StructuralElement1D* elem = (dynamic_cast<MAST::StructuralElement1D*>(elem_base.get()));
-    
-    // Get element DOFs
-    const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
-    std::vector<libMesh::dof_id_type> dof_indices;
-    dof_map.dof_indices (reference_elem, dof_indices);
-    uint n_dofs = uint(dof_indices.size());
-    
-    // Set element's initial solution and solution sensitivity to zero
-    RealVectorX elem_solution = RealVectorX::Zero(n_dofs);
-    elem->set_solution(elem_solution);
-    elem->set_solution(elem_solution, true);
-    
-    const Real V0 = reference_elem->volume();
-    
-    /**
-     *  Below, we start building the Jacobian up for a very basic element that 
-     *  is already in an isoparametric format.  The following four steps:
-     *      Extension Only Stiffness
-     *      Extension & Bending Stiffness
-     *      Extension, Bending, & Transverse Shear Stiffness
-     *      Extension, Bending, & Extension-Bending Coupling Stiffness
-     *      Extension, Bending, Transverse Shear & Extension-Bending Coupling Stiffness
-     * 
-     *  Testing the Jacobian incrementally this way allows errors in the
-     *  Jacobian to be located more precisely.
-     * 
-     *  It would probably be even better to test each stiffness contribution 
-     *  separately, but currently, we don't have a way to disable extension
-     *  stiffness and transverse shear stiffness doesn't exist without bending 
-     *  and extension-bending coupling stiffness don't make sense without both
-     *  extension and/or bending. 
-     */
+    RealMatrixX coords = RealMatrixX::Zero(3, 2);
+    coords << -1.0, 1.0, 0.0,
+               0.0, 0.0, 0.0;
+    TEST::TestStructuralSingleElement1D test_elem(libMesh::EDGE2, coords);
+
+    const Real V0 = test_elem.reference_elem->volume();
     
     // Set shear coefficient to zero to disable transverse shear stiffness
-    kappa_zz = 0.0;
-    kappa_yy = 0.0;
+    test_elem.kappa_zz = 0.0;
+    test_elem.kappa_yy = 0.0;
     
     // Set the offset to zero to disable extension-bending coupling
-    offset_y = 0.0;
-    offset_z = 0.0;
-    
-    // Calculate residual and jacobian
-    RealVectorX residual = RealVectorX::Zero(n_dofs);
-    RealMatrixX jacobian0 = RealMatrixX::Zero(n_dofs, n_dofs);
-    elem->internal_residual(true, residual, jacobian0);
-            
-    double val_margin = (jacobian0.array().abs()).mean() * 1.490116119384766e-08;
-    
-    libMesh::out << "J =\n" << jacobian0 << std::endl;
-    
-    SECTION("internal_jacobian_finite_difference_check")                   
+    test_elem.offset_y = 0.0;
+    test_elem.offset_z = 0.0;
+
+    // Update residual and Jacobian storage since we have modified baseline test element properties.
+    test_elem.update_residual_and_jacobian0();
+
+    double val_margin = (test_elem.jacobian0.array().abs()).mean() * 1.490116119384766e-08;
+
+    libMesh::out << "J =\n" << test_elem.jacobian0 << std::endl;
+
+
+    SECTION("Internal Jacobian (stiffness matrix) finite difference check")
     {
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem,
+                                                                   test_elem.elem_solution, test_elem.jacobian_fd);
+
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
     }
-    
-    
-    SECTION("internal_jacobian_symmetry_check")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) should be symmetric")
     {
-        // Element stiffness matrix should be symmetric
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0.transpose());
-        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0.transpose())));
     }
-    
-    
-    SECTION("internal_jacobian_determinant_check")
+
+
+    SECTION("Determinant of undeformed internal Jacobian (stiffness matrix) should be zero")
     {
-        // Determinant of undeformed element stiffness matrix should be zero
-        REQUIRE( jacobian0.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian0.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    
-    SECTION("internal_jacobian_eigenvalue_check")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) eigenvalue check")
     {
-        /**
+        /*
          * Number of zero eigenvalues should equal the number of rigid body
-         * modes.  With extension (including torsion) and bending about y and 
+         * modes.  With extension (including torsion) and bending about y and
          * z axes, we have 6 rigid body modes (3 translations, 3 rotations).
-         * 
+         *
          * Note that the use of reduced integration can result in more rigid
          * body modes than expected.
          */
-        SelfAdjointEigenSolver<RealMatrixX> eigensolver(jacobian0, false);
+        Real eps = 1.4901161193847656e-07;
+        SelfAdjointEigenSolver<RealMatrixX> eigensolver(test_elem.jacobian0, false);
         RealVectorX eigenvalues = eigensolver.eigenvalues();
         libMesh::out << "Eigenvalues are:\n" << eigenvalues << std::endl;
         uint nz = 0;
         for (uint i=0; i<eigenvalues.size(); i++)
         {
-            if (std::abs(eigenvalues(i))<1e-10)
+            if (std::abs(eigenvalues(i))<eps)
             {
                 nz++;
             }
         }
+        libMesh::out << "Eigenvalues:\n" << eigenvalues << std::endl;
         REQUIRE( nz == 6);
-        
-        /**
+
+        /*
          * All non-zero eigenvalues should be positive.
          */
-        REQUIRE(eigenvalues.minCoeff()>(-1e-10));
+        REQUIRE(eigenvalues.minCoeff()>(-eps));
     }
-    
-    
-    SECTION("internal_jacobian_orientation_invariant")
+
+
+   SECTION("Internal Jacobian (stiffness matrix) is invariant to section orientation")
     {
-        section.clear();
+        test_elem.section.clear();
         RealVectorX orientation = RealVectorX::Zero(3);
         orientation(2) = 1.0;
-        section.y_vector() = orientation;
-        section.init();
-        
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-                
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
+        test_elem.section.y_vector() = orientation;
+        test_elem.section.init();
+        test_elem.update_residual_and_jacobian();
 
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
     }
-    
-    
-    SECTION("internal_jacobian_displacement_invariant")
-    {
-        // Calculate residual and jacobian at arbitrary displacement
-        RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
-        elem_sol << 0.05727841,  0.08896581,  0.09541619, -0.03774913,  
-                    0.07510557, -0.07122266, -0.00979117, -0.08300009, 
-                    -0.03453369, -0.05487761, -0.01407677, -0.09268421;
-        elem->set_solution(elem_sol);
-        
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-                
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
 
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
-    }
-    
-    SECTION("internal_jacobian_shifted_x_invariant")
-    {
-        // Shifted in x-direction
-        transform_element(mesh, X0, 5.2, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-                
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
 
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
-    }
-    
-    SECTION("internal_jacobian_shifted_y_invariant")
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to displacement solution")
     {
-        // Shifted in y-direction
-        transform_element(mesh, X0, 0.0, -11.5, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
-        
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        RealVectorX elem_sol = RealVectorX::Zero(test_elem.n_dofs);
+        elem_sol << 0.05727841,  0.08896581,  0.09541619, -0.03774913,
+                    0.07510557, -0.07122266, -0.00979117, -0.08300009,
+                   -0.03453369, -0.05487761, -0.01407677, -0.09268421;
+        test_elem.elem->set_solution(elem_sol);
+        test_elem.update_residual_and_jacobian();
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
     }
-    
-    SECTION("internal_jacobian_shifted_z_invariant")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to element x-location")
     {
-        // Shifted in y-direction
-        transform_element(mesh, X0, 0.0, 0.0, 7.6, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
-        
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        TEST::transform_element(test_elem.mesh, coords,5.2, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
     }
-    
-    
-    SECTION("internal_jacobian_aligned_y")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to element y-location")
+    {
+        TEST::transform_element(test_elem.mesh, coords, 0.0, -11.5, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
+    }
+
+
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to element z-location")
+    {
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 7.6,
+                                1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
+    }
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element aligned along y-axis")
     {
         /*
          * NOTE: We could try to use the transform_element method here, but the
          * issue is that if the sin and cos calculations are not exact, then we
          * may not be perfectly aligned along the y axis like we want.
          */
-        RealMatrixX X= RealMatrixX::Zero(3,n_nodes);
-        X << 0.0, 0.0, -1.0, 1.0, 0.0, 0.0;
-        for (int i=0; i<n_nodes; i++)
-        {
-            (*mesh.node_ptr(i)) = libMesh::Point(X(0,i), X(1,i), X(2,i));
-        }
-        
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        RealMatrixX new_coordinates = RealMatrixX::Zero(3,test_elem.n_nodes);
+        new_coordinates << 0.0, 0.0, -1.0, 1.0, 0.0, 0.0;
+        test_elem.update_coordinates(new_coordinates);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_aligned_z")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element aligned along z-axis")
     {
         /*
          * NOTE: We could try to use the transform_element method here, but the
          * issue is that if the sin and cos calculations are not exact, then we
          * may not be perfectly aligned along the z axis like we want.
          */
-        RealMatrixX X= RealMatrixX::Zero(3,n_nodes);
-        X << 0.0, 0.0, 0.0, 0.0, -1.0, 1.0;
-        for (int i=0; i<n_nodes; i++)
-        {
-            (*mesh.node_ptr(i)) = libMesh::Point(X(0,i), X(1,i), X(2,i));
-        }
-        
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        RealMatrixX new_coordinates = RealMatrixX::Zero(3,test_elem.n_nodes);
+        new_coordinates << 0.0, 0.0, 0.0, 0.0, -1.0, 1.0;
+        test_elem.update_coordinates(new_coordinates);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_rotated_about_z")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element rotated about z-axis")
     {
         // Rotated 63.4 about z-axis at element's centroid
-        transform_element(mesh, X0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 63.4);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 63.4);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_rotated_about_y")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element rotated about y-axis")
     {
         // Rotated 35.8 about y-axis at element's centroid
-        transform_element(mesh, X0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 35.8, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 35.8, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_scaled_x")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element stretched in x-direction")
     {
-        // Rotated 63.4 about z-axis at element's centroid
-        transform_element(mesh, X0, 0.0, 0.0, 0.0, 3.2, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                3.2, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_arbitrary_transformation")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element arbitrarily scaled, stretched, and rotated")
     {
-        // Arbitrary transformations applied to the element
-        transform_element(mesh, X0, -5.0, 7.8, -13.1, 2.7, 6.4, 20.0, 47.8, -70.1);
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        // Apply arbitrary transformation to the element
+        TEST::transform_element(test_elem.mesh, coords, -5.0, 7.8, -13.1,
+                                2.7, 6.4, 20.0, 47.8, -70.1);
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_arbitrary_with_displacements")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element arbitrarily scaled, stretched, rotated, and displaced")
     {
-        // Arbitrary transformations applied to the element
-        transform_element(mesh, X0, 4.1, -6.3, 7.5, 4.2, 1.5, -18.0, -24.8, 
-                          30.1);
-        
-        // Calculate residual and jacobian at arbitrary displacement
-        RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
-        elem_sol << 0.08158724,  0.07991906, -0.00719128,  0.02025461, 
-                    -0.04602193, 0.05280159,  0.03700081,  0.04636344,  
-                    0.05559377,  0.06448206, 0.08919238, -0.03079122;
-        elem->set_solution(elem_sol);
-        
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        // Apply arbitrary transformation to the element
+        TEST::transform_element(test_elem.mesh, coords, 4.1, -6.3, 7.5,
+                                4.2, 1.5, -18.0, -24.8, 30.1);
+
+        // Apply arbitrary displacement to the element
+        RealVectorX elem_sol = RealVectorX::Zero(test_elem.n_dofs);
+        elem_sol << 0.08158724,  0.07991906, -0.00719128,  0.02025461,
+                -0.04602193,  0.05280159,  0.03700081,  0.04636344,
+                0.05559377,  0.06448206,  0.08919238, -0.03079122;
+        test_elem.elem->set_solution(elem_sol);
+
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
 }

--- a/tests/element/structural/1D/edge2/mast_edge2_linear_structural_extension_bending_shear_internal_jacobian.cpp
+++ b/tests/element/structural/1D/edge2/mast_edge2_linear_structural_extension_bending_shear_internal_jacobian.cpp
@@ -1,16 +1,25 @@
-// C++ Stanard Includes
-#include <math.h>
-
-// Catch2 includes
-#include "catch.hpp"
+/*
+ * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
+ * Copyright (C) 2013-2020  Manav Bhatia and MAST authors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
 
 // libMesh includes
 #include "libmesh/libmesh.h"
-#include "libmesh/replicated_mesh.h"
-#include "libmesh/point.h"
 #include "libmesh/elem.h"
-#include "libmesh/edge_edge2.h"
-#include "libmesh/equation_systems.h"
 #include "libmesh/dof_map.h"
 
 // MAST includes
@@ -20,15 +29,15 @@
 #include "property_cards/solid_1d_section_element_property_card.h"
 #include "elasticity/structural_element_1d.h"
 #include "elasticity/structural_system_initialization.h"
-#include "base/physics_discipline_base.h"
 #include "base/nonlinear_implicit_assembly.h"
 #include "elasticity/structural_nonlinear_assembly.h"
 #include "base/nonlinear_system.h"
-#include "elasticity/structural_element_base.h"
 #include "mesh/geom_elem.h"
 
-// Custom includes
+// Test includes
+#include "catch.hpp"
 #include "test_helpers.h"
+#include "element/structural/1D/mast_structural_element_1d.h"
 
 #define pi 3.14159265358979323846
 
@@ -38,227 +47,53 @@ extern libMesh::LibMeshInit* p_global_init;
 TEST_CASE("edge2_linear_extension_bending_shear_structural",
           "[1D],[structural],[edge],[edge2],[linear]")
 {
-    const int n_elems = 1;
-    const int n_nodes = 2;
-    
-    RealMatrixX temp = RealMatrixX::Zero(3,n_nodes);
-    temp << -1.0, 1.0, 0.0, 0.0, 0.0, 0.0;
-    const RealMatrixX X0 = temp;
-    
-    /**
-     * Create the mesh with the one element we are testing
-     */
-    libMesh::ReplicatedMesh mesh(p_global_init->comm());
-    mesh.set_mesh_dimension(1);
-    mesh.set_spatial_dimension(3);
-    mesh.reserve_elem(n_elems);
-    mesh.reserve_nodes(n_nodes);
-    
-    // Add nodes to the mesh
-    for (uint i=0; i<n_nodes; i++)
-    {
-        mesh.add_point(libMesh::Point(X0(0,i), X0(1,i), X0(2,i)));
-    }
-    
-    // Add the element to the mesh
-    libMesh::Elem *reference_elem = new libMesh::Edge2;
-    reference_elem->set_id(0);    
-    reference_elem->subdomain_id() = 0;
-    reference_elem = mesh.add_elem(reference_elem);
-    for (int i=0; i<n_nodes; i++)
-    {
-        reference_elem->set_node(i) = mesh.node_ptr(i);
-    }
-    
-    // Prepare the mesh for use
-    mesh.prepare_for_use();
-    
-    // Ensure the libMesh element has the expected volume
-    const Real elem_volume = reference_elem->volume();
-    Real true_volume = 2.0;
-    REQUIRE( elem_volume == true_volume );
-    
-    // Define Material Properties as MAST Parameters
-    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
-    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
-    MAST::Parameter rho("rho_param", 1420.5);         // Density
-    MAST::Parameter alpha("alpha_param", 5.43e-05);   // Coefficient of thermal expansion
-    MAST::Parameter cp("cp_param",   908.0);          // Specific Heat Capacity
-    MAST::Parameter k("k_param",     237.0);          // Thermal Conductivity
-    
-    // Define Section Properties as MAST Parameters
-    MAST::Parameter thickness_y("thy_param", 0.8);   // Section thickness in y-direction
-    MAST::Parameter thickness_z("thz_param", 0.7);   // Section thickness in z-direction
-    MAST::Parameter offset_y("offy_param", 0.5);    // Section offset in y-direction
-    MAST::Parameter offset_z("offz_param", 0.4);    // Section offset in z-direction
-    MAST::Parameter kappa_zz("kappa_zz", 5.0/6.0);    // Shear coefficient
-    MAST::Parameter kappa_yy("kappa_yy", 2.0/6.0);    // Shear coefficient
-    
-    // Create field functions to dsitribute these constant parameters throughout the model
-    MAST::ConstantFieldFunction E_f("E", E);
-    MAST::ConstantFieldFunction nu_f("nu", nu);
-    MAST::ConstantFieldFunction rho_f("rho", rho);
-    MAST::ConstantFieldFunction alpha_f("alpha_expansion", alpha);
-    MAST::ConstantFieldFunction cp_f("cp", cp);
-    MAST::ConstantFieldFunction k_f("k_th", k);
-    MAST::ConstantFieldFunction thicknessy_f("hy", thickness_y);
-    MAST::ConstantFieldFunction offsety_f("hy_off", offset_y);
-    MAST::ConstantFieldFunction thicknessz_f("hz", thickness_z);
-    MAST::ConstantFieldFunction offsetz_f("hz_off", offset_z);
-    MAST::ConstantFieldFunction kappa_zz_f("Kappazz", kappa_zz);
-    MAST::ConstantFieldFunction kappa_yy_f("Kappayy", kappa_yy);
-    
-    // Initialize the material
-    MAST::IsotropicMaterialPropertyCard material;                   
-    
-    // Add the material property constant field functions to the material card
-    material.add(E_f);
-    material.add(nu_f);
-    material.add(rho_f);
-    material.add(alpha_f);
-    material.add(k_f);
-    material.add(cp_f);
-    
-    // Initialize the section
-    MAST::Solid1DSectionElementPropertyCard section;
-    
-    // Add the section property constant field functions to the section card
-    section.add(thicknessy_f);
-    section.add(offsety_f);
-    section.add(thicknessz_f);
-    section.add(offsetz_f);
-    section.add(kappa_zz_f);
-    section.add(kappa_yy_f);
-    
-    // Add the material card to the section card
-    section.set_material(material);
-    
-    // Specify a section orientation point and add it to the section.
-    // FIXME: Orientation isn't affecting the element's jacobian for some reason
-    RealVectorX orientation = RealVectorX::Zero(3);
-    orientation(2) = 1.0;
-    section.y_vector() = orientation;
-    
-    // Set the strain type to linear for the section
-    section.set_strain(MAST::LINEAR_STRAIN);
-    
-    // Set the bending operator to Euler-Bernoulli
-    section.set_bending_model(MAST::TIMOSHENKO);
-    
-    // Now initialize the section
-    section.init();
-    
-    /**
-     *  Now we setup the structural system we will be solving.
-     */
-    libMesh::EquationSystems equation_systems(mesh);
-    
-    MAST::NonlinearSystem& system = equation_systems.add_system<MAST::NonlinearSystem>("structural");
-    
-    libMesh::FEType fetype(libMesh::FIRST, libMesh::LAGRANGE);
-    
-    MAST::StructuralSystemInitialization structural_system(system, 
-                                                           system.name(), 
-                                                           fetype);
-    
-    MAST::PhysicsDisciplineBase discipline(equation_systems);
-    
-    discipline.set_property_for_subdomain(0, section);
-    
-    equation_systems.init();
-    //equation_systems.print_info();
-    
-    MAST::NonlinearImplicitAssembly assembly;
-    assembly.set_discipline_and_system(discipline, structural_system);
-    
-    // Create the MAST element from the libMesh reference element
-    MAST::GeomElem geom_elem;
-    geom_elem.init(*reference_elem, structural_system);
-    std::unique_ptr<MAST::StructuralElementBase> elem_base = build_structural_element(structural_system, geom_elem, section);
-    
-    // Cast the base structural element as a 2D structural element
-    MAST::StructuralElement1D* elem = (dynamic_cast<MAST::StructuralElement1D*>(elem_base.get()));
-    
-    // Get element DOFs
-    const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
-    std::vector<libMesh::dof_id_type> dof_indices;
-    dof_map.dof_indices (reference_elem, dof_indices);
-    uint n_dofs = uint(dof_indices.size());
-    
-    // Set element's initial solution and solution sensitivity to zero
-    RealVectorX elem_solution = RealVectorX::Zero(n_dofs);
-    elem->set_solution(elem_solution);
-    elem->set_solution(elem_solution, true);
-    
-    const Real V0 = reference_elem->volume();
-    
-    /**
-     *  Below, we start building the Jacobian up for a very basic element that 
-     *  is already in an isoparametric format.  The following four steps:
-     *      Extension Only Stiffness
-     *      Extension & Bending Stiffness
-     *      Extension, Bending, & Transverse Shear Stiffness
-     *      Extension, Bending, & Extension-Bending Coupling Stiffness
-     *      Extension, Bending, Transverse Shear & Extension-Bending Coupling Stiffness
-     * 
-     *  Testing the Jacobian incrementally this way allows errors in the
-     *  Jacobian to be located more precisely.
-     * 
-     *  It would probably be even better to test each stiffness contribution 
-     *  separately, but currently, we don't have a way to disable extension
-     *  stiffness and transverse shear stiffness doesn't exist without bending 
-     *  and extension-bending coupling stiffness don't make sense without both
-     *  extension and/or bending. 
-     */
+    RealMatrixX coords = RealMatrixX::Zero(3, 2);
+    coords << -1.0, 1.0, 0.0,
+               0.0, 0.0, 0.0;
+    TEST::TestStructuralSingleElement1D test_elem(libMesh::EDGE2, coords);
+
+    const Real V0 = test_elem.reference_elem->volume();
     
     // Set the offset to zero to disable extension-bending coupling
-    offset_y = 0.0;
-    offset_z = 0.0;
+    test_elem.offset_y = 0.0;
+    test_elem.offset_z = 0.0;
     
-    // Calculate residual and jacobian
-    RealVectorX residual = RealVectorX::Zero(n_dofs);
-    RealMatrixX jacobian0 = RealMatrixX::Zero(n_dofs, n_dofs);
-    elem->internal_residual(true, residual, jacobian0);
+    // Update residual and Jacobian storage since we have modified baseline test element properties.
+    test_elem.update_residual_and_jacobian0();
             
-    double val_margin = (jacobian0.array().abs()).mean() * 1.490116119384766e-08;
+    double val_margin = (test_elem.jacobian0.array().abs()).mean() * 1.490116119384766e-08;
     
-    libMesh::out << "J =\n" << jacobian0 << std::endl;
+    libMesh::out << "J =\n" << test_elem.jacobian0 << std::endl;
+
     
-    SECTION("internal_jacobian_finite_difference_check")                   
+    SECTION("Internal Jacobian (stiffness matrix) finite difference check")
     {
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem,
+                                                                   test_elem.elem_solution, test_elem.jacobian_fd);
+
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
     }
-    
-    
-    SECTION("internal_jacobian_symmetry_check")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) should be symmetric")
     {
-        // Element stiffness matrix should be symmetric
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0.transpose());
-        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0.transpose())));
     }
-    
-    
-    SECTION("internal_jacobian_determinant_check")
+
+
+    SECTION("Determinant of undeformed internal Jacobian (stiffness matrix) should be zero")
     {
-        // Determinant of undeformed element stiffness matrix should be zero
-        REQUIRE( jacobian0.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian0.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    
-    SECTION("internal_jacobian_eigenvalue_check")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) eigenvalue check")
     {
-        /**
+        /*
          * Number of zero eigenvalues should equal the number of rigid body
          * modes.  With extension (including torsion) and bending about y and 
          * z axes, we have 6 rigid body modes (3 translations, 3 rotations).
@@ -266,7 +101,7 @@ TEST_CASE("edge2_linear_extension_bending_shear_structural",
          * Note that the use of reduced integration can result in more rigid
          * body modes than expected.
          */
-        SelfAdjointEigenSolver<RealMatrixX> eigensolver(jacobian0, false);
+        SelfAdjointEigenSolver<RealMatrixX> eigensolver(test_elem.jacobian0, false);
         RealVectorX eigenvalues = eigensolver.eigenvalues();
         libMesh::out << "Eigenvalues are:\n" << eigenvalues << std::endl;
         uint nz = 0;
@@ -279,402 +114,252 @@ TEST_CASE("edge2_linear_extension_bending_shear_structural",
         }
         REQUIRE( nz == 6);
         
-        /**
+        /*
          * All non-zero eigenvalues should be positive.
          */
         REQUIRE(eigenvalues.minCoeff()>(-0.0001220703125));
     }
     
     
-    SECTION("internal_jacobian_orientation_invariant")
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to section orientation")
     {
-        section.clear();
+        test_elem.section.clear();
         RealVectorX orientation = RealVectorX::Zero(3);
         orientation(2) = 1.0;
-        section.y_vector() = orientation;
-        section.init();
-        
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-                
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
+        test_elem.section.y_vector() = orientation;
+        test_elem.section.init();
+        test_elem.update_residual_and_jacobian();
 
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
     }
-    
-    
-    SECTION("internal_jacobian_displacement_invariant")
-    {
-        // Calculate residual and jacobian at arbitrary displacement
-        RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
-        elem_sol << 0.05727841,  0.08896581,  0.09541619, -0.03774913,  
-                    0.07510557, -0.07122266, -0.00979117, -0.08300009, 
-                    -0.03453369, -0.05487761, -0.01407677, -0.09268421;
-        elem->set_solution(elem_sol);
-        
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-                
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
 
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
-    }
-    
-    SECTION("internal_jacobian_shifted_x_invariant")
-    {
-        // Shifted in x-direction
-        transform_element(mesh, X0, 5.2, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-                
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
 
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
-    }
-    
-    SECTION("internal_jacobian_shifted_y_invariant")
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to displacement solution")
     {
-        // Shifted in y-direction
-        transform_element(mesh, X0, 0.0, -11.5, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
-        
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        RealVectorX elem_sol = RealVectorX::Zero(test_elem.n_dofs);
+        elem_sol << 0.05727841,  0.08896581,  0.09541619, -0.03774913,
+                    0.07510557, -0.07122266, -0.00979117, -0.08300009,
+                   -0.03453369, -0.05487761, -0.01407677, -0.09268421;
+        test_elem.elem->set_solution(elem_sol);
+        test_elem.update_residual_and_jacobian();
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
     }
+
     
-    SECTION("internal_jacobian_shifted_z_invariant")
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to element x-location")
     {
-        // Shifted in y-direction
-        transform_element(mesh, X0, 0.0, 0.0, 7.6, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
-        
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        TEST::transform_element(test_elem.mesh, coords,5.2, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
+    }
+
+
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to element y-location")
+    {
+        TEST::transform_element(test_elem.mesh, coords, 0.0, -11.5, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
+    }
+
+
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to element z-location")
+    {
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 7.6,
+                                1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
     }
     
     
-    SECTION("internal_jacobian_aligned_y")
+    SECTION("Internal Jacobian (stiffness matrix) checks for element aligned along y-axis")
     {
         /*
          * NOTE: We could try to use the transform_element method here, but the
          * issue is that if the sin and cos calculations are not exact, then we
          * may not be perfectly aligned along the y axis like we want.
          */
-        RealMatrixX X= RealMatrixX::Zero(3,n_nodes);
-        X << 0.0, 0.0, -1.0, 1.0, 0.0, 0.0;
-        for (int i=0; i<n_nodes; i++)
-        {
-            (*mesh.node_ptr(i)) = libMesh::Point(X(0,i), X(1,i), X(2,i));
-        }
-        
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        RealMatrixX new_coordinates = RealMatrixX::Zero(3,test_elem.n_nodes);
+        new_coordinates << 0.0, 0.0, -1.0, 1.0, 0.0, 0.0;
+        test_elem.update_coordinates(new_coordinates);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_aligned_z")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element aligned along z-axis")
     {
         /*
          * NOTE: We could try to use the transform_element method here, but the
          * issue is that if the sin and cos calculations are not exact, then we
          * may not be perfectly aligned along the z axis like we want.
          */
-        RealMatrixX X= RealMatrixX::Zero(3,n_nodes);
-        X << 0.0, 0.0, 0.0, 0.0, -1.0, 1.0;
-        for (int i=0; i<n_nodes; i++)
-        {
-            (*mesh.node_ptr(i)) = libMesh::Point(X(0,i), X(1,i), X(2,i));
-        }
-        
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        RealMatrixX new_coordinates = RealMatrixX::Zero(3,test_elem.n_nodes);
+        new_coordinates << 0.0, 0.0, 0.0, 0.0, -1.0, 1.0;
+        test_elem.update_coordinates(new_coordinates);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_rotated_about_z")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element rotated about z-axis")
     {
         // Rotated 63.4 about z-axis at element's centroid
-        transform_element(mesh, X0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 63.4);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 63.4);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_rotated_about_y")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element rotated about y-axis")
     {
         // Rotated 35.8 about y-axis at element's centroid
-        transform_element(mesh, X0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 35.8, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 35.8, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_scaled_x")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element stretched in x-direction")
     {
-        // Rotated 63.4 about z-axis at element's centroid
-        transform_element(mesh, X0, 0.0, 0.0, 0.0, 3.2, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                3.2, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_arbitrary_transformation")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element arbitrarily scaled, stretched, and rotated")
     {
-        // Arbitrary transformations applied to the element
-        transform_element(mesh, X0, -5.0, 7.8, -13.1, 2.7, 6.4, 20.0, 47.8, -70.1);
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        // Apply arbitrary transformation to the element
+        TEST::transform_element(test_elem.mesh, coords, -5.0, 7.8, -13.1,
+                                2.7, 6.4, 20.0, 47.8, -70.1);
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_arbitrary_with_displacements")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element arbitrarily scaled, stretched, rotated, and displaced")
     {
-        // Arbitrary transformations applied to the element
-        transform_element(mesh, X0, 4.1, -6.3, 7.5, 4.2, 1.5, -18.0, -24.8, 
-                          30.1);
-        
-        // Calculate residual and jacobian at arbitrary displacement
-        RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
-        elem_sol << 0.08158724,  0.07991906, -0.00719128,  0.02025461, 
-                    -0.04602193, 0.05280159,  0.03700081,  0.04636344,  
-                    0.05559377,  0.06448206, 0.08919238, -0.03079122;
-        elem->set_solution(elem_sol);
-        
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        // Apply arbitrary transformation to the element
+        TEST::transform_element(test_elem.mesh, coords, 4.1, -6.3, 7.5,
+                                4.2, 1.5, -18.0, -24.8, 30.1);
+
+        // Apply arbitrary displacement to the element
+        RealVectorX elem_sol = RealVectorX::Zero(test_elem.n_dofs);
+        elem_sol << 0.08158724,  0.07991906, -0.00719128,  0.02025461,
+                   -0.04602193,  0.05280159,  0.03700081,  0.04636344,
+                    0.05559377,  0.06448206,  0.08919238, -0.03079122;
+        test_elem.elem->set_solution(elem_sol);
+
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
 }

--- a/tests/element/structural/1D/edge2/mast_edge2_linear_structural_extension_internal_jacobian.cpp
+++ b/tests/element/structural/1D/edge2/mast_edge2_linear_structural_extension_internal_jacobian.cpp
@@ -1,16 +1,25 @@
-// C++ Stanard Includes
-#include <math.h>
-
-// Catch2 includes
-#include "catch.hpp"
+/*
+ * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
+ * Copyright (C) 2013-2020  Manav Bhatia and MAST authors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
 
 // libMesh includes
 #include "libmesh/libmesh.h"
-#include "libmesh/replicated_mesh.h"
-#include "libmesh/point.h"
 #include "libmesh/elem.h"
-#include "libmesh/edge_edge2.h"
-#include "libmesh/equation_systems.h"
 #include "libmesh/dof_map.h"
 
 // MAST includes
@@ -20,15 +29,15 @@
 #include "property_cards/solid_1d_section_element_property_card.h"
 #include "elasticity/structural_element_1d.h"
 #include "elasticity/structural_system_initialization.h"
-#include "base/physics_discipline_base.h"
 #include "base/nonlinear_implicit_assembly.h"
 #include "elasticity/structural_nonlinear_assembly.h"
 #include "base/nonlinear_system.h"
-#include "elasticity/structural_element_base.h"
 #include "mesh/geom_elem.h"
 
-// Custom includes
+// Test includes
+#include "catch.hpp"
 #include "test_helpers.h"
+#include "element/structural/1D/mast_structural_element_1d.h"
 
 #define pi 3.14159265358979323846
 
@@ -36,240 +45,72 @@ extern libMesh::LibMeshInit* p_global_init;
 
 
 TEST_CASE("edge2_linear_extension_structural",
-          "[1D],[structural],[edge],[edge2],[linear]")
+          "[1D][structural][edge][edge2][linear]")
 {
-    const int n_elems = 1;
-    const int n_nodes = 2;
-    
-    RealMatrixX temp = RealMatrixX::Zero(3,n_nodes);
-    temp << -1.0, 1.0, 0.0, 0.0, 0.0, 0.0;
-    const RealMatrixX X0 = temp;
-    
-    /**
-     * Create the mesh with the one element we are testing
-     */
-    libMesh::ReplicatedMesh mesh(p_global_init->comm());
-    mesh.set_mesh_dimension(1);
-    mesh.set_spatial_dimension(3);
-    mesh.reserve_elem(n_elems);
-    mesh.reserve_nodes(n_nodes);
-    
-    // Add nodes to the mesh
-    for (uint i=0; i<n_nodes; i++)
-    {
-        mesh.add_point(libMesh::Point(X0(0,i), X0(1,i), X0(2,i)));
-    }
-    
-    // Add the element to the mesh
-    libMesh::Elem *reference_elem = new libMesh::Edge2;
-    reference_elem->set_id(0);    
-    reference_elem->subdomain_id() = 0;
-    reference_elem = mesh.add_elem(reference_elem);
-    for (int i=0; i<n_nodes; i++)
-    {
-        reference_elem->set_node(i) = mesh.node_ptr(i);
-    }
-    
-    // Prepare the mesh for use
-    mesh.prepare_for_use();
-    
-    // Ensure the libMesh element has the expected volume
-    const Real elem_volume = reference_elem->volume();
-    Real true_volume = 2.0;
-    REQUIRE( elem_volume == true_volume );
-    
-    // Define Material Properties as MAST Parameters
-    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
-    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
-    MAST::Parameter rho("rho_param", 1420.5);         // Density
-    MAST::Parameter alpha("alpha_param", 5.43e-05);   // Coefficient of thermal expansion
-    MAST::Parameter cp("cp_param",   908.0);          // Specific Heat Capacity
-    MAST::Parameter k("k_param",     237.0);          // Thermal Conductivity
-    
-    // Define Section Properties as MAST Parameters
-    MAST::Parameter thickness_y("thy_param", 0.06);   // Section thickness in y-direction
-    MAST::Parameter thickness_z("thz_param", 0.04);   // Section thickness in z-direction
-    MAST::Parameter offset_y("offy_param", 0.035);    // Section offset in y-direction
-    MAST::Parameter offset_z("offz_param", 0.026);    // Section offset in z-direction
-    MAST::Parameter kappa_zz("kappa_zz", 5.0/6.0);    // Shear coefficient
-    MAST::Parameter kappa_yy("kappa_yy", 2.0/6.0);    // Shear coefficient
-    
-    // Create field functions to dsitribute these constant parameters throughout the model
-    MAST::ConstantFieldFunction E_f("E", E);
-    MAST::ConstantFieldFunction nu_f("nu", nu);
-    MAST::ConstantFieldFunction rho_f("rho", rho);
-    MAST::ConstantFieldFunction alpha_f("alpha_expansion", alpha);
-    MAST::ConstantFieldFunction cp_f("cp", cp);
-    MAST::ConstantFieldFunction k_f("k_th", k);
-    MAST::ConstantFieldFunction thicknessy_f("hy", thickness_y);
-    MAST::ConstantFieldFunction offsety_f("hy_off", offset_y);
-    MAST::ConstantFieldFunction thicknessz_f("hz", thickness_z);
-    MAST::ConstantFieldFunction offsetz_f("hz_off", offset_z);
-    MAST::ConstantFieldFunction kappa_zz_f("Kappazz", kappa_zz);
-    MAST::ConstantFieldFunction kappa_yy_f("Kappayy", kappa_yy);
-    
-    // Initialize the material
-    MAST::IsotropicMaterialPropertyCard material;                   
-    
-    // Add the material property constant field functions to the material card
-    material.add(E_f);
-    material.add(nu_f);
-    material.add(rho_f);
-    material.add(alpha_f);
-    material.add(k_f);
-    material.add(cp_f);
-    
-    // Initialize the section
-    MAST::Solid1DSectionElementPropertyCard section;
-    
-    // Add the section property constant field functions to the section card
-    section.add(thicknessy_f);
-    section.add(offsety_f);
-    section.add(thicknessz_f);
-    section.add(offsetz_f);
-    section.add(kappa_zz_f);
-    section.add(kappa_yy_f);
-    
-    // Add the material card to the section card
-    section.set_material(material);
-    
-    // Specify a section orientation point and add it to the section.
-    RealVectorX orientation = RealVectorX::Zero(3);
-    orientation(1) = 1.0;
-    section.y_vector() = orientation;
-    
-    // Set the strain type to linear for the section
-    section.set_strain(MAST::LINEAR_STRAIN);
-    
-    // Now initialize the section
-    section.init();
-    
-    /**
-     *  Now we setup the structural system we will be solving.
-     */
-    libMesh::EquationSystems equation_systems(mesh);
-    
-    MAST::NonlinearSystem& system = equation_systems.add_system<MAST::NonlinearSystem>("structural");
-    
-    libMesh::FEType fetype(libMesh::FIRST, libMesh::LAGRANGE);
-    
-    MAST::StructuralSystemInitialization structural_system(system, 
-                                                           system.name(), 
-                                                           fetype);
-    
-    MAST::PhysicsDisciplineBase discipline(equation_systems);
-    
-    discipline.set_property_for_subdomain(0, section);
-    
-    equation_systems.init();
-    //equation_systems.print_info();
-    
-    MAST::NonlinearImplicitAssembly assembly;
-    assembly.set_discipline_and_system(discipline, structural_system);
-    
-    // Create the MAST element from the libMesh reference element
-    MAST::GeomElem geom_elem;
-    geom_elem.init(*reference_elem, structural_system);
-    std::unique_ptr<MAST::StructuralElementBase> elem_base = build_structural_element(structural_system, geom_elem, section);
-    
-    // Cast the base structural element as a 2D structural element
-    MAST::StructuralElement1D* elem = (dynamic_cast<MAST::StructuralElement1D*>(elem_base.get()));
-    
-    // Get element DOFs
-    const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
-    std::vector<libMesh::dof_id_type> dof_indices;
-    dof_map.dof_indices (reference_elem, dof_indices);
-    uint n_dofs = uint(dof_indices.size());
-    
-    // Set element's initial solution and solution sensitivity to zero
-    RealVectorX elem_solution = RealVectorX::Zero(n_dofs);
-    elem->set_solution(elem_solution);
-    elem->set_solution(elem_solution, true);
-    
-    const Real V0 = reference_elem->volume();
-    
-    /**
-     *  Below, we start building the Jacobian up for a very basic element that 
-     *  is already in an isoparametric format.  The following four steps:
-     *      Extension Only Stiffness
-     *      Extension & Bending Stiffness
-     *      Extension, Bending, & Transverse Shear Stiffness
-     *      Extension, Bending, & Extension-Bending Coupling Stiffness
-     *      Extension, Bending, Transverse Shear & Extension-Bending Coupling Stiffness
-     * 
-     *  Testing the Jacobian incrementally this way allows errors in the
-     *  Jacobian to be located more precisely.
-     * 
-     *  It would probably be even better to test each stiffness contribution 
-     *  separately, but currently, we don't have a way to disable extension
-     *  stiffness and transverse shear stiffness doesn't exist without bending 
-     *  and extension-bending coupling stiffness don't make sense without both
-     *  extension and/or bending. 
-     */
-    
+    RealMatrixX coords = RealMatrixX::Zero(3, 2);
+    coords << -1.0, 1.0, 0.0,
+               0.0, 0.0, 0.0;
+    TEST::TestStructuralSingleElement1D test_elem(libMesh::EDGE2, coords);
+
+    const Real V0 = test_elem.reference_elem->volume();
+
     // Set shear coefficient to zero to disable transverse shear stiffness
-    kappa_zz = 0.0;
-    kappa_yy = 0.0;
-    
+    test_elem.kappa_zz = 0.0;
+    test_elem.kappa_yy = 0.0;
+
     // Set the offset to zero to disable extension-bending coupling
-    offset_y = 0.0;
-    offset_z = 0.0;
+    test_elem.offset_y = 0.0;
+    test_elem.offset_z = 0.0;
+
+    // Set the bending operator to no_bending to disable bending stiffness. This also disables
+    // transverse shear stiffness.
+    test_elem.section.set_bending_model(MAST::NO_BENDING);
+
+    // Update residual and Jacobian storage since we have modified baseline test element properties.
+    test_elem.update_residual_and_jacobian0();
+
+    double val_margin = (test_elem.jacobian0.array().abs()).mean() * 1.490116119384766e-08;
+
+    libMesh::out << "J =\n" << test_elem.jacobian0 << std::endl;
+
     
-    // Set the bending operator to no_bending to disable bending stiffness
-    // NOTE: This also disables the transverse shear stiffness
-    section.set_bending_model(MAST::NO_BENDING);
-    
-    // Calculate residual and jacobian
-    RealVectorX residual = RealVectorX::Zero(n_dofs);
-    RealMatrixX jacobian0 = RealMatrixX::Zero(n_dofs, n_dofs);
-    elem->internal_residual(true, residual, jacobian0);
-            
-    double val_margin = (jacobian0.array().abs()).mean() * 1.490116119384766e-08;
-        
-    SECTION("internal_jacobian_finite_difference_check")                   
+    SECTION("Internal Jacobian (stiffness matrix) finite difference check")
     {
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem,
+                test_elem.elem_solution, test_elem.jacobian_fd);
+
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
     }
-    
-    
-    SECTION("internal_jacobian_symmetry_check")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) should be symmetric")
     {
-        // Element stiffness matrix should be symmetric
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0.transpose());
-        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0.transpose())));
     }
-    
-    
-    SECTION("internal_jacobian_determinant_check")
+
+
+    SECTION("Determinant of undeformed internal Jacobian (stiffness matrix) should be zero")
     {
-        // Determinant of undeformed element stiffness matrix should be zero
-        REQUIRE( jacobian0.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian0.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    
-    SECTION("internal_jacobian_eigenvalue_check")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) eigenvalue check")
     {
-        /**
+        /*
          * Number of zero eigenvalues should equal the number of rigid body
-         * modes.  For 1D extension (including torsion), we have 1 rigid 
-         * translations along the element's x-axis and 1 rigid rotation about 
+         * modes.  For 1D extension (including torsion), we have 1 rigid
+         * translations along the element's x-axis and 1 rigid rotation about
          * the element's x-axis, for a total of 2 rigid body modes.
-         * 
+         *
          * Note that the use of reduced integration can result in more rigid
          * body modes than expected.
          */
-        SelfAdjointEigenSolver<RealMatrixX> eigensolver(jacobian0, false);
+        SelfAdjointEigenSolver<RealMatrixX> eigensolver(test_elem.jacobian0, false);
         RealVectorX eigenvalues = eigensolver.eigenvalues();
         uint nz = 0;
         for (uint i=0; i<eigenvalues.size(); i++)
@@ -279,391 +120,239 @@ TEST_CASE("edge2_linear_extension_structural",
                 nz++;
             }
         }
-        REQUIRE( nz == 2);
-        
-        /**
+        REQUIRE(nz == 2);
+
+        /*
          * All non-zero eigenvalues should be positive.
          */
         REQUIRE(eigenvalues.minCoeff()>(-1e-10));
     }
-    
-    
-//     SECTION("internal_jacobian_orientation_invariant")
-//     {
-//         
-//     }
-    
-    
-    SECTION("internal_jacobian_displacement_invariant")
-    {
-        // Calculate residual and jacobian at arbitrary displacement
-        RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
-        elem_sol << 0.05727841,  0.08896581,  0.09541619, -0.03774913,  
-                    0.07510557, -0.07122266, -0.00979117, -0.08300009, 
-                    -0.03453369, -0.05487761, -0.01407677, -0.09268421;
-        elem->set_solution(elem_sol);
-        
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-                
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
 
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
-    }
-    
-    SECTION("internal_jacobian_shifted_x_invariant")
-    {
-        // Shifted in x-direction
-        transform_element(mesh, X0, 5.2, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-                
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
 
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
-    }
-    
-    SECTION("internal_jacobian_shifted_y_invariant")
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to displacement solution")
     {
-        // Shifted in y-direction
-        transform_element(mesh, X0, 0.0, -11.5, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
-        
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        RealVectorX elem_sol = RealVectorX::Zero(test_elem.n_dofs);
+        elem_sol << 0.05727841,  0.08896581,  0.09541619, -0.03774913,
+                    0.07510557, -0.07122266, -0.00979117, -0.08300009,
+                   -0.03453369, -0.05487761, -0.01407677, -0.09268421;
+        test_elem.elem->set_solution(elem_sol);
+        test_elem.update_residual_and_jacobian();
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
     }
-    
-    SECTION("internal_jacobian_shifted_z_invariant")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to element x-location")
     {
-        // Shifted in y-direction
-        transform_element(mesh, X0, 0.0, 0.0, 7.6, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
-        
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        TEST::transform_element(test_elem.mesh, coords,5.2, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
     }
-    
-    
-    SECTION("internal_jacobian_aligned_y")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to element y-location")
+    {
+        TEST::transform_element(test_elem.mesh, coords, 0.0, -11.5, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
+    }
+
+
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to element z-location")
+    {
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 7.6,
+                                1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
+    }
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element aligned along y-axis")
     {
         /*
          * NOTE: We could try to use the transform_element method here, but the
          * issue is that if the sin and cos calculations are not exact, then we
          * may not be perfectly aligned along the y axis like we want.
          */
-        RealMatrixX X= RealMatrixX::Zero(3,n_nodes);
-        X << 0.0, 0.0, -1.0, 1.0, 0.0, 0.0;
-        for (int i=0; i<n_nodes; i++)
-        {
-            (*mesh.node_ptr(i)) = libMesh::Point(X(0,i), X(1,i), X(2,i));
-        }
-        
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        RealMatrixX new_coordinates = RealMatrixX::Zero(3,test_elem.n_nodes);
+        new_coordinates << 0.0, 0.0, -1.0, 1.0, 0.0, 0.0;
+        test_elem.update_coordinates(new_coordinates);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_aligned_z")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element aligned along z-axis")
     {
         /*
          * NOTE: We could try to use the transform_element method here, but the
          * issue is that if the sin and cos calculations are not exact, then we
          * may not be perfectly aligned along the z axis like we want.
          */
-        RealMatrixX X= RealMatrixX::Zero(3,n_nodes);
-        X << 0.0, 0.0, 0.0, 0.0, -1.0, 1.0;
-        for (int i=0; i<n_nodes; i++)
-        {
-            (*mesh.node_ptr(i)) = libMesh::Point(X(0,i), X(1,i), X(2,i));
-        }
-        
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        RealMatrixX new_coordinates = RealMatrixX::Zero(3,test_elem.n_nodes);
+        new_coordinates << 0.0, 0.0, 0.0, 0.0, -1.0, 1.0;
+        test_elem.update_coordinates(new_coordinates);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_rotated_about_z")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element rotated about z-axis")
     {
         // Rotated 63.4 about z-axis at element's centroid
-        transform_element(mesh, X0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 63.4);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                        1.0, 1.0, 0.0, 0.0, 63.4);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_rotated_about_y")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element rotated about y-axis")
     {
         // Rotated 35.8 about y-axis at element's centroid
-        transform_element(mesh, X0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 35.8, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 35.8, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_scaled_x")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element stretched in x-direction")
     {
-        // Rotated 63.4 about z-axis at element's centroid
-        transform_element(mesh, X0, 0.0, 0.0, 0.0, 3.2, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                3.2, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_arbitrary_transformation")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element arbitrarily scaled, stretched, and rotated")
     {
-        // Arbitrary transformations applied to the element
-        transform_element(mesh, X0, -5.0, 7.8, -13.1, 2.7, 6.4, 20.0, 47.8, -70.1);
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        // Apply arbitrary transformation to the element
+        TEST::transform_element(test_elem.mesh, coords, -5.0, 7.8, -13.1,
+                                2.7, 6.4, 20.0, 47.8, -70.1);
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_arbitrary_with_displacements")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element arbitrarily scaled, stretched, rotated, and displaced")
     {
-        // Arbitrary transformations applied to the element
-        transform_element(mesh, X0, 4.1, -6.3, 7.5, 4.2, 1.5, -18.0, -24.8, 
-                          30.1);
-        
-        // Calculate residual and jacobian at arbitrary displacement
-        RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
-        elem_sol << 0.08158724,  0.07991906, -0.00719128,  0.02025461, 
-                    -0.04602193, 0.05280159,  0.03700081,  0.04636344,  
-                    0.05559377,  0.06448206, 0.08919238, -0.03079122;
-        elem->set_solution(elem_sol);
-        
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        // Apply arbitrary transformation to the element
+        TEST::transform_element(test_elem.mesh, coords, 4.1, -6.3, 7.5,
+                        4.2, 1.5, -18.0, -24.8, 30.1);
+
+        // Apply arbitrary displacement to the element
+        RealVectorX elem_sol = RealVectorX::Zero(test_elem.n_dofs);
+        elem_sol << 0.08158724,  0.07991906, -0.00719128,  0.02025461,
+                   -0.04602193,  0.05280159,  0.03700081,  0.04636344,
+                    0.05559377,  0.06448206,  0.08919238, -0.03079122;
+        test_elem.elem->set_solution(elem_sol);
+
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
 }

--- a/tests/element/structural/1D/edge2/mast_edge2_linear_structural_inertial_jacobian.cpp
+++ b/tests/element/structural/1D/edge2/mast_edge2_linear_structural_inertial_jacobian.cpp
@@ -1,16 +1,25 @@
-// C++ Stanard Includes
-#include <math.h>
-
-// Catch2 includes
-#include "catch.hpp"
+/*
+ * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
+ * Copyright (C) 2013-2020  Manav Bhatia and MAST authors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
 
 // libMesh includes
 #include "libmesh/libmesh.h"
-#include "libmesh/replicated_mesh.h"
-#include "libmesh/point.h"
 #include "libmesh/elem.h"
-#include "libmesh/edge_edge2.h"
-#include "libmesh/equation_systems.h"
 #include "libmesh/dof_map.h"
 
 // MAST includes
@@ -20,15 +29,15 @@
 #include "property_cards/solid_1d_section_element_property_card.h"
 #include "elasticity/structural_element_1d.h"
 #include "elasticity/structural_system_initialization.h"
-#include "base/physics_discipline_base.h"
 #include "base/nonlinear_implicit_assembly.h"
 #include "elasticity/structural_nonlinear_assembly.h"
 #include "base/nonlinear_system.h"
-#include "elasticity/structural_element_base.h"
 #include "mesh/geom_elem.h"
 
-// Custom includes
+// Test includes
+#include "catch.hpp"
 #include "test_helpers.h"
+#include "element/structural/1D/mast_structural_element_1d.h"
 
 #define pi 3.14159265358979323846
 
@@ -38,214 +47,50 @@ extern libMesh::LibMeshInit* p_global_init;
 TEST_CASE("edge2_linear_structural_inertial_consistent",
           "[1D],[dynamic],[edge],[edge2],[element]")
 {
-    const int n_elems = 1;
-    const int n_nodes = 2;
+    RealMatrixX coords = RealMatrixX::Zero(3, 2);
+    coords << -1.0, 1.0, 0.0,
+               0.0, 0.0, 0.0;
+    TEST::TestStructuralSingleElement1D test_elem(libMesh::EDGE2, coords);
     
-    RealMatrixX temp = RealMatrixX::Zero(3,n_nodes);
-    temp << -1.0, 1.0, 0.0, 0.0, 0.0, 0.0;
-    const RealMatrixX X0 = temp;
+    const Real V0 = test_elem.reference_elem->volume();
+
+    // Set mass matrix to consistent & compute inertial residual and Jacobians.
+    test_elem.section.set_diagonal_mass_matrix(false);
+    test_elem.update_inertial_residual_and_jacobian0();
+
+    double val_margin = (test_elem.jacobian_xddot0.array().abs()).mean() * 1.490116119384766e-08;
     
-    /**
-     * Create the mesh with the one element we are testing
-     */
-    libMesh::ReplicatedMesh mesh(p_global_init->comm());
-    mesh.set_mesh_dimension(1);
-    mesh.set_spatial_dimension(3);
-    mesh.reserve_elem(n_elems);
-    mesh.reserve_nodes(n_nodes);
-    
-    // Add nodes to the mesh
-    for (uint i=0; i<n_nodes; i++)
+    libMesh::out << "Jac_xddot0:\n" << test_elem.jacobian_xddot0 << std::endl;
+
+
+    SECTION("Inertial Jacobian (mass matrix) finite difference check")
     {
-        mesh.add_point(libMesh::Point(X0(0,i), X0(1,i), X0(2,i)));
-    }
-    
-    // Add the element to the mesh
-    libMesh::Elem *reference_elem = new libMesh::Edge2;
-    reference_elem->set_id(0);    
-    reference_elem->subdomain_id() = 0;
-    reference_elem = mesh.add_elem(reference_elem);
-    for (int i=0; i<n_nodes; i++)
-    {
-        reference_elem->set_node(i) = mesh.node_ptr(i);
-    }
-    
-    // Prepare the mesh for use
-    mesh.prepare_for_use();
-    
-    // Ensure the libMesh element has the expected volume
-    const Real elem_volume = reference_elem->volume();
-    Real true_volume = 2.0;
-    REQUIRE( elem_volume == true_volume );
-    
-    // Define Material Properties as MAST Parameters
-    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
-    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
-    MAST::Parameter rho("rho_param", 1420.5);         // Density
-    MAST::Parameter alpha("alpha_param", 5.43e-05);   // Coefficient of thermal expansion
-    MAST::Parameter cp("cp_param",   908.0);          // Specific Heat Capacity
-    MAST::Parameter k("k_param",     237.0);          // Thermal Conductivity
-    
-    // Define Section Properties as MAST Parameters
-    MAST::Parameter thickness_y("thy_param", 0.8);   // Section thickness in y-direction
-    MAST::Parameter thickness_z("thz_param", 0.7);   // Section thickness in z-direction
-    MAST::Parameter offset_y("offy_param", 0.5);    // Section offset in y-direction
-    MAST::Parameter offset_z("offz_param", 0.4);    // Section offset in z-direction
-    MAST::Parameter kappa_zz("kappa_zz", 5.0/6.0);    // Shear coefficient
-    MAST::Parameter kappa_yy("kappa_yy", 2.0/6.0);    // Shear coefficient
-    
-    // Create field functions to dsitribute these constant parameters throughout the model
-    MAST::ConstantFieldFunction E_f("E", E);
-    MAST::ConstantFieldFunction nu_f("nu", nu);
-    MAST::ConstantFieldFunction rho_f("rho", rho);
-    MAST::ConstantFieldFunction alpha_f("alpha_expansion", alpha);
-    MAST::ConstantFieldFunction cp_f("cp", cp);
-    MAST::ConstantFieldFunction k_f("k_th", k);
-    MAST::ConstantFieldFunction thicknessy_f("hy", thickness_y);
-    MAST::ConstantFieldFunction offsety_f("hy_off", offset_y);
-    MAST::ConstantFieldFunction thicknessz_f("hz", thickness_z);
-    MAST::ConstantFieldFunction offsetz_f("hz_off", offset_z);
-    MAST::ConstantFieldFunction kappa_zz_f("Kappazz", kappa_zz);
-    MAST::ConstantFieldFunction kappa_yy_f("Kappayy", kappa_yy);
-    
-    // Initialize the material
-    MAST::IsotropicMaterialPropertyCard material;                   
-    
-    // Add the material property constant field functions to the material card
-    material.add(E_f);
-    material.add(nu_f);
-    material.add(rho_f);
-    material.add(alpha_f);
-    material.add(k_f);
-    material.add(cp_f);
-    
-    // Initialize the section
-    MAST::Solid1DSectionElementPropertyCard section;
-    
-    // Add the section property constant field functions to the section card
-    section.add(thicknessy_f);
-    section.add(offsety_f);
-    section.add(thicknessz_f);
-    section.add(offsetz_f);
-    section.add(kappa_zz_f);
-    section.add(kappa_yy_f);
-    
-    // Add the material card to the section card
-    section.set_material(material);
-    
-    // Specify a section orientation point and add it to the section.
-    RealVectorX orientation = RealVectorX::Zero(3);
-    orientation(2) = 1.0;
-    section.y_vector() = orientation;
-    
-    // Set the strain type to linear for the section
-    section.set_strain(MAST::LINEAR_STRAIN);
-    
-    // Set the bending operator to Timoshenko
-    section.set_bending_model(MAST::TIMOSHENKO);
-    
-    // Now initialize the section
-    section.init();
-    
-    /**
-     *  Now we setup the structural system we will be solving.
-     */
-    libMesh::EquationSystems equation_systems(mesh);
-    
-    MAST::NonlinearSystem& system = equation_systems.add_system<MAST::NonlinearSystem>("structural");
-    
-    libMesh::FEType fetype(libMesh::FIRST, libMesh::LAGRANGE);
-    
-    MAST::StructuralSystemInitialization structural_system(system, 
-                                                           system.name(), 
-                                                           fetype);
-    
-    MAST::PhysicsDisciplineBase discipline(equation_systems);
-    
-    discipline.set_property_for_subdomain(0, section);
-    
-    equation_systems.init();
-    //equation_systems.print_info();
-    
-    MAST::NonlinearImplicitAssembly assembly;
-    assembly.set_discipline_and_system(discipline, structural_system);
-    
-    // Create the MAST element from the libMesh reference element
-    MAST::GeomElem geom_elem;
-    geom_elem.init(*reference_elem, structural_system);
-    std::unique_ptr<MAST::StructuralElementBase> elem_base = build_structural_element(structural_system, geom_elem, section);
-    
-    // Cast the base structural element as a 2D structural element
-    MAST::StructuralElement1D* elem = (dynamic_cast<MAST::StructuralElement1D*>(elem_base.get()));
-    
-    // Get element DOFs
-    const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
-    std::vector<libMesh::dof_id_type> dof_indices;
-    dof_map.dof_indices (reference_elem, dof_indices);
-    uint n_dofs = uint(dof_indices.size());
-    
-    // Set element's initial solution and solution sensitivity to zero
-    RealVectorX elem_solution = RealVectorX::Zero(n_dofs);
-    elem->set_solution(elem_solution);
-    elem->set_solution(elem_solution, true);
-    
-    // Set element's initial acceleration and acceleration sensitivity to zero
-    RealVectorX elem_accel = RealVectorX::Zero(n_dofs);
-    elem->set_acceleration(elem_accel);
-    elem->set_acceleration(elem_accel, true);
-    
-    const Real V0 = reference_elem->volume();
-    
-    // Calculate residual and jacobian
-    RealVectorX residual = RealVectorX::Zero(n_dofs);
-    RealMatrixX jac0 = RealMatrixX::Zero(n_dofs, n_dofs);
-    RealMatrixX jac_xddot0 = RealMatrixX::Zero(n_dofs, n_dofs);
-    RealMatrixX jac_xdot0 = RealMatrixX::Zero(n_dofs, n_dofs);
-    elem->inertial_residual(true, residual, jac_xddot0, jac_xdot0, jac0);
-            
-    double val_margin = (jac_xddot0.array().abs()).mean() * 1.490116119384766e-08;
-    
-    //libMesh::out << "Jac_xddot0:\n" << jac_xddot0 << std::endl;
-    
-    SECTION("inertial_jacobian_finite_difference_check")                   
-    {
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_inertial_jacobian_with_finite_difference(*elem, elem_accel, jacobian_fd);
-        
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        
-        std::vector<double> test =  eigen_matrix_to_std_vector(jac_xddot0);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        TEST::approximate_inertial_jacobian_with_finite_difference(*test_elem.elem,
+                                                                   test_elem.elem_solution, test_elem.jacobian_fd);
+
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_xddot0),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
     }
     
     
-    SECTION("inertial_jacobian_symmetry_check")
+    SECTION("Inertial Jacobian (mass matrix) should be symmetric")
     {
-        // Element inertial jacobian should be symmetric
-        std::vector<double> test =  eigen_matrix_to_std_vector(jac_xddot0);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jac_xddot0.transpose());
-        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_xddot0),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_xddot0.transpose())));
     }
     
     
-    SECTION("inertial_jacobian_determinant_check")
+    SECTION("Determinant of undeformed inertial Jacobian (mass matrix) should be zero")
     {
-        // Determinant of inertial jacobian should be positive
-        REQUIRE( jac_xddot0.determinant() > 0.0 );
+        REQUIRE(test_elem.jacobian_xddot0.determinant() == Approx(0.0).margin(1e-06));
     }
     
     
-    SECTION("inertial_jacobian_eigenvalue_check")
+    SECTION("Inertial Jacobian (mass matrix) eigenvalues should all be positive")
     {
-        /**
-         * A lumped mass matrix should have all positive eigenvalues since it
-         * is a diagonal matrix and masses should not be zero or negative.
-         */
-        SelfAdjointEigenSolver<RealMatrixX> eigensolver(jac_xddot0, false);
+        SelfAdjointEigenSolver<RealMatrixX> eigensolver(test_elem.jacobian_xddot0, false);
         RealVectorX eigenvalues = eigensolver.eigenvalues();
         //libMesh::out << "Eigenvalues are:\n" << eigenvalues << std::endl;
         REQUIRE(eigenvalues.minCoeff()>0.0);
@@ -256,218 +101,50 @@ TEST_CASE("edge2_linear_structural_inertial_consistent",
 TEST_CASE("edge2_linear_structural_inertial_lumped",
           "[1D],[dynamic],[edge],[edge2]")
 {
-    const int n_elems = 1;
-    const int n_nodes = 2;
-    
-    RealMatrixX temp = RealMatrixX::Zero(3,n_nodes);
-    temp << -1.0, 1.0, 0.0, 0.0, 0.0, 0.0;
-    const RealMatrixX X0 = temp;
-    
-    /**
-     * Create the mesh with the one element we are testing
-     */
-    libMesh::ReplicatedMesh mesh(p_global_init->comm());
-    mesh.set_mesh_dimension(1);
-    mesh.set_spatial_dimension(3);
-    mesh.reserve_elem(n_elems);
-    mesh.reserve_nodes(n_nodes);
-    
-    // Add nodes to the mesh
-    for (uint i=0; i<n_nodes; i++)
+    RealMatrixX coords = RealMatrixX::Zero(3, 2);
+    coords << -1.0, 1.0, 0.0,
+            0.0, 0.0, 0.0;
+    TEST::TestStructuralSingleElement1D test_elem(libMesh::EDGE2, coords);
+
+    const Real V0 = test_elem.reference_elem->volume();
+
+    // Set mass matrix to lumped & compute inertial residual and Jacobians.
+    test_elem.section.set_diagonal_mass_matrix(true);
+    test_elem.update_inertial_residual_and_jacobian0();
+
+    double val_margin = (test_elem.jacobian_xddot0.array().abs()).mean() * 1.490116119384766e-08;
+
+    libMesh::out << "Jac_xddot0:\n" << test_elem.jacobian_xddot0 << std::endl;
+
+
+    SECTION("Inertial Jacobian (mass matrix) finite difference check")
     {
-        mesh.add_point(libMesh::Point(X0(0,i), X0(1,i), X0(2,i)));
+        TEST::approximate_inertial_jacobian_with_finite_difference(*test_elem.elem,
+                                                                   test_elem.elem_solution, test_elem.jacobian_fd);
+
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_xddot0),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
     }
-    
-    // Add the element to the mesh
-    libMesh::Elem *reference_elem = new libMesh::Edge2;
-    reference_elem->set_id(0);    
-    reference_elem->subdomain_id() = 0;
-    reference_elem = mesh.add_elem(reference_elem);
-    for (int i=0; i<n_nodes; i++)
+
+
+    SECTION("Inertial Jacobian (mass matrix) should be symmetric")
     {
-        reference_elem->set_node(i) = mesh.node_ptr(i);
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_xddot0),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_xddot0.transpose())));
     }
-    
-    // Prepare the mesh for use
-    mesh.prepare_for_use();
-    
-    // Ensure the libMesh element has the expected volume
-    const Real elem_volume = reference_elem->volume();
-    Real true_volume = 2.0;
-    REQUIRE( elem_volume == true_volume );
-    
-    // Define Material Properties as MAST Parameters
-    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
-    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
-    MAST::Parameter rho("rho_param", 1420.5);         // Density
-    MAST::Parameter alpha("alpha_param", 5.43e-05);   // Coefficient of thermal expansion
-    MAST::Parameter cp("cp_param",   908.0);          // Specific Heat Capacity
-    MAST::Parameter k("k_param",     237.0);          // Thermal Conductivity
-    
-    // Define Section Properties as MAST Parameters
-    MAST::Parameter thickness_y("thy_param", 0.8);   // Section thickness in y-direction
-    MAST::Parameter thickness_z("thz_param", 0.7);   // Section thickness in z-direction
-    MAST::Parameter offset_y("offy_param", 0.5);    // Section offset in y-direction
-    MAST::Parameter offset_z("offz_param", 0.4);    // Section offset in z-direction
-    MAST::Parameter kappa_zz("kappa_zz", 5.0/6.0);    // Shear coefficient
-    MAST::Parameter kappa_yy("kappa_yy", 2.0/6.0);    // Shear coefficient
-    
-    // Create field functions to dsitribute these constant parameters throughout the model
-    MAST::ConstantFieldFunction E_f("E", E);
-    MAST::ConstantFieldFunction nu_f("nu", nu);
-    MAST::ConstantFieldFunction rho_f("rho", rho);
-    MAST::ConstantFieldFunction alpha_f("alpha_expansion", alpha);
-    MAST::ConstantFieldFunction cp_f("cp", cp);
-    MAST::ConstantFieldFunction k_f("k_th", k);
-    MAST::ConstantFieldFunction thicknessy_f("hy", thickness_y);
-    MAST::ConstantFieldFunction offsety_f("hy_off", offset_y);
-    MAST::ConstantFieldFunction thicknessz_f("hz", thickness_z);
-    MAST::ConstantFieldFunction offsetz_f("hz_off", offset_z);
-    MAST::ConstantFieldFunction kappa_zz_f("Kappazz", kappa_zz);
-    MAST::ConstantFieldFunction kappa_yy_f("Kappayy", kappa_yy);
-    
-    // Initialize the material
-    MAST::IsotropicMaterialPropertyCard material;                   
-    
-    // Add the material property constant field functions to the material card
-    material.add(E_f);
-    material.add(nu_f);
-    material.add(rho_f);
-    material.add(alpha_f);
-    material.add(k_f);
-    material.add(cp_f);
-    
-    // Initialize the section
-    MAST::Solid1DSectionElementPropertyCard section;
-    
-    // Add the section property constant field functions to the section card
-    section.add(thicknessy_f);
-    section.add(offsety_f);
-    section.add(thicknessz_f);
-    section.add(offsetz_f);
-    section.add(kappa_zz_f);
-    section.add(kappa_yy_f);
-    
-    // Add the material card to the section card
-    section.set_material(material);
-    
-    // Specify a section orientation point and add it to the section.
-    RealVectorX orientation = RealVectorX::Zero(3);
-    orientation(2) = 1.0;
-    section.y_vector() = orientation;
-    
-    // Set the strain type to linear for the section
-    section.set_strain(MAST::LINEAR_STRAIN);
-    
-    // Set the bending operator to Euler-Bernoulli
-    section.set_bending_model(MAST::TIMOSHENKO);
-    
-    // Set the mass matrix to be lumped as opposed to the default, consistent
-    section.set_diagonal_mass_matrix(true);
-    REQUIRE( section.if_diagonal_mass_matrix() );
-    
-    // Now initialize the section
-    section.init();
-    
-    /**
-     *  Now we setup the structural system we will be solving.
-     */
-    libMesh::EquationSystems equation_systems(mesh);
-    
-    MAST::NonlinearSystem& system = equation_systems.add_system<MAST::NonlinearSystem>("structural");
-    
-    libMesh::FEType fetype(libMesh::FIRST, libMesh::LAGRANGE);
-    
-    MAST::StructuralSystemInitialization structural_system(system, 
-                                                           system.name(), 
-                                                           fetype);
-    
-    MAST::PhysicsDisciplineBase discipline(equation_systems);
-    
-    discipline.set_property_for_subdomain(0, section);
-    
-    equation_systems.init();
-    //equation_systems.print_info();
-    
-    MAST::NonlinearImplicitAssembly assembly;
-    assembly.set_discipline_and_system(discipline, structural_system);
-    
-    // Create the MAST element from the libMesh reference element
-    MAST::GeomElem geom_elem;
-    geom_elem.init(*reference_elem, structural_system);
-    std::unique_ptr<MAST::StructuralElementBase> elem_base = build_structural_element(structural_system, geom_elem, section);
-    
-    // Cast the base structural element as a 2D structural element
-    MAST::StructuralElement1D* elem = (dynamic_cast<MAST::StructuralElement1D*>(elem_base.get()));
-    
-    // Get element DOFs
-    const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
-    std::vector<libMesh::dof_id_type> dof_indices;
-    dof_map.dof_indices (reference_elem, dof_indices);
-    uint n_dofs = uint(dof_indices.size());
-    
-    // Set element's initial solution and solution sensitivity to zero
-    RealVectorX elem_solution = RealVectorX::Zero(n_dofs);
-    elem->set_solution(elem_solution);
-    elem->set_solution(elem_solution, true);
-    
-    // Set element's initial acceleration and acceleration sensitivity to zero
-    RealVectorX elem_accel = RealVectorX::Zero(n_dofs);
-    elem->set_acceleration(elem_accel);
-    elem->set_acceleration(elem_accel, true);
-    
-    const Real V0 = reference_elem->volume();
-    
-    // Calculate residual and jacobian
-    RealVectorX residual = RealVectorX::Zero(n_dofs);
-    RealMatrixX jac0 = RealMatrixX::Zero(n_dofs, n_dofs);
-    RealMatrixX jac_xddot0 = RealMatrixX::Zero(n_dofs, n_dofs);
-    RealMatrixX jac_xdot0 = RealMatrixX::Zero(n_dofs, n_dofs);
-    elem->inertial_residual(true, residual, jac_xddot0, jac_xdot0, jac0);
-            
-    double val_margin = (jac_xddot0.array().abs()).mean() * 1.490116119384766e-08;
-    
-    //libMesh::out << "Jac_xddot0:\n" << jac_xddot0 << std::endl;
-    
-    SECTION("inertial_jacobian_finite_difference_check")                   
+
+
+    SECTION("Determinant of undeformed inertial Jacobian (mass matrix) should be zero")
     {
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_inertial_jacobian_with_finite_difference(*elem, elem_accel, jacobian_fd);
-        
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        
-        std::vector<double> test =  eigen_matrix_to_std_vector(jac_xddot0);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        REQUIRE(test_elem.jacobian_xddot0.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    
-    SECTION("inertial_jacobian_symmetry_check")
+
+
+    SECTION("Inertial Jacobian (mass matrix) eigenvalues should all be positive")
     {
-        // Element interial jacobian should be symmetric
-        std::vector<double> test =  eigen_matrix_to_std_vector(jac_xddot0);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jac_xddot0.transpose());
-        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
-    }
-    
-    
-    SECTION("inertial_jacobian_determinant_check")
-    {
-        // Determinant of inertial jacobian should be positive
-        REQUIRE( jac_xddot0.determinant() > 0.0 );
-    }
-    
-    
-    SECTION("inertial_jacobian_eigenvalue_check")
-    {
-        /**
-         * A lumped mass matrix should have all positive eigenvalues since it
-         * is a diagonal matrix and masses should not be zero or negative.
-         */
-        SelfAdjointEigenSolver<RealMatrixX> eigensolver(jac_xddot0, false);
+        SelfAdjointEigenSolver<RealMatrixX> eigensolver(test_elem.jacobian_xddot0, false);
         RealVectorX eigenvalues = eigensolver.eigenvalues();
         //libMesh::out << "Eigenvalues are:\n" << eigenvalues << std::endl;
         REQUIRE(eigenvalues.minCoeff()>0.0);

--- a/tests/element/structural/1D/edge2/mast_edge2_linear_structural_internal_jacobian.cpp
+++ b/tests/element/structural/1D/edge2/mast_edge2_linear_structural_internal_jacobian.cpp
@@ -1,16 +1,25 @@
-// C++ Stanard Includes
-#include <math.h>
-
-// Catch2 includes
-#include "catch.hpp"
+/*
+ * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
+ * Copyright (C) 2013-2020  Manav Bhatia and MAST authors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
 
 // libMesh includes
 #include "libmesh/libmesh.h"
-#include "libmesh/replicated_mesh.h"
-#include "libmesh/point.h"
 #include "libmesh/elem.h"
-#include "libmesh/edge_edge2.h"
-#include "libmesh/equation_systems.h"
 #include "libmesh/dof_map.h"
 
 // MAST includes
@@ -20,15 +29,15 @@
 #include "property_cards/solid_1d_section_element_property_card.h"
 #include "elasticity/structural_element_1d.h"
 #include "elasticity/structural_system_initialization.h"
-#include "base/physics_discipline_base.h"
 #include "base/nonlinear_implicit_assembly.h"
 #include "elasticity/structural_nonlinear_assembly.h"
 #include "base/nonlinear_system.h"
-#include "elasticity/structural_element_base.h"
 #include "mesh/geom_elem.h"
 
-// Custom includes
+// Test includes
+#include "catch.hpp"
 #include "test_helpers.h"
+#include "element/structural/1D/mast_structural_element_1d.h"
 
 #define pi 3.14159265358979323846
 
@@ -38,231 +47,56 @@ extern libMesh::LibMeshInit* p_global_init;
 TEST_CASE("edge2_linear_structural",
           "[1D],[structural],[edge],[edge2],[linear]")
 {
-    const int n_elems = 1;
-    const int n_nodes = 2;
+    RealMatrixX coords = RealMatrixX::Zero(3, 2);
+    coords << -1.0, 1.0, 0.0,
+               0.0, 0.0, 0.0;
+    TEST::TestStructuralSingleElement1D test_elem(libMesh::EDGE2, coords);
     
-    RealMatrixX temp = RealMatrixX::Zero(3,n_nodes);
-    temp << -1.0, 1.0, 0.0, 0.0, 0.0, 0.0;
-    const RealMatrixX X0 = temp;
+    const Real V0 = test_elem.reference_elem->volume();
+
+    test_elem.update_residual_and_jacobian0();
+
+    double val_margin = (test_elem.jacobian0.array().abs()).mean() * 1.490116119384766e-08;
     
-    /**
-     * Create the mesh with the one element we are testing
-     */
-    libMesh::ReplicatedMesh mesh(p_global_init->comm());
-    mesh.set_mesh_dimension(1);
-    mesh.set_spatial_dimension(3);
-    mesh.reserve_elem(n_elems);
-    mesh.reserve_nodes(n_nodes);
-    
-    // Add nodes to the mesh
-    for (uint i=0; i<n_nodes; i++)
+    libMesh::out << "J =\n" << test_elem.jacobian0 << std::endl;
+
+
+    SECTION("Internal Jacobian (stiffness matrix) finite difference check")
     {
-        mesh.add_point(libMesh::Point(X0(0,i), X0(1,i), X0(2,i)));
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem,
+                                                                   test_elem.elem_solution, test_elem.jacobian_fd);
+
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
     }
-    
-    // Add the element to the mesh
-    libMesh::Elem *reference_elem = new libMesh::Edge2;
-    reference_elem->set_id(0);    
-    reference_elem->subdomain_id() = 0;
-    reference_elem = mesh.add_elem(reference_elem);
-    for (int i=0; i<n_nodes; i++)
+
+
+    SECTION("Internal Jacobian (stiffness matrix) should be symmetric")
     {
-        reference_elem->set_node(i) = mesh.node_ptr(i);
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0.transpose())));
     }
-    
-    // Prepare the mesh for use
-    mesh.prepare_for_use();
-    
-    // Ensure the libMesh element has the expected volume
-    const Real elem_volume = reference_elem->volume();
-    Real true_volume = 2.0;
-    REQUIRE( elem_volume == true_volume );
-    
-    // Define Material Properties as MAST Parameters
-    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
-    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
-    MAST::Parameter rho("rho_param", 1420.5);         // Density
-    MAST::Parameter alpha("alpha_param", 5.43e-05);   // Coefficient of thermal expansion
-    MAST::Parameter cp("cp_param",   908.0);          // Specific Heat Capacity
-    MAST::Parameter k("k_param",     237.0);          // Thermal Conductivity
-    
-    // Define Section Properties as MAST Parameters
-    MAST::Parameter thickness_y("thy_param", 0.8);   // Section thickness in y-direction
-    MAST::Parameter thickness_z("thz_param", 0.7);   // Section thickness in z-direction
-    MAST::Parameter offset_y("offy_param", 0.5);    // Section offset in y-direction
-    MAST::Parameter offset_z("offz_param", 0.4);    // Section offset in z-direction
-    MAST::Parameter kappa_zz("kappa_zz", 5.0/6.0);    // Shear coefficient
-    MAST::Parameter kappa_yy("kappa_yy", 2.0/6.0);    // Shear coefficient
-    
-    // Create field functions to dsitribute these constant parameters throughout the model
-    MAST::ConstantFieldFunction E_f("E", E);
-    MAST::ConstantFieldFunction nu_f("nu", nu);
-    MAST::ConstantFieldFunction rho_f("rho", rho);
-    MAST::ConstantFieldFunction alpha_f("alpha_expansion", alpha);
-    MAST::ConstantFieldFunction cp_f("cp", cp);
-    MAST::ConstantFieldFunction k_f("k_th", k);
-    MAST::ConstantFieldFunction thicknessy_f("hy", thickness_y);
-    MAST::ConstantFieldFunction offsety_f("hy_off", offset_y);
-    MAST::ConstantFieldFunction thicknessz_f("hz", thickness_z);
-    MAST::ConstantFieldFunction offsetz_f("hz_off", offset_z);
-    MAST::ConstantFieldFunction kappa_zz_f("Kappazz", kappa_zz);
-    MAST::ConstantFieldFunction kappa_yy_f("Kappayy", kappa_yy);
-    
-    // Initialize the material
-    MAST::IsotropicMaterialPropertyCard material;                   
-    
-    // Add the material property constant field functions to the material card
-    material.add(E_f);
-    material.add(nu_f);
-    material.add(rho_f);
-    material.add(alpha_f);
-    material.add(k_f);
-    material.add(cp_f);
-    
-    // Initialize the section
-    MAST::Solid1DSectionElementPropertyCard section;
-    
-    // Add the section property constant field functions to the section card
-    section.add(thicknessy_f);
-    section.add(offsety_f);
-    section.add(thicknessz_f);
-    section.add(offsetz_f);
-    section.add(kappa_zz_f);
-    section.add(kappa_yy_f);
-    
-    // Add the material card to the section card
-    section.set_material(material);
-    
-    // Specify a section orientation point and add it to the section.
-    // FIXME: Orientation isn't affecting the element's jacobian for some reason
-    RealVectorX orientation = RealVectorX::Zero(3);
-    orientation(2) = 1.0;
-    section.y_vector() = orientation;
-    
-    // Set the strain type to linear for the section
-    section.set_strain(MAST::LINEAR_STRAIN);
-    
-    // Set the bending operator to Euler-Bernoulli
-    section.set_bending_model(MAST::TIMOSHENKO);
-    
-    // Now initialize the section
-    section.init();
-    
-    /**
-     *  Now we setup the structural system we will be solving.
-     */
-    libMesh::EquationSystems equation_systems(mesh);
-    
-    MAST::NonlinearSystem& system = equation_systems.add_system<MAST::NonlinearSystem>("structural");
-    
-    libMesh::FEType fetype(libMesh::FIRST, libMesh::LAGRANGE);
-    
-    MAST::StructuralSystemInitialization structural_system(system, 
-                                                           system.name(), 
-                                                           fetype);
-    
-    MAST::PhysicsDisciplineBase discipline(equation_systems);
-    
-    discipline.set_property_for_subdomain(0, section);
-    
-    equation_systems.init();
-    //equation_systems.print_info();
-    
-    MAST::NonlinearImplicitAssembly assembly;
-    assembly.set_discipline_and_system(discipline, structural_system);
-    
-    // Create the MAST element from the libMesh reference element
-    MAST::GeomElem geom_elem;
-    geom_elem.init(*reference_elem, structural_system);
-    std::unique_ptr<MAST::StructuralElementBase> elem_base = build_structural_element(structural_system, geom_elem, section);
-    
-    // Cast the base structural element as a 2D structural element
-    MAST::StructuralElement1D* elem = (dynamic_cast<MAST::StructuralElement1D*>(elem_base.get()));
-    
-    // Get element DOFs
-    const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
-    std::vector<libMesh::dof_id_type> dof_indices;
-    dof_map.dof_indices (reference_elem, dof_indices);
-    uint n_dofs = uint(dof_indices.size());
-    
-    // Set element's initial solution and solution sensitivity to zero
-    RealVectorX elem_solution = RealVectorX::Zero(n_dofs);
-    elem->set_solution(elem_solution);
-    elem->set_solution(elem_solution, true);
-    
-    const Real V0 = reference_elem->volume();
-    
-    /**
-     *  Below, we start building the Jacobian up for a very basic element that 
-     *  is already in an isoparametric format.  The following four steps:
-     *      Extension Only Stiffness
-     *      Extension & Bending Stiffness
-     *      Extension, Bending, & Transverse Shear Stiffness
-     *      Extension, Bending, & Extension-Bending Coupling Stiffness
-     *      Extension, Bending, Transverse Shear & Extension-Bending Coupling Stiffness
-     * 
-     *  Testing the Jacobian incrementally this way allows errors in the
-     *  Jacobian to be located more precisely.
-     * 
-     *  It would probably be even better to test each stiffness contribution 
-     *  separately, but currently, we don't have a way to disable extension
-     *  stiffness and transverse shear stiffness doesn't exist without bending 
-     *  and extension-bending coupling stiffness don't make sense without both
-     *  extension and/or bending. 
-     */
-    
-    // Calculate residual and jacobian
-    RealVectorX residual = RealVectorX::Zero(n_dofs);
-    RealMatrixX jacobian0 = RealMatrixX::Zero(n_dofs, n_dofs);
-    elem->internal_residual(true, residual, jacobian0);
-            
-    double val_margin = (jacobian0.array().abs()).mean() * 1.490116119384766e-08;
-    
-    libMesh::out << "J =\n" << jacobian0 << std::endl;
-    
-    SECTION("internal_jacobian_finite_difference_check")                   
+
+
+    SECTION("Determinant of undeformed internal Jacobian (stiffness matrix) should be zero")
     {
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        REQUIRE(test_elem.jacobian0.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    
-    SECTION("internal_jacobian_symmetry_check")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) eigenvalue check")
     {
-        // Element stiffness matrix should be symmetric
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0.transpose());
-        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
-    }
-    
-    
-    SECTION("internal_jacobian_determinant_check")
-    {
-        // Determinant of undeformed element stiffness matrix should be zero
-        REQUIRE( jacobian0.determinant() == Approx(0.0).margin(1e-06) );
-    }
-    
-    
-    SECTION("internal_jacobian_eigenvalue_check")
-    {
-        /**
+        /*
          * Number of zero eigenvalues should equal the number of rigid body
-         * modes.  With extension (including torsion) and bending about y and 
+         * modes.  With extension (including torsion) and bending about y and
          * z axes, we have 6 rigid body modes (3 translations, 3 rotations).
-         * 
+         *
          * Note that the use of reduced integration can result in more rigid
          * body modes than expected.
          */
-        SelfAdjointEigenSolver<RealMatrixX> eigensolver(jacobian0, false);
+        SelfAdjointEigenSolver<RealMatrixX> eigensolver(test_elem.jacobian0, false);
         RealVectorX eigenvalues = eigensolver.eigenvalues();
         libMesh::out << "Eigenvalues are:\n" << eigenvalues << std::endl;
         uint nz = 0;
@@ -274,404 +108,253 @@ TEST_CASE("edge2_linear_structural",
             }
         }
         REQUIRE( nz == 6);
-        
+
         /**
          * All non-zero eigenvalues should be positive.
          */
         REQUIRE(eigenvalues.minCoeff()>(-0.0001220703125));
     }
-    
-    
-    SECTION("internal_jacobian_orientation_invariant")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to section orientation")
     {
-        section.clear();
+        test_elem.section.clear();
         RealVectorX orientation = RealVectorX::Zero(3);
         orientation(2) = 1.0;
-        section.y_vector() = orientation;
-        section.init();
-        //discipline.set_property_for_subdomain(0, section);
-        
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-                
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
+        test_elem.section.y_vector() = orientation;
+        test_elem.section.init();
+        test_elem.update_residual_and_jacobian();
 
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
     }
-    
-    
-    SECTION("internal_jacobian_displacement_invariant")
-    {
-        // Calculate residual and jacobian at arbitrary displacement
-        RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
-        elem_sol << 0.05727841,  0.08896581,  0.09541619, -0.03774913,  
-                    0.07510557, -0.07122266, -0.00979117, -0.08300009, 
-                    -0.03453369, -0.05487761, -0.01407677, -0.09268421;
-        elem->set_solution(elem_sol);
-        
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-                
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
 
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
-    }
-    
-    SECTION("internal_jacobian_shifted_x_invariant")
-    {
-        // Shifted in x-direction
-        transform_element(mesh, X0, 5.2, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-                
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
 
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
-    }
-    
-    SECTION("internal_jacobian_shifted_y_invariant")
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to displacement solution")
     {
-        // Shifted in y-direction
-        transform_element(mesh, X0, 0.0, -11.5, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
-        
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        RealVectorX elem_sol = RealVectorX::Zero(test_elem.n_dofs);
+        elem_sol << 0.05727841,  0.08896581,  0.09541619, -0.03774913,
+                0.07510557, -0.07122266, -0.00979117, -0.08300009,
+                -0.03453369, -0.05487761, -0.01407677, -0.09268421;
+        test_elem.elem->set_solution(elem_sol);
+        test_elem.update_residual_and_jacobian();
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
     }
-    
-    SECTION("internal_jacobian_shifted_z_invariant")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to element x-location")
     {
-        // Shifted in y-direction
-        transform_element(mesh, X0, 0.0, 0.0, 7.6, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
-        
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        TEST::transform_element(test_elem.mesh, coords,5.2, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
     }
-    
-    
-    SECTION("internal_jacobian_aligned_y")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to element y-location")
+    {
+        TEST::transform_element(test_elem.mesh, coords, 0.0, -11.5, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
+    }
+
+
+    SECTION("Internal Jacobian (stiffness matrix) is invariant to element z-location")
+    {
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 7.6,
+                                1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
+    }
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element aligned along y-axis")
     {
         /*
          * NOTE: We could try to use the transform_element method here, but the
          * issue is that if the sin and cos calculations are not exact, then we
          * may not be perfectly aligned along the y axis like we want.
          */
-        RealMatrixX X= RealMatrixX::Zero(3,n_nodes);
-        X << 0.0, 0.0, -1.0, 1.0, 0.0, 0.0;
-        for (int i=0; i<n_nodes; i++)
-        {
-            (*mesh.node_ptr(i)) = libMesh::Point(X(0,i), X(1,i), X(2,i));
-        }
-        
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        RealMatrixX new_coordinates = RealMatrixX::Zero(3,test_elem.n_nodes);
+        new_coordinates << 0.0, 0.0, -1.0, 1.0, 0.0, 0.0;
+        test_elem.update_coordinates(new_coordinates);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_aligned_z")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element aligned along z-axis")
     {
         /*
          * NOTE: We could try to use the transform_element method here, but the
          * issue is that if the sin and cos calculations are not exact, then we
          * may not be perfectly aligned along the z axis like we want.
          */
-        RealMatrixX X= RealMatrixX::Zero(3,n_nodes);
-        X << 0.0, 0.0, 0.0, 0.0, -1.0, 1.0;
-        for (int i=0; i<n_nodes; i++)
-        {
-            (*mesh.node_ptr(i)) = libMesh::Point(X(0,i), X(1,i), X(2,i));
-        }
-        
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        RealMatrixX new_coordinates = RealMatrixX::Zero(3,test_elem.n_nodes);
+        new_coordinates << 0.0, 0.0, 0.0, 0.0, -1.0, 1.0;
+        test_elem.update_coordinates(new_coordinates);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_rotated_about_z")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element rotated about z-axis")
     {
         // Rotated 63.4 about z-axis at element's centroid
-        transform_element(mesh, X0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 63.4);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 63.4);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_rotated_about_y")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element rotated about y-axis")
     {
         // Rotated 35.8 about y-axis at element's centroid
-        transform_element(mesh, X0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 35.8, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 35.8, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_scaled_x")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element stretched in x-direction")
     {
-        // Rotated 63.4 about z-axis at element's centroid
-        transform_element(mesh, X0, 0.0, 0.0, 0.0, 3.2, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                3.2, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_arbitrary_transformation")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element arbitrarily scaled, stretched, and rotated")
     {
-        // Arbitrary transformations applied to the element
-        transform_element(mesh, X0, -5.0, 7.8, -13.1, 2.7, 6.4, 20.0, 47.8, -70.1);
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        // Apply arbitrary transformation to the element
+        TEST::transform_element(test_elem.mesh, coords, -5.0, 7.8, -13.1,
+                                2.7, 6.4, 20.0, 47.8, -70.1);
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("internal_jacobian_arbitrary_with_displacements")
+
+
+    SECTION("Internal Jacobian (stiffness matrix) checks for element arbitrarily scaled, stretched, rotated, and displaced")
     {
-        // Arbitrary transformations applied to the element
-        transform_element(mesh, X0, 4.1, -6.3, 7.5, 4.2, 1.5, -18.0, -24.8, 
-                          30.1);
-        
-        // Calculate residual and jacobian at arbitrary displacement
-        RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
-        elem_sol << 0.08158724,  0.07991906, -0.00719128,  0.02025461, 
-                    -0.04602193, 0.05280159,  0.03700081,  0.04636344,  
-                    0.05559377,  0.06448206, 0.08919238, -0.03079122;
-        elem->set_solution(elem_sol);
-        
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->internal_residual(true, residual, jacobian);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_internal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        // Apply arbitrary transformation to the element
+        TEST::transform_element(test_elem.mesh, coords, 4.1, -6.3, 7.5,
+                                4.2, 1.5, -18.0, -24.8, 30.1);
+
+        // Apply arbitrary displacement to the element
+        RealVectorX elem_sol = RealVectorX::Zero(test_elem.n_dofs);
+        elem_sol << 0.08158724,  0.07991906, -0.00719128,  0.02025461,
+                -0.04602193,  0.05280159,  0.03700081,  0.04636344,
+                0.05559377,  0.06448206,  0.08919238, -0.03079122;
+        test_elem.elem->set_solution(elem_sol);
+
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.update_residual_and_jacobian();
+
+        // Finite difference Jacobian check
+        TEST::approximate_internal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
 }

--- a/tests/element/structural/1D/edge2/mast_edge2_linear_structural_thermal_jacobian.cpp
+++ b/tests/element/structural/1D/edge2/mast_edge2_linear_structural_thermal_jacobian.cpp
@@ -1,20 +1,29 @@
+/*
+ * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
+ * Copyright (C) 2013-2020  Manav Bhatia and MAST authors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
 // We need access to the protected thermal_residual method to test it
 // NOTE: Be careful with this, it could cause unexpected problems
 #define protected public
 
-// C++ Stanard Includes
-#include <math.h>
-
-// Catch2 includes
-#include "catch.hpp"
-
 // libMesh includes
 #include "libmesh/libmesh.h"
-#include "libmesh/replicated_mesh.h"
-#include "libmesh/point.h"
 #include "libmesh/elem.h"
-#include "libmesh/edge_edge2.h"
-#include "libmesh/equation_systems.h"
 #include "libmesh/dof_map.h"
 
 // MAST includes
@@ -24,16 +33,16 @@
 #include "property_cards/solid_1d_section_element_property_card.h"
 #include "elasticity/structural_element_1d.h"
 #include "elasticity/structural_system_initialization.h"
-#include "base/physics_discipline_base.h"
 #include "base/nonlinear_implicit_assembly.h"
 #include "elasticity/structural_nonlinear_assembly.h"
 #include "base/nonlinear_system.h"
-#include "elasticity/structural_element_base.h"
 #include "mesh/geom_elem.h"
 #include "base/boundary_condition_base.h"
 
-// Custom includes
+// Test includes
+#include "catch.hpp"
 #include "test_helpers.h"
+#include "element/structural/1D/mast_structural_element_1d.h"
 
 #define pi 3.14159265358979323846
 
@@ -43,237 +52,78 @@ extern libMesh::LibMeshInit* p_global_init;
 TEST_CASE("edge2_linear_structural_thermal_jacobian",
           "[1D],[thermoelastic],[edge],[edge2],[linear],[protected]")
 {
-    const int n_elems = 1;
-    const int n_nodes = 2;
-    
-    RealMatrixX temp = RealMatrixX::Zero(3,n_nodes);
-    temp << -1.0, 1.0, 0.0, 0.0, 0.0, 0.0;
-    const RealMatrixX X0 = temp;
-    
-    /**
-     * Create the mesh with the one element we are testing
-     */
-    libMesh::ReplicatedMesh mesh(p_global_init->comm());
-    mesh.set_mesh_dimension(1);
-    mesh.set_spatial_dimension(3);
-    mesh.reserve_elem(n_elems);
-    mesh.reserve_nodes(n_nodes);
-    
-    // Add nodes to the mesh
-    for (uint i=0; i<n_nodes; i++)
-    {
-        mesh.add_point(libMesh::Point(X0(0,i), X0(1,i), X0(2,i)));
-    }
-    
-    // Add the element to the mesh
-    libMesh::Elem *reference_elem = new libMesh::Edge2;
-    reference_elem->set_id(0);    
-    reference_elem->subdomain_id() = 0;
-    reference_elem = mesh.add_elem(reference_elem);
-    for (int i=0; i<n_nodes; i++)
-    {
-        reference_elem->set_node(i) = mesh.node_ptr(i);
-    }
-    
-    // Prepare the mesh for use
-    mesh.prepare_for_use();
-    
-    // Ensure the libMesh element has the expected volume
-    const Real elem_volume = reference_elem->volume();
-    Real true_volume = 2.0;
-    REQUIRE( elem_volume == true_volume );
-    
-    // Define Material Properties as MAST Parameters
-    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
-    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
-    MAST::Parameter rho("rho_param", 1420.5);         // Density
-    MAST::Parameter alpha("alpha_param", 5.43e-05);   // Coefficient of thermal expansion
-    MAST::Parameter cp("cp_param",   908.0);          // Specific Heat Capacity
-    MAST::Parameter k("k_param",     237.0);          // Thermal Conductivity
-    
-    // Define Section Properties as MAST Parameters
-    MAST::Parameter thickness_y("thy_param", 0.8);   // Section thickness in y-direction
-    MAST::Parameter thickness_z("thz_param", 0.7);   // Section thickness in z-direction
-    MAST::Parameter offset_y("offy_param", 0.5);    // Section offset in y-direction
-    MAST::Parameter offset_z("offz_param", 0.4);    // Section offset in z-direction
-    MAST::Parameter kappa_zz("kappa_zz", 5.0/6.0);    // Shear coefficient
-    MAST::Parameter kappa_yy("kappa_yy", 2.0/6.0);    // Shear coefficient
-    
-    // Define the Thermoelastic Properties
+    RealMatrixX coords = RealMatrixX::Zero(3, 2);
+    coords << -1.0, 1.0, 0.0,
+               0.0, 0.0, 0.0;
+    TEST::TestStructuralSingleElement1D test_elem(libMesh::EDGE2, coords);
+
     // Define the Uniform Temperature and Uniform Reference Temperature
     MAST::Parameter temperature("T", 400.0);
     MAST::Parameter ref_temperature("T0", 0.0);
-    
-    // Create field functions to dsitribute these constant parameters throughout the model
-    MAST::ConstantFieldFunction E_f("E", E);
-    MAST::ConstantFieldFunction nu_f("nu", nu);
-    MAST::ConstantFieldFunction rho_f("rho", rho);
-    MAST::ConstantFieldFunction alpha_f("alpha_expansion", alpha);
-    MAST::ConstantFieldFunction cp_f("cp", cp);
-    MAST::ConstantFieldFunction k_f("k_th", k);
-    MAST::ConstantFieldFunction thicknessy_f("hy", thickness_y);
-    MAST::ConstantFieldFunction offsety_f("hy_off", offset_y);
-    MAST::ConstantFieldFunction thicknessz_f("hz", thickness_z);
-    MAST::ConstantFieldFunction offsetz_f("hz_off", offset_z);
     MAST::ConstantFieldFunction temperature_f("temperature", temperature);
     MAST::ConstantFieldFunction ref_temperature_f("ref_temperature", ref_temperature);
-    MAST::ConstantFieldFunction kappa_zz_f("Kappazz", kappa_zz);
-    MAST::ConstantFieldFunction kappa_yy_f("Kappayy", kappa_yy);
-    
-    // Initialize the material
-    MAST::IsotropicMaterialPropertyCard material;                   
-    
-    // Add the material property constant field functions to the material card
-    material.add(E_f);
-    material.add(nu_f);
-    material.add(rho_f);
-    material.add(alpha_f);
-    material.add(k_f);
-    material.add(cp_f);
-    
-    // Initialize the section
-    MAST::Solid1DSectionElementPropertyCard section;
-    
-    // Add the section property constant field functions to the section card
-    section.add(thicknessy_f);
-    section.add(offsety_f);
-    section.add(thicknessz_f);
-    section.add(offsetz_f);
-    section.add(kappa_zz_f);
-    section.add(kappa_yy_f);
-    
-    // Add the material card to the section card
-    section.set_material(material);
-    
-    // Specify a section orientation point and add it to the section.
-    // FIXME: Orientation isn't affecting the element's jacobian for some reason
-    RealVectorX orientation = RealVectorX::Zero(3);
-    orientation(2) = 1.0;
-    section.y_vector() = orientation;
-    
-    // Set the strain type to linear for the section
-    section.set_strain(MAST::LINEAR_STRAIN);
-    
-    // Set the bending operator to Euler-Bernoulli
-    section.set_bending_model(MAST::TIMOSHENKO);
-    
-    // Now initialize the section
-    section.init();
-    
-    
-    /**
-     *  Now we setup the structural system we will be solving.
-     */
-    libMesh::EquationSystems equation_systems(mesh);
-    
-    MAST::NonlinearSystem& system = equation_systems.add_system<MAST::NonlinearSystem>("structural");
-    
-    libMesh::FEType fetype(libMesh::FIRST, libMesh::LAGRANGE);
-    
-    MAST::StructuralSystemInitialization structural_system(system, 
-                                                           system.name(), 
-                                                           fetype);
-    
-    MAST::PhysicsDisciplineBase discipline(equation_systems);
-    
-    discipline.set_property_for_subdomain(0, section);
-    
-    equation_systems.init();
-    //equation_systems.print_info();
-    
-    /**
-     * Setup the temperature change boundary condition
-     */
+
+    // Setup the temperature change boundary condition
     MAST::BoundaryConditionBase temperature_load(MAST::TEMPERATURE);
     temperature_load.add(temperature_f);
     temperature_load.add(ref_temperature_f);
-    discipline.add_volume_load(0, temperature_load);
-    
-    MAST::NonlinearImplicitAssembly assembly;
-    assembly.set_discipline_and_system(discipline, structural_system);
-    
-    // Create the MAST element from the libMesh reference element
-    MAST::GeomElem geom_elem;
-    geom_elem.init(*reference_elem, structural_system);
-    std::unique_ptr<MAST::StructuralElementBase> elem_base = build_structural_element(structural_system, geom_elem, section);
-    
-    // Cast the base structural element as a 2D structural element
-    MAST::StructuralElement1D* elem = (dynamic_cast<MAST::StructuralElement1D*>(elem_base.get()));
-    
-    // Get element DOFs
-    const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
-    std::vector<libMesh::dof_id_type> dof_indices;
-    dof_map.dof_indices (reference_elem, dof_indices);
-    uint n_dofs = uint(dof_indices.size());
-    
-    // Set element's initial solution and solution sensitivity to zero
-    RealVectorX elem_solution = RealVectorX::Zero(n_dofs);
-    elem->set_solution(elem_solution);
-    elem->set_solution(elem_solution, true);
-    
-    const Real V0 = reference_elem->volume();
-    
+    test_elem.discipline.add_volume_load(0, temperature_load);
+
+    const Real V0 = test_elem.reference_elem->volume();
+
     // Calculate residual and jacobian
-    RealVectorX residual = RealVectorX::Zero(n_dofs);
-    RealMatrixX jacobian0 = RealMatrixX::Zero(n_dofs, n_dofs);
-    elem->thermal_residual(true, residual, jacobian0, temperature_load);
-            
-    double val_margin = (jacobian0.array().abs()).mean() * 1.490116119384766e-08;
+    test_elem.elem->thermal_residual(true, test_elem.residual, test_elem.jacobian0, temperature_load);
     
-    libMesh::out << "R=\n" << residual << std::endl;
-    libMesh::out << "J =\n" << jacobian0 << std::endl;
+    double val_margin = (test_elem.jacobian0.array().abs()).mean() * 1.490116119384766e-08;
+    
+    libMesh::out << "R=\n" << test_elem.residual << std::endl;
+    libMesh::out << "J =\n" << test_elem.jacobian0 << std::endl;
     
     SECTION("thermal_jacobian_is_zero_matrix")
     {
         // Approximate Jacobian with Finite Difference
-        RealMatrixX zero_matrix = RealMatrixX::Zero(n_dofs, n_dofs);
+        RealMatrixX zero_matrix = RealMatrixX::Zero(test_elem.n_dofs, test_elem.n_dofs);
         
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
-        std::vector<double> truth = eigen_matrix_to_std_vector(zero_matrix);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(test_elem.jacobian0);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(zero_matrix);
         
         REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(0.0) );
     }
-    
-    
-    SECTION("thermal_jacobian_finite_difference_check")                   
+
+
+    SECTION("Thermoelastic Jacobian finite difference check")
     {
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_thermal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd, temperature_load);
-        
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        TEST::approximate_thermal_jacobian_with_finite_difference(*test_elem.elem,
+                                                                  test_elem.elem_solution, test_elem.jacobian_fd,
+                                                                  temperature_load);
+
+        val_margin = 1.0e-5;
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
     }
-    
-    
-    SECTION("thermal_jacobian_symmetry_check")
+
+
+    SECTION("Thermoelastic Jacobian should be symmetric")
     {
-        // Element stiffness matrix should be symmetric
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0.transpose());
-        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0.transpose())));
     }
-    
-    
-    SECTION("thermal_jacobian_determinant_check")
+
+
+    SECTION("Determinant of undeformed thermoelastic Jacobian should be zero")
     {
-        // Determinant of linear thermoelastic jacobian should be zero
-        REQUIRE( jacobian0.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian0.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    
-    SECTION("thermal_jacobian_eigenvalue_check")
+
+
+    SECTION("Thermoelastic Jacobian eigenvalue check")
     {
-        /**
-         * Linear thermoelastic Jacobian should be independent of the 
+        /*
+         * Linear thermoelastic Jacobian should be independent of the
          * displacements and thus should be a zero matrix.
          */
-        SelfAdjointEigenSolver<RealMatrixX> eigensolver(jacobian0, false);
+        SelfAdjointEigenSolver<RealMatrixX> eigensolver(test_elem.jacobian0, false);
         RealVectorX eigenvalues = eigensolver.eigenvalues();
         libMesh::out << "Eigenvalues are:\n" << eigenvalues << std::endl;
         uint nz = 0;
@@ -286,397 +136,242 @@ TEST_CASE("edge2_linear_structural_thermal_jacobian",
         }
         REQUIRE( nz == 12);
     }
-    
-    
-    SECTION("thermal_jacobian_orientation_invariant")
+
+
+    SECTION("Thermoelastic Jacobian is invariant to section orientation")
     {
-        section.clear();
+        test_elem.section.clear();
         RealVectorX orientation = RealVectorX::Zero(3);
         orientation(2) = 1.0;
-        section.y_vector() = orientation;
-        section.init();
-        
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->thermal_residual(true, residual, jacobian, temperature_load);
-                
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
+        test_elem.section.y_vector() = orientation;
+        test_elem.section.init();
+        test_elem.elem->thermal_residual(true, test_elem.residual, test_elem.jacobian, temperature_load);
 
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
     }
-    
-    
-    SECTION("thermal_jacobian_displacement_invariant")
-    {
-        // Calculate residual and jacobian at arbitrary displacement
-        RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
-        elem_sol << 0.05727841,  0.08896581,  0.09541619, -0.03774913,  
-                    0.07510557, -0.07122266, -0.00979117, -0.08300009, 
-                    -0.03453369, -0.05487761, -0.01407677, -0.09268421;
-        elem->set_solution(elem_sol);
-        
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->thermal_residual(true, residual, jacobian, temperature_load);
-                
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
 
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
-    }
-    
-    SECTION("thermal_jacobian_shifted_x_invariant")
-    {
-        // Shifted in x-direction
-        transform_element(mesh, X0, 5.2, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->thermal_residual(true, residual, jacobian, temperature_load);
-                
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
 
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
-    }
-    
-    SECTION("thermal_jacobian_shifted_y_invariant")
+    SECTION("Thermoelastic Jacobian is invariant to displacement solution")
     {
-        // Shifted in y-direction
-        transform_element(mesh, X0, 0.0, -11.5, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->thermal_residual(true, residual, jacobian, temperature_load);
-        
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
-        
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        RealVectorX elem_sol = RealVectorX::Zero(test_elem.n_dofs);
+        elem_sol << 0.05727841,  0.08896581,  0.09541619, -0.03774913,
+                0.07510557, -0.07122266, -0.00979117, -0.08300009,
+                -0.03453369, -0.05487761, -0.01407677, -0.09268421;
+        test_elem.elem->set_solution(elem_sol);
+        test_elem.elem->thermal_residual(true, test_elem.residual, test_elem.jacobian, temperature_load);
+
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
     }
-    
-    SECTION("thermal_jacobian_shifted_z_invariant")
+
+
+    SECTION("Thermoelastic Jacobian is invariant to element x-location")
     {
-        // Shifted in y-direction
-        transform_element(mesh, X0, 0.0, 0.0, 7.6, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->thermal_residual(true, residual, jacobian, temperature_load);
-        
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
-        
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        TEST::transform_element(test_elem.mesh, coords,5.2, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.elem->thermal_residual(true, test_elem.residual, test_elem.jacobian, temperature_load);
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
     }
-    
-    
-    SECTION("thermal_jacobian_aligned_y")
+
+
+    SECTION("Thermoelastic Jacobian is invariant to element y-location")
+    {
+        TEST::transform_element(test_elem.mesh, coords, 0.0, -11.5, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.elem->thermal_residual(true, test_elem.residual, test_elem.jacobian, temperature_load);
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
+    }
+
+
+    SECTION("Thermoelastic Jacobian is invariant to element z-location")
+    {
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 7.6,
+                                1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.elem->thermal_residual(true, test_elem.residual, test_elem.jacobian, temperature_load);
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
+    }
+
+
+    SECTION("Thermoelastic Jacobian checks for element aligned along y-axis")
     {
         /*
          * NOTE: We could try to use the transform_element method here, but the
          * issue is that if the sin and cos calculations are not exact, then we
          * may not be perfectly aligned along the y axis like we want.
          */
-        RealMatrixX X= RealMatrixX::Zero(3,n_nodes);
-        X << 0.0, 0.0, -1.0, 1.0, 0.0, 0.0;
-        for (int i=0; i<n_nodes; i++)
-        {
-            (*mesh.node_ptr(i)) = libMesh::Point(X(0,i), X(1,i), X(2,i));
-        }
-        
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->thermal_residual(true, residual, jacobian, temperature_load);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_thermal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd, temperature_load);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        RealMatrixX new_coordinates = RealMatrixX::Zero(3,test_elem.n_nodes);
+        new_coordinates << 0.0, 0.0, -1.0, 1.0, 0.0, 0.0;
+        test_elem.update_coordinates(new_coordinates);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.elem->thermal_residual(true, test_elem.residual, test_elem.jacobian, temperature_load);
+
+        // Finite difference Jacobian check
+        TEST::approximate_thermal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd, temperature_load);
+        val_margin = 1.0e-5;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("thermal_jacobian_aligned_z")
+
+    SECTION("Thermoelastic Jacobian checks for element aligned along z-axis")
     {
         /*
          * NOTE: We could try to use the transform_element method here, but the
          * issue is that if the sin and cos calculations are not exact, then we
          * may not be perfectly aligned along the z axis like we want.
          */
-        RealMatrixX X= RealMatrixX::Zero(3,n_nodes);
-        X << 0.0, 0.0, 0.0, 0.0, -1.0, 1.0;
-        for (int i=0; i<n_nodes; i++)
-        {
-            (*mesh.node_ptr(i)) = libMesh::Point(X(0,i), X(1,i), X(2,i));
-        }
-        
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->thermal_residual(true, residual, jacobian, temperature_load);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_thermal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd, temperature_load);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        RealMatrixX new_coordinates = RealMatrixX::Zero(3,test_elem.n_nodes);
+        new_coordinates << 0.0, 0.0, 0.0, 0.0, -1.0, 1.0;
+        test_elem.update_coordinates(new_coordinates);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.elem->thermal_residual(true, test_elem.residual, test_elem.jacobian, temperature_load);
+
+        // Finite difference Jacobian check
+        TEST::approximate_thermal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd, temperature_load);
+        val_margin = 1.0e-5;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("thermal_jacobian_rotated_about_z")
+    SECTION("Thermoelastic Jacobian checks for element rotated about z-axis")
     {
         // Rotated 63.4 about z-axis at element's centroid
-        transform_element(mesh, X0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 63.4);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->thermal_residual(true, residual, jacobian, temperature_load);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_thermal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd, temperature_load);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 63.4);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.elem->thermal_residual(true, test_elem.residual, test_elem.jacobian, temperature_load);
+
+        // Finite difference Jacobian check
+        TEST::approximate_thermal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd, temperature_load);
+        val_margin = 1.0e-6;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("thermal_jacobian_rotated_about_y")
+
+
+    SECTION("Thermoelastic Jacobian checks for element rotated about y-axis")
     {
         // Rotated 35.8 about y-axis at element's centroid
-        transform_element(mesh, X0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 35.8, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->thermal_residual(true, residual, jacobian, temperature_load);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_thermal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd, temperature_load);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 35.8, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.elem->thermal_residual(true, test_elem.residual, test_elem.jacobian, temperature_load);
+
+        // Finite difference Jacobian check
+        TEST::approximate_thermal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd, temperature_load);
+        val_margin = 1.0e-6;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("thermal_jacobian_scaled_x")
+    SECTION("Thermoelastic Jacobian checks for element stretched in x-direction")
     {
-        // Rotated 63.4 about z-axis at element's centroid
-        transform_element(mesh, X0, 0.0, 0.0, 0.0, 3.2, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->thermal_residual(true, residual, jacobian, temperature_load);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_thermal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd, temperature_load);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                3.2, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.elem->thermal_residual(true, test_elem.residual, test_elem.jacobian, temperature_load);
+
+        // Finite difference Jacobian check
+        TEST::approximate_thermal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd, temperature_load);
+        val_margin = 1.0e-6;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("thermal_jacobian_arbitrary_transformation")
+
+
+    SECTION("Thermoelastic Jacobian checks for element arbitrarily scaled, stretched, and rotated")
     {
-        // Arbitrary transformations applied to the element
-        transform_element(mesh, X0, -5.0, 7.8, -13.1, 2.7, 6.4, 20.0, 47.8, -70.1);
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->thermal_residual(true, residual, jacobian, temperature_load);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_thermal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd, temperature_load);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        // Apply arbitrary transformation to the element
+        TEST::transform_element(test_elem.mesh, coords, -5.0, 7.8, -13.1,
+                                2.7, 6.4, 20.0, 47.8, -70.1);
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.elem->thermal_residual(true, test_elem.residual, test_elem.jacobian, temperature_load);
+
+        // Finite difference Jacobian check
+        TEST::approximate_thermal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd, temperature_load);
+        val_margin = 1.0e-6;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("thermal_jacobian_arbitrary_with_displacements")
+
+
+    SECTION("Thermoelastic Jacobian checks for element arbitrarily scaled, stretched, rotated, and displaced")
     {
-        // Arbitrary transformations applied to the element
-        transform_element(mesh, X0, 4.1, -6.3, 7.5, 4.2, 1.5, -18.0, -24.8, 
-                          30.1);
-        
-        // Calculate residual and jacobian at arbitrary displacement
-        RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
-        elem_sol << 0.08158724,  0.07991906, -0.00719128,  0.02025461, 
-                    -0.04602193, 0.05280159,  0.03700081,  0.04636344,  
-                    0.05559377,  0.06448206, 0.08919238, -0.03079122;
-        elem->set_solution(elem_sol);
-        
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->thermal_residual(true, residual, jacobian, temperature_load);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_thermal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd, temperature_load);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        // Apply arbitrary transformation to the element
+        TEST::transform_element(test_elem.mesh, coords, 4.1, -6.3, 7.5,
+                                4.2, 1.5, -18.0, -24.8, 30.1);
+
+        // Apply arbitrary displacement to the element
+        RealVectorX elem_sol = RealVectorX::Zero(test_elem.n_dofs);
+        elem_sol << 0.08158724,  0.07991906, -0.00719128,  0.02025461,
+                -0.04602193,  0.05280159,  0.03700081,  0.04636344,
+                0.05559377,  0.06448206,  0.08919238, -0.03079122;
+        test_elem.elem->set_solution(elem_sol);
+
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.elem->thermal_residual(true, test_elem.residual, test_elem.jacobian, temperature_load);
+
+        // Finite difference Jacobian check
+        TEST::approximate_thermal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd, temperature_load);
+        val_margin = 1.0e-6;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
 }

--- a/tests/element/structural/1D/edge2/mast_edge2_nonlinear_structural_thermal_jacobian.cpp
+++ b/tests/element/structural/1D/edge2/mast_edge2_nonlinear_structural_thermal_jacobian.cpp
@@ -1,20 +1,29 @@
+/*
+ * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
+ * Copyright (C) 2013-2020  Manav Bhatia and MAST authors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
 // We need access to the protected thermal_residual method to test it
 // NOTE: Be careful with this, it could cause unexpected problems
 #define protected public
 
-// C++ Stanard Includes
-#include <math.h>
-
-// Catch2 includes
-#include "catch.hpp"
-
 // libMesh includes
 #include "libmesh/libmesh.h"
-#include "libmesh/replicated_mesh.h"
-#include "libmesh/point.h"
 #include "libmesh/elem.h"
-#include "libmesh/edge_edge2.h"
-#include "libmesh/equation_systems.h"
 #include "libmesh/dof_map.h"
 
 // MAST includes
@@ -24,17 +33,16 @@
 #include "property_cards/solid_1d_section_element_property_card.h"
 #include "elasticity/structural_element_1d.h"
 #include "elasticity/structural_system_initialization.h"
-#include "base/physics_discipline_base.h"
 #include "base/nonlinear_implicit_assembly.h"
 #include "elasticity/structural_nonlinear_assembly.h"
 #include "base/nonlinear_system.h"
-#include "elasticity/structural_element_base.h"
 #include "mesh/geom_elem.h"
 #include "base/boundary_condition_base.h"
 
-
-// Custom includes
+// Test includes
+#include "catch.hpp"
 #include "test_helpers.h"
+#include "element/structural/1D/mast_structural_element_1d.h"
 
 #define pi 3.14159265358979323846
 
@@ -44,216 +52,62 @@ extern libMesh::LibMeshInit* p_global_init;
 TEST_CASE("edge2_nonlinear_structural_thermal_jacobian",
           "[1D],[thermoelastic],[edge],[edge2],[nonlinear],[protected]")
 {
-    const int n_elems = 1;
-    const int n_nodes = 2;
-    
-    RealMatrixX temp = RealMatrixX::Zero(3,n_nodes);
-    temp << -1.0, 1.0, 0.0, 0.0, 0.0, 0.0;
-    const RealMatrixX X0 = temp;
-    
-    /**
-     * Create the mesh with the one element we are testing
-     */
-    libMesh::ReplicatedMesh mesh(p_global_init->comm());
-    mesh.set_mesh_dimension(1);
-    mesh.set_spatial_dimension(3);
-    mesh.reserve_elem(n_elems);
-    mesh.reserve_nodes(n_nodes);
-    
-    // Add nodes to the mesh
-    for (uint i=0; i<n_nodes; i++)
-    {
-        mesh.add_point(libMesh::Point(X0(0,i), X0(1,i), X0(2,i)));
-    }
-    
-    // Add the element to the mesh
-    libMesh::Elem *reference_elem = new libMesh::Edge2;
-    reference_elem->set_id(0);    
-    reference_elem->subdomain_id() = 0;
-    reference_elem = mesh.add_elem(reference_elem);
-    for (int i=0; i<n_nodes; i++)
-    {
-        reference_elem->set_node(i) = mesh.node_ptr(i);
-    }
-    
-    // Prepare the mesh for use
-    mesh.prepare_for_use();
-    
-    // Ensure the libMesh element has the expected volume
-    const Real elem_volume = reference_elem->volume();
-    Real true_volume = 2.0;
-    REQUIRE( elem_volume == true_volume );
-    
-    // Define Material Properties as MAST Parameters
-    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
-    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
-    MAST::Parameter rho("rho_param", 1420.5);         // Density
-    MAST::Parameter alpha("alpha_param", 5.43e-05);   // Coefficient of thermal expansion
-    MAST::Parameter cp("cp_param",   908.0);          // Specific Heat Capacity
-    MAST::Parameter k("k_param",     237.0);          // Thermal Conductivity
-    
-    // Define Section Properties as MAST Parameters
-    MAST::Parameter thickness_y("thy_param", 0.8);   // Section thickness in y-direction
-    MAST::Parameter thickness_z("thz_param", 0.7);   // Section thickness in z-direction
-    MAST::Parameter offset_y("offy_param", 0.5);    // Section offset in y-direction
-    MAST::Parameter offset_z("offz_param", 0.4);    // Section offset in z-direction
-    MAST::Parameter kappa_zz("kappa_zz", 5.0/6.0);    // Shear coefficient
-    MAST::Parameter kappa_yy("kappa_yy", 2.0/6.0);    // Shear coefficient
-    
-    // Define the Thermoelastic Properties
+    RealMatrixX coords = RealMatrixX::Zero(3, 2);
+    coords << -1.0, 1.0, 0.0,
+               0.0, 0.0, 0.0;
+    TEST::TestStructuralSingleElement1D test_elem(libMesh::EDGE2, coords);
+
     // Define the Uniform Temperature and Uniform Reference Temperature
     MAST::Parameter temperature("T", 400.0);
     MAST::Parameter ref_temperature("T0", 0.0);
-    
-    // Create field functions to dsitribute these constant parameters throughout the model
-    MAST::ConstantFieldFunction E_f("E", E);
-    MAST::ConstantFieldFunction nu_f("nu", nu);
-    MAST::ConstantFieldFunction rho_f("rho", rho);
-    MAST::ConstantFieldFunction alpha_f("alpha_expansion", alpha);
-    MAST::ConstantFieldFunction cp_f("cp", cp);
-    MAST::ConstantFieldFunction k_f("k_th", k);
-    MAST::ConstantFieldFunction thicknessy_f("hy", thickness_y);
-    MAST::ConstantFieldFunction offsety_f("hy_off", offset_y);
-    MAST::ConstantFieldFunction thicknessz_f("hz", thickness_z);
-    MAST::ConstantFieldFunction offsetz_f("hz_off", offset_z);
     MAST::ConstantFieldFunction temperature_f("temperature", temperature);
     MAST::ConstantFieldFunction ref_temperature_f("ref_temperature", ref_temperature);
-    MAST::ConstantFieldFunction kappa_zz_f("Kappazz", kappa_zz);
-    MAST::ConstantFieldFunction kappa_yy_f("Kappayy", kappa_yy);
-    
-    // Initialize the material
-    MAST::IsotropicMaterialPropertyCard material;                   
-    
-    // Add the material property constant field functions to the material card
-    material.add(E_f);
-    material.add(nu_f);
-    material.add(rho_f);
-    material.add(alpha_f);
-    material.add(k_f);
-    material.add(cp_f);
-    
-    // Initialize the section
-    MAST::Solid1DSectionElementPropertyCard section;
-    
-    // Add the section property constant field functions to the section card
-    section.add(thicknessy_f);
-    section.add(offsety_f);
-    section.add(thicknessz_f);
-    section.add(offsetz_f);
-    section.add(kappa_zz_f);
-    section.add(kappa_yy_f);
-    
-    // Add the material card to the section card
-    section.set_material(material);
-    
-    // Specify a section orientation point and add it to the section.
-    // FIXME: Orientation isn't affecting the element's jacobian for some reason
-    RealVectorX orientation = RealVectorX::Zero(3);
-    orientation(2) = 1.0;
-    section.y_vector() = orientation;
-    
-    // Set the strain type to linear for the section
-    section.set_strain(MAST::NONLINEAR_STRAIN);
-    
-    // Set the bending operator to Euler-Bernoulli
-    section.set_bending_model(MAST::TIMOSHENKO);
-    
-    // Now initialize the section
-    section.init();
-    
-    
-    /**
-     *  Now we setup the structural system we will be solving.
-     */
-    libMesh::EquationSystems equation_systems(mesh);
-    
-    MAST::NonlinearSystem& system = equation_systems.add_system<MAST::NonlinearSystem>("structural");
-    
-    libMesh::FEType fetype(libMesh::FIRST, libMesh::LAGRANGE);
-    
-    MAST::StructuralSystemInitialization structural_system(system, 
-                                                           system.name(), 
-                                                           fetype);
-    
-    MAST::PhysicsDisciplineBase discipline(equation_systems);
-    
-    discipline.set_property_for_subdomain(0, section);
-    
-    equation_systems.init();
-    //equation_systems.print_info();
-    
-    /**
-     * Setup the temperature change boundary condition
-     */
+
+    // Setup the temperature change boundary condition
     MAST::BoundaryConditionBase temperature_load(MAST::TEMPERATURE);
     temperature_load.add(temperature_f);
     temperature_load.add(ref_temperature_f);
-    discipline.add_volume_load(0, temperature_load);
-    
-    MAST::NonlinearImplicitAssembly assembly;
-    assembly.set_discipline_and_system(discipline, structural_system);
-    
-    // Create the MAST element from the libMesh reference element
-    MAST::GeomElem geom_elem;
-    geom_elem.init(*reference_elem, structural_system);
-    std::unique_ptr<MAST::StructuralElementBase> elem_base = build_structural_element(structural_system, geom_elem, section);
-    
-    // Cast the base structural element as a 2D structural element
-    MAST::StructuralElement1D* elem = (dynamic_cast<MAST::StructuralElement1D*>(elem_base.get()));
-    
-    // Get element DOFs
-    const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
-    std::vector<libMesh::dof_id_type> dof_indices;
-    dof_map.dof_indices (reference_elem, dof_indices);
-    uint n_dofs = uint(dof_indices.size());
-    
-    // Set element's initial solution and solution sensitivity to zero
-    RealVectorX elem_solution = RealVectorX::Zero(n_dofs);
-    elem->set_solution(elem_solution);
-    elem->set_solution(elem_solution, true);
-    
-    const Real V0 = reference_elem->volume();
+    test_elem.discipline.add_volume_load(0, temperature_load);
+
+    // Set the strain type to non-linear for the section
+    test_elem.section.set_strain(MAST::NONLINEAR_STRAIN);
+    // Set the bending operator to Euler-Bernoulli
+    test_elem.section.set_bending_model(MAST::TIMOSHENKO);
+
+    const Real V0 = test_elem.reference_elem->volume();
     
     // Calculate residual and jacobian
-    RealVectorX residual = RealVectorX::Zero(n_dofs);
-    RealMatrixX jacobian0 = RealMatrixX::Zero(n_dofs, n_dofs);
-    elem->thermal_residual(true, residual, jacobian0, temperature_load);
+    test_elem.elem->thermal_residual(true, test_elem.residual, test_elem.jacobian0, temperature_load);
             
-    double val_margin = (jacobian0.array().abs()).mean() * 1.490116119384766e-08;
+    double val_margin = (test_elem.jacobian0.array().abs()).mean() * 1.490116119384766e-08;
     
     //libMesh::out << "R=\n" << residual << std::endl;
-    //libMesh::out << "J =\n" << jacobian0 << std::endl;
-    
+    libMesh::out << "J =\n" << test_elem.jacobian0 << std::endl;
 
-    SECTION("thermal_jacobian_finite_difference_check")                   
+
+    SECTION("Thermoelastic Jacobian finite difference check")
     {
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_thermal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd, temperature_load);
-        
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        TEST::approximate_thermal_jacobian_with_finite_difference(*test_elem.elem,
+                                                                   test_elem.elem_solution, test_elem.jacobian_fd,
+                                                                   temperature_load);
+
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
     }
-    
-    
-    SECTION("thermal_jacobian_symmetry_check")
+
+
+    SECTION("Thermoelastic Jacobian should be symmetric")
     {
-        // Element stiffness matrix should be symmetric
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian0);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0.transpose());
-        REQUIRE_THAT( test, Catch::Approx<double>(truth) );
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0.transpose())));
     }
-    
-    
-    SECTION("thermal_jacobian_determinant_check")
+
+
+    SECTION("Determinant of undeformed thermoelastic Jacobian should be zero")
     {
-        // Determinant of linear thermoelastic jacobian should be zero
-        REQUIRE( jacobian0.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian0.determinant() == Approx(0.0).margin(1e-06));
     }
     
     
@@ -276,397 +130,246 @@ TEST_CASE("edge2_nonlinear_structural_thermal_jacobian",
 //         }
 //         REQUIRE( nz == 12);
 //     }
-    
-    
-    SECTION("thermal_jacobian_orientation_invariant")
+
+
+    SECTION("Thermoelastic Jacobian is invariant to section orientation")
     {
-        section.clear();
+        test_elem.section.clear();
         RealVectorX orientation = RealVectorX::Zero(3);
         orientation(2) = 1.0;
-        section.y_vector() = orientation;
-        section.init();
-        
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->thermal_residual(true, residual, jacobian, temperature_load);
-                
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
+        test_elem.section.y_vector() = orientation;
+        test_elem.section.init();
+        test_elem.elem->thermal_residual(true, test_elem.residual, test_elem.jacobian, temperature_load);
 
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
     }
-    
-    
-    SECTION("thermal_jacobian_displacement_invariant")
-    {
-        // Calculate residual and jacobian at arbitrary displacement
-        RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
-        elem_sol << 0.5727841,  0.8896581,  0.9541619, -0.3774913,  
-                    0.7510557, -0.7122266, -0.0979117, -0.8300009, 
-                    -0.3453369, -0.5487761, -0.1407677, -0.9268421;
-        elem->set_solution(elem_sol);
-        
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->thermal_residual(true, residual, jacobian, temperature_load);
-                
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
 
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
-    }
-    
-    SECTION("thermal_jacobian_shifted_x_invariant")
-    {
-        // Shifted in x-direction
-        transform_element(mesh, X0, 5.2, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->thermal_residual(true, residual, jacobian, temperature_load);
-                
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
 
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
-    }
-    
-    SECTION("thermal_jacobian_shifted_y_invariant")
+    SECTION("Thermoelastic Jacobian is invariant to displacement solution")
     {
-        // Shifted in y-direction
-        transform_element(mesh, X0, 0.0, -11.5, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->thermal_residual(true, residual, jacobian, temperature_load);
-        
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
-        
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        RealVectorX elem_sol = RealVectorX::Zero(test_elem.n_dofs);
+        elem_sol << 0.05727841,  0.08896581,  0.09541619, -0.03774913,
+                0.07510557, -0.07122266, -0.00979117, -0.08300009,
+                -0.03453369, -0.05487761, -0.01407677, -0.09268421;
+        test_elem.elem->set_solution(elem_sol);
+        test_elem.elem->thermal_residual(true, test_elem.residual, test_elem.jacobian, temperature_load);
+
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
     }
-    
-    SECTION("thermal_jacobian_shifted_z_invariant")
+
+
+    SECTION("Thermoelastic Jacobian is invariant to element x-location")
     {
-        // Shifted in y-direction
-        transform_element(mesh, X0, 0.0, 0.0, 7.6, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->thermal_residual(true, residual, jacobian, temperature_load);
-        
-        std::vector<double> test =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> truth = eigen_matrix_to_std_vector(jacobian0);
-        
-        REQUIRE_THAT( test, Catch::Approx<double>(truth).margin(val_margin) );
+        TEST::transform_element(test_elem.mesh, coords,5.2, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.elem->thermal_residual(true, test_elem.residual, test_elem.jacobian, temperature_load);
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
     }
-    
-    
-    SECTION("thermal_jacobian_aligned_y")
+
+
+    SECTION("Thermoelastic Jacobian is invariant to element y-location")
+    {
+        TEST::transform_element(test_elem.mesh, coords, 0.0, -11.5, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.elem->thermal_residual(true, test_elem.residual, test_elem.jacobian, temperature_load);
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
+    }
+
+
+    SECTION("Thermoelastic Jacobian is invariant to element z-location")
+    {
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 7.6,
+                                1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.elem->thermal_residual(true, test_elem.residual, test_elem.jacobian, temperature_load);
+
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian0)).margin(val_margin));
+    }
+
+
+    SECTION("Thermoelastic Jacobian checks for element aligned along y-axis")
     {
         /*
          * NOTE: We could try to use the transform_element method here, but the
          * issue is that if the sin and cos calculations are not exact, then we
          * may not be perfectly aligned along the y axis like we want.
          */
-        RealMatrixX X= RealMatrixX::Zero(3,n_nodes);
-        X << 0.0, 0.0, -1.0, 1.0, 0.0, 0.0;
-        for (int i=0; i<n_nodes; i++)
-        {
-            (*mesh.node_ptr(i)) = libMesh::Point(X(0,i), X(1,i), X(2,i));
-        }
-        
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->thermal_residual(true, residual, jacobian, temperature_load);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_thermal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd, temperature_load);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        RealMatrixX new_coordinates = RealMatrixX::Zero(3,test_elem.n_nodes);
+        new_coordinates << 0.0, 0.0, -1.0, 1.0, 0.0, 0.0;
+        test_elem.update_coordinates(new_coordinates);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.elem->thermal_residual(true, test_elem.residual, test_elem.jacobian, temperature_load);
+
+        // Finite difference Jacobian check
+        TEST::approximate_thermal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd, temperature_load);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("thermal_jacobian_aligned_z")
+
+    SECTION("Thermoelastic Jacobian checks for element aligned along z-axis")
     {
         /*
          * NOTE: We could try to use the transform_element method here, but the
          * issue is that if the sin and cos calculations are not exact, then we
          * may not be perfectly aligned along the z axis like we want.
          */
-        RealMatrixX X= RealMatrixX::Zero(3,n_nodes);
-        X << 0.0, 0.0, 0.0, 0.0, -1.0, 1.0;
-        for (int i=0; i<n_nodes; i++)
-        {
-            (*mesh.node_ptr(i)) = libMesh::Point(X(0,i), X(1,i), X(2,i));
-        }
-        
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->thermal_residual(true, residual, jacobian, temperature_load);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_thermal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd, temperature_load);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        RealMatrixX new_coordinates = RealMatrixX::Zero(3,test_elem.n_nodes);
+        new_coordinates << 0.0, 0.0, 0.0, 0.0, -1.0, 1.0;
+        test_elem.update_coordinates(new_coordinates);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.elem->thermal_residual(true, test_elem.residual, test_elem.jacobian, temperature_load);
+
+        // Finite difference Jacobian check
+        TEST::approximate_thermal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd, temperature_load);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("thermal_jacobian_rotated_about_z")
+
+
+    SECTION("Thermoelastic Jacobian checks for element rotated about z-axis")
     {
         // Rotated 63.4 about z-axis at element's centroid
-        transform_element(mesh, X0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 63.4);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->thermal_residual(true, residual, jacobian, temperature_load);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_thermal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd, temperature_load);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 0.0, 63.4);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.elem->thermal_residual(true, test_elem.residual, test_elem.jacobian, temperature_load);
+
+        // Finite difference Jacobian check
+        TEST::approximate_thermal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd, temperature_load);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("thermal_jacobian_rotated_about_y")
+
+
+    SECTION("Thermoelastic Jacobian checks for element rotated about y-axis")
     {
         // Rotated 35.8 about y-axis at element's centroid
-        transform_element(mesh, X0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 35.8, 0.0);
-        REQUIRE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->thermal_residual(true, residual, jacobian, temperature_load);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_thermal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd, temperature_load);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                1.0, 1.0, 0.0, 35.8, 0.0);
+        REQUIRE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.elem->thermal_residual(true, test_elem.residual, test_elem.jacobian, temperature_load);
+
+        // Finite difference Jacobian check
+        TEST::approximate_thermal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd, temperature_load);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("thermal_jacobian_scaled_x")
+
+
+    SECTION("Thermoelastic Jacobian checks for element stretched in x-direction")
     {
-        // Rotated 63.4 about z-axis at element's centroid
-        transform_element(mesh, X0, 0.0, 0.0, 0.0, 3.2, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->thermal_residual(true, residual, jacobian, temperature_load);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_thermal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd, temperature_load);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        TEST::transform_element(test_elem.mesh, coords, 0.0, 0.0, 0.0,
+                                3.2, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.elem->thermal_residual(true, test_elem.residual, test_elem.jacobian, temperature_load);
+
+        // Finite difference Jacobian check
+        TEST::approximate_thermal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd, temperature_load);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("thermal_jacobian_arbitrary_transformation")
+
+
+    SECTION("Thermoelastic Jacobian checks for element arbitrarily scaled, stretched, and rotated")
     {
-        // Arbitrary transformations applied to the element
-        transform_element(mesh, X0, -5.0, 7.8, -13.1, 2.7, 6.4, 20.0, 47.8, -70.1);
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->thermal_residual(true, residual, jacobian, temperature_load);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_thermal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd, temperature_load);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        // Apply arbitrary transformation to the element
+        TEST::transform_element(test_elem.mesh, coords, -5.0, 7.8, -13.1,
+                                2.7, 6.4, 20.0, 47.8, -70.1);
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.elem->thermal_residual(true, test_elem.residual, test_elem.jacobian, temperature_load);
+
+        // Finite difference Jacobian check
+        TEST::approximate_thermal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd, temperature_load);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
-    
-    SECTION("thermal_jacobian_arbitrary_with_displacements")
+
+
+    SECTION("Thermoelastic Jacobian checks for element arbitrarily scaled, stretched, rotated, and displaced")
     {
-        // Arbitrary transformations applied to the element
-        transform_element(mesh, X0, 4.1, -6.3, 7.5, 4.2, 1.5, -18.0, -24.8, 
-                          30.1);
-        
-        // Calculate residual and jacobian at arbitrary displacement
-        RealVectorX elem_sol = RealVectorX::Zero(n_dofs);
-        elem_sol << 0.8158724,  0.7991906, -0.0719128,  0.2025461, 
-                    -0.4602193, 0.5280159,  0.3700081,  0.4636344,  
-                    0.5559377,  0.6448206, 0.8919238, -0.3079122;
-        elem->set_solution(elem_sol);
-        
-        REQUIRE_FALSE( reference_elem->volume() == Approx(V0) );
-        
-        // Calculate residual and jacobian
-        RealVectorX residual = RealVectorX::Zero(n_dofs);
-        RealMatrixX jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
-        elem->thermal_residual(true, residual, jacobian, temperature_load);
-        
-        // Approximate Jacobian with Finite Difference
-        RealMatrixX jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
-        approximate_thermal_jacobian_with_finite_difference(*elem, elem_solution, jacobian_fd, temperature_load);
-        
-        // This is necessary because MAST manually (hard-coded) adds a small 
-        // value to the diagonal to prevent singularities at inactive DOFs
-        //double val_margin = (jacobian_fd.array().abs()).maxCoeff() * 1.490116119384766e-08;
-        val_margin = (jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
-        //std::cout << "val_margin = " << val_margin << std::endl;
-        
-        // Convert the test and truth Eigen::Matrix objects to std::vector
-        // since Catch2 has built in methods to compare vectors
-        std::vector<double> J =  eigen_matrix_to_std_vector(jacobian);
-        std::vector<double> J_fd = eigen_matrix_to_std_vector(jacobian_fd);
-        
-        // Floating point approximations are diffcult to compare since the
-        // values typically aren't exactly equal due to numerical error.
-        // Therefore, we use the Approx comparison instead of Equals
-        REQUIRE_THAT( J, Catch::Approx<double>(J_fd).margin(val_margin) );
-        
+        // Apply arbitrary transformation to the element
+        TEST::transform_element(test_elem.mesh, coords, 4.1, -6.3, 7.5,
+                                4.2, 1.5, -18.0, -24.8, 30.1);
+
+        // Apply arbitrary displacement to the element
+        RealVectorX elem_sol = RealVectorX::Zero(test_elem.n_dofs);
+        elem_sol << 0.08158724,  0.07991906, -0.00719128,  0.02025461,
+                -0.04602193,  0.05280159,  0.03700081,  0.04636344,
+                0.05559377,  0.06448206,  0.08919238, -0.03079122;
+        test_elem.elem->set_solution(elem_sol);
+
+        REQUIRE_FALSE(test_elem.reference_elem->volume() == Approx(V0));
+        test_elem.elem->thermal_residual(true, test_elem.residual, test_elem.jacobian, temperature_load);
+
+        // Finite difference Jacobian check
+        TEST::approximate_thermal_jacobian_with_finite_difference(*test_elem.elem, test_elem.elem_solution, test_elem.jacobian_fd, temperature_load);
+        val_margin = (test_elem.jacobian_fd.array().abs()).mean() * 1.490116119384766e-08;
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian_fd)).margin(val_margin));
+
         // Symmetry check
-        std::vector<double> Jt = eigen_matrix_to_std_vector(jacobian.transpose());
-        REQUIRE_THAT( Jt, Catch::Approx<double>(J) );
-        
+        REQUIRE_THAT(TEST::eigen_matrix_to_std_vector(test_elem.jacobian),
+                     Catch::Approx<double>(TEST::eigen_matrix_to_std_vector(test_elem.jacobian.transpose())));
+
         // Determinant check
-        REQUIRE( jacobian.determinant() == Approx(0.0).margin(1e-06) );
+        REQUIRE(test_elem.jacobian.determinant() == Approx(0.0).margin(1e-06));
     }
 }

--- a/tests/element/structural/1D/mast_structural_element_1d.cpp
+++ b/tests/element/structural/1D/mast_structural_element_1d.cpp
@@ -1,16 +1,25 @@
-// C++ Stanard Includes
-#include <math.h>
-
-// Catch2 includes
-#include "catch.hpp"
+/*
+ * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
+ * Copyright (C) 2013-2020  Manav Bhatia and MAST authors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
 
 // libMesh includes
 #include "libmesh/libmesh.h"
-#include "libmesh/replicated_mesh.h"
-#include "libmesh/point.h"
 #include "libmesh/elem.h"
-#include "libmesh/edge_edge2.h"
-#include "libmesh/equation_systems.h"
 #include "libmesh/dof_map.h"
 
 // MAST includes
@@ -20,15 +29,15 @@
 #include "property_cards/solid_1d_section_element_property_card.h"
 #include "elasticity/structural_element_1d.h"
 #include "elasticity/structural_system_initialization.h"
-#include "base/physics_discipline_base.h"
 #include "base/nonlinear_implicit_assembly.h"
 #include "elasticity/structural_nonlinear_assembly.h"
 #include "base/nonlinear_system.h"
-#include "elasticity/structural_element_base.h"
 #include "mesh/geom_elem.h"
 
-// Custom includes
+// Test includes
+#include "catch.hpp"
 #include "test_helpers.h"
+#include "element/structural/1D/mast_structural_element_1d.h"
 
 #define pi 3.14159265358979323846
 
@@ -37,197 +46,68 @@ extern libMesh::LibMeshInit* p_global_init;
 TEST_CASE("structural_element_1d_base_tests",
           "[1D],[structural],[base]")
 {
-    const int n_elems = 1;
-    const int n_nodes = 2;
-    
-    RealMatrixX temp = RealMatrixX::Zero(3,n_nodes);
-    temp << -1.0, 1.0, 0.0, 0.0, 0.0, 0.0;
-    const RealMatrixX X0 = temp;
-    
-    /**
-     * Create the mesh with the one element we are testing
-     */
-    libMesh::ReplicatedMesh mesh(p_global_init->comm());
-    mesh.set_mesh_dimension(1);
-    mesh.set_spatial_dimension(3);
-    mesh.reserve_elem(n_elems);
-    mesh.reserve_nodes(n_nodes);
-    
-    // Add nodes to the mesh
-    for (uint i=0; i<n_nodes; i++)
-    {
-        mesh.add_point(libMesh::Point(X0(0,i), X0(1,i), X0(2,i)));
-    }
-    
-    // Add the element to the mesh
-    libMesh::Elem *reference_elem = new libMesh::Edge2;
-    reference_elem->set_id(0);    
-    reference_elem->subdomain_id() = 0;
-    reference_elem = mesh.add_elem(reference_elem);
-    for (int i=0; i<n_nodes; i++)
-    {
-        reference_elem->set_node(i) = mesh.node_ptr(i);
-    }
-    
-    // Prepare the mesh for use
-    mesh.prepare_for_use();
-    
-    // Ensure the libMesh element has the expected volume
-    const Real elem_volume = reference_elem->volume();
-    Real true_volume = 2.0;
-    REQUIRE( elem_volume == true_volume );
-    
-    // Define Material Properties as MAST Parameters
-    MAST::Parameter E("E_param", 72.0e9);             // Modulus of Elasticity
-    MAST::Parameter nu("nu_param", 0.33);             // Poisson's ratio
-    MAST::Parameter rho("rho_param", 1420.5);         // Density
-    MAST::Parameter alpha("alpha_param", 5.43e-05);   // Coefficient of thermal expansion
-    MAST::Parameter cp("cp_param",   908.0);          // Specific Heat Capacity
-    MAST::Parameter k("k_param",     237.0);          // Thermal Conductivity
-    
-    // Define Section Properties as MAST Parameters
-    MAST::Parameter thickness_y("thy_param", 0.06);   // Section thickness in y-direction
-    MAST::Parameter thickness_z("thz_param", 0.04);   // Section thickness in z-direction
-    MAST::Parameter offset_y("offy_param", 0.035);    // Section offset in y-direction
-    MAST::Parameter Kzz("kappa_zz", 5.0/6.0);         // Shear coefficient
-    MAST::Parameter Kyy("kappa_yy", 2.0/6.0);         // Shear coefficient
-    MAST::Parameter offset_z("offz_param", 0.026);    // Section offset in z-direction
-    
-    // Create field functions to dsitribute these constant parameters throughout the model
-    MAST::ConstantFieldFunction E_f("E", E);
-    MAST::ConstantFieldFunction nu_f("nu", nu);
-    MAST::ConstantFieldFunction rho_f("rho", rho);
-    MAST::ConstantFieldFunction alpha_f("alpha_expansion", alpha);
-    MAST::ConstantFieldFunction cp_f("cp", cp);
-    MAST::ConstantFieldFunction k_f("k_th", k);
-    MAST::ConstantFieldFunction thicknessy_f("hy", thickness_y);
-    MAST::ConstantFieldFunction offsety_f("hy_off", offset_y);
-    MAST::ConstantFieldFunction thicknessz_f("hz", thickness_z);
-    MAST::ConstantFieldFunction offsetz_f("hz_off", offset_z);
-    MAST::ConstantFieldFunction Kappazz_f("Kappazz", Kzz);
-    MAST::ConstantFieldFunction Kappayy_f("Kappayy", Kyy);
-    
-    // Initialize the material
-    MAST::IsotropicMaterialPropertyCard material;                   
-    
-    // Add the material property constant field functions to the material card
-    material.add(E_f);
-    material.add(nu_f);
-    material.add(rho_f);
-    material.add(alpha_f);
-    material.add(k_f);
-    material.add(cp_f);
-    
-    // Initialize the section
-    MAST::Solid1DSectionElementPropertyCard section;
-    
-    // Add the section property constant field functions to the section card
-    section.add(thicknessy_f);
-    section.add(offsety_f);
-    section.add(thicknessz_f);
-    section.add(offsetz_f);
-    section.add(Kappazz_f);
-    section.add(Kappayy_f);
-    
-    // Add the material card to the section card
-    section.set_material(material);
-    
-    // Specify a section orientation point and add it to the section.
-    RealVectorX orientation = RealVectorX::Zero(3);
-    orientation(1) = 1.0;
-    section.y_vector() = orientation;
-    
-    // Now initialize the section
-    section.init();
-    
-    /**
-     *  Now we setup the structural system we will be solving.
-     */
-    libMesh::EquationSystems equation_systems(mesh);
-    
-    MAST::NonlinearSystem& system = equation_systems.add_system<MAST::NonlinearSystem>("structural");
-    
-    libMesh::FEType fetype(libMesh::FIRST, libMesh::LAGRANGE);
-    
-    MAST::StructuralSystemInitialization structural_system(system, 
-                                                           system.name(), 
-                                                           fetype);
-    
-    MAST::PhysicsDisciplineBase discipline(equation_systems);
-    
-    discipline.set_property_for_subdomain(0, section);
-    
-    equation_systems.init();
-    //equation_systems.print_info();
-    
-    MAST::NonlinearImplicitAssembly assembly;
-    assembly.set_discipline_and_system(discipline, structural_system);
-    
-    // Create the MAST element from the libMesh reference element
-    MAST::GeomElem geom_elem;
-    geom_elem.init(*reference_elem, structural_system);
-    std::unique_ptr<MAST::StructuralElementBase> elem_base = build_structural_element(structural_system, geom_elem, section);
-    
-    // Cast the base structural element as a 2D structural element
-    MAST::StructuralElement1D* elem = (dynamic_cast<MAST::StructuralElement1D*>(elem_base.get()));
-    
+    RealMatrixX coords = RealMatrixX::Zero(3, 2);
+    coords << -1.0, 1.0, 0.0,
+               0.0, 0.0, 0.0;
+    TEST::TestStructuralSingleElement1D test_struct_elem(libMesh::EDGE2, coords);
+
     SECTION("number_strain_components")
     {
-        REQUIRE(elem->n_direct_strain_components() == 2);
-        REQUIRE(elem->n_von_karman_strain_components() == 2);
+        REQUIRE(test_struct_elem.elem->n_direct_strain_components() == 2);
+        REQUIRE(test_struct_elem.elem->n_von_karman_strain_components() == 2);
     }
     
     SECTION("no_incompatible_modes")
     {
-        REQUIRE_FALSE( elem->if_incompatible_modes() );
+        REQUIRE_FALSE(test_struct_elem.elem->if_incompatible_modes() );
     }
-    
+
     SECTION("return_section_property")
     {
-        const MAST::ElementPropertyCardBase& elem_section = elem->elem_property();
+        const MAST::ElementPropertyCardBase& elem_section = test_struct_elem.elem->elem_property();
         CHECK( elem_section.if_isotropic() );
     }
-    
+
     SECTION("set_get_local_solution")
     {
-        const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
+        const libMesh::DofMap& dof_map = test_struct_elem.assembly.system().get_dof_map();
         std::vector<libMesh::dof_id_type> dof_indices;
-        dof_map.dof_indices (reference_elem, dof_indices);
+        dof_map.dof_indices (test_struct_elem.reference_elem, dof_indices);
         uint n_dofs = uint(dof_indices.size());
-        
+
         RealVectorX elem_solution = 5.3*RealVectorX::Ones(n_dofs);
-        elem->set_solution(elem_solution);
-        
-        const RealVectorX& local_solution = elem->local_solution();
-        
+        test_struct_elem.elem->set_solution(elem_solution);
+
+        const RealVectorX& local_solution = test_struct_elem.elem->local_solution();
+
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(elem_solution);
-        std::vector<double> truth = eigen_matrix_to_std_vector(local_solution);
-        
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(elem_solution);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(local_solution);
+
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
         // Therefore, we use the Approx comparison instead of Equals
         REQUIRE_THAT( test, Catch::Approx<double>(truth) );
     }
-    
+
     SECTION("set_get_local_solution_sensitivity")
     {
-        const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
+        const libMesh::DofMap& dof_map = test_struct_elem.assembly.system().get_dof_map();
         std::vector<libMesh::dof_id_type> dof_indices;
-        dof_map.dof_indices (reference_elem, dof_indices);
+        dof_map.dof_indices (test_struct_elem.reference_elem, dof_indices);
         uint n_dofs = uint(dof_indices.size());
-        
+
         RealVectorX elem_solution_sens = 3.1*RealVectorX::Ones(n_dofs);
-        elem->set_solution(elem_solution_sens, true);
-        
-        const RealVectorX& local_solution_sens = elem->local_solution(true);
-        
+        test_struct_elem.elem->set_solution(elem_solution_sens, true);
+
+        const RealVectorX& local_solution_sens = test_struct_elem.elem->local_solution(true);
+
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(elem_solution_sens);
-        std::vector<double> truth = eigen_matrix_to_std_vector(local_solution_sens);
-        
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(elem_solution_sens);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(local_solution_sens);
+
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
         // Therefore, we use the Approx comparison instead of Equals
@@ -236,34 +116,34 @@ TEST_CASE("structural_element_1d_base_tests",
     
     SECTION("element shape can be transformed")
     {
-        const Real V0 = reference_elem->volume();
+        const Real V0 = test_struct_elem.reference_elem->volume();
         
         // Stretch in x-direction
-        transform_element(mesh, X0, 0.0, 0.0, 0.0, 3.1, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE(reference_elem->volume() == 6.2);
+        TEST::transform_element(test_struct_elem.mesh, coords, 0.0, 0.0, 0.0, 3.1, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_struct_elem.reference_elem->volume() == 6.2);
         
         // Rotation about z-axis
-        transform_element(mesh, X0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 60.0);
-        REQUIRE(reference_elem->volume() == V0);
+        TEST::transform_element(test_struct_elem.mesh, coords, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 60.0);
+        REQUIRE(test_struct_elem.reference_elem->volume() == V0);
         
         // Rotation about y-axis
-        transform_element(mesh, X0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 30.0, 0.0);
-        REQUIRE(reference_elem->volume() == V0);
+        TEST::transform_element(test_struct_elem.mesh, coords, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 30.0, 0.0);
+        REQUIRE(test_struct_elem.reference_elem->volume() == V0);
         
         // Rotation about x-axis
-        transform_element(mesh, X0, 0.0, 0.0, 0.0, 1.0, 1.0, 20.0, 0.0, 0.0);
-        REQUIRE(reference_elem->volume() == V0);
+        TEST::transform_element(test_struct_elem.mesh, coords, 0.0, 0.0, 0.0, 1.0, 1.0, 20.0, 0.0, 0.0);
+        REQUIRE(test_struct_elem.reference_elem->volume() == V0);
         
         // Shifted in x-direction
-        transform_element(mesh, X0, 10.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE(reference_elem->volume() == V0);
+        TEST::transform_element(test_struct_elem.mesh, coords, 10.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_struct_elem.reference_elem->volume() == V0);
         
         // Shifted in y-direction
-        transform_element(mesh, X0, 0.0, 7.5, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE(reference_elem->volume() == V0);
+        TEST::transform_element(test_struct_elem.mesh, coords, 0.0, 7.5, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_struct_elem.reference_elem->volume() == V0);
         
         // Shifted in z-direction
-        transform_element(mesh, X0, 0.0, 0.0, 4.2, 1.0, 1.0, 0.0, 0.0, 0.0);
-        REQUIRE(reference_elem->volume() == V0);
+        TEST::transform_element(test_struct_elem.mesh, coords, 0.0, 0.0, 4.2, 1.0, 1.0, 0.0, 0.0, 0.0);
+        REQUIRE(test_struct_elem.reference_elem->volume() == V0);
     }
 }

--- a/tests/element/structural/1D/mast_structural_element_1d.h
+++ b/tests/element/structural/1D/mast_structural_element_1d.h
@@ -1,0 +1,192 @@
+/*
+ * MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
+ * Copyright (C) 2013-2020  Manav Bhatia and MAST authors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef MAST_MAST_STRUCTURAL_ELEMENT_1D_H
+#define MAST_MAST_STRUCTURAL_ELEMENT_1D_H
+
+// Test includes
+#include "base/mast_mesh.h"
+
+extern libMesh::LibMeshInit* p_global_init;
+
+namespace TEST {
+
+    /**
+     *
+     */
+    class TestStructuralSingleElement1D: public TEST::TestMeshSingleElement {
+    public:
+        // Material properties.
+        MAST::Parameter E;                // Modulus of Elasticity
+        MAST::Parameter nu;               // Poisson's ratio
+        MAST::Parameter rho;              // Density
+        MAST::Parameter alpha;            // Coefficient of thermal expansion
+        MAST::Parameter cp;               // Specific Heat Capacity
+        MAST::Parameter k;                // Thermal Conductivity
+        // Section properties.
+        MAST::Parameter thickness_y;      // Section thickness in y-direction
+        MAST::Parameter thickness_z;      // Section thickness in z-direction
+        MAST::Parameter offset_y;         // Section offset in y-direction
+        MAST::Parameter offset_z;         // Section offset in z-direction
+        MAST::Parameter kappa_yy;         // Shear coefficient
+        MAST::Parameter kappa_zz;         // Shear coefficient
+        // Field functions to distribution parameters throughout model.
+        MAST::ConstantFieldFunction E_f;
+        MAST::ConstantFieldFunction nu_f;
+        MAST::ConstantFieldFunction rho_f;
+        MAST::ConstantFieldFunction alpha_f;
+        MAST::ConstantFieldFunction cp_f;
+        MAST::ConstantFieldFunction k_f;
+        MAST::ConstantFieldFunction thicknessy_f;
+        MAST::ConstantFieldFunction thicknessz_f;
+        MAST::ConstantFieldFunction offsety_f;
+        MAST::ConstantFieldFunction offsetz_f;
+        MAST::ConstantFieldFunction kappa_yy_f;
+        MAST::ConstantFieldFunction kappa_zz_f;
+        // Material and property cards.
+        MAST::IsotropicMaterialPropertyCard material;
+        MAST::Solid1DSectionElementPropertyCard section;
+        // Data associated with finite element system/assembly and discipline.
+        libMesh::EquationSystems equation_systems;
+        MAST::NonlinearSystem& system;
+        libMesh::FEType fetype;
+        MAST::StructuralSystemInitialization structural_system;
+        MAST::PhysicsDisciplineBase discipline;
+        MAST::NonlinearImplicitAssembly assembly;
+        // Data for actual structural element.
+        MAST::GeomElem geom_elem;
+        std::unique_ptr<MAST::StructuralElementBase> elem_base;
+        MAST::StructuralElement1D* elem;
+        // Quick reference to element degree of freedom IDs.
+        std::vector<libMesh::dof_id_type> dof_indices;
+        uint n_dofs;
+        // Element states.
+        RealVectorX elem_solution;
+        RealVectorX elem_accel;
+        // Storage for element residual & Jacobian for zero solution.
+        RealVectorX residual;    ///< Vector storage for element's residual vector.
+        RealMatrixX jacobian0;   ///< Matrix storage for Jacobian of baseline/undeformed element.
+        RealMatrixX jacobian_xdot0;   ///< Matrix storage for velocity Jacobian of baseline/undeformed element.
+        RealMatrixX jacobian_xddot0;  ///< Matrix storage for acceleration Jacobian of baseline/undeformed element.
+        RealMatrixX jacobian;    ///< Matrix storage for Jacobian of the element in a perturbed/modified state.
+        RealMatrixX jacobian_fd; ///< Matrix storage for element Jacobian approximated by finite difference.
+
+        TestStructuralSingleElement1D(libMesh::ElemType e_type, RealMatrixX& coordinates):
+        TestMeshSingleElement(e_type, coordinates),
+        // Initialize material properties to some default values.
+        E("E_param", 72.0e9),
+        nu("nu_param", 0.33),
+        rho("rho_param", 1420.5),
+        alpha("alpha_param", 5.43e-05),
+        cp("cp_param",   908.0),
+        k("k_param",     237.0),
+        // Initialize section properties to some default values.
+        thickness_y("thy_param", 0.06),   // Section thickness in y-direction
+        thickness_z("thz_param", 0.04),   // Section thickness in z-direction
+        offset_y("offy_param", 0.035),    // Section offset in y-direction
+        offset_z("offz_param", 0.026),    // Section offset in z-direction
+        kappa_yy("kappa_yy", 5.0/6.0),    // Shear coefficient
+        kappa_zz("kappa_zz", 5.0/6.0),    // Shear coefficient
+        // Initialize field functions using parameters.
+        E_f("E", E),
+        nu_f("nu", nu),
+        rho_f("rho", rho),
+        alpha_f("alpha_expansion", alpha),
+        cp_f("cp", cp),
+        k_f("k_th", k),
+        thicknessy_f("hy", thickness_y),
+        thicknessz_f("hz", thickness_z),
+        offsety_f("hy_off", offset_y),
+        offsetz_f("hz_off", offset_z),
+        kappa_yy_f("Kappayy", kappa_yy),
+        kappa_zz_f("Kappazz", kappa_zz),
+        // Initialize system/discipline/etc.
+        equation_systems(mesh),
+        system(equation_systems.add_system<MAST::NonlinearSystem>("structural")),
+        fetype(libMesh::FIRST, libMesh::LAGRANGE),
+        structural_system(system, system.name(), fetype),
+        discipline(equation_systems)
+        {
+            // Configure material card.
+            material.add(E_f);
+            material.add(nu_f);
+            material.add(rho_f);
+            material.add(alpha_f);
+            material.add(k_f);
+            material.add(cp_f);
+
+            // Configure section property card.
+            section.add(thicknessy_f);
+            section.add(offsety_f);
+            section.add(thicknessz_f);
+            section.add(offsetz_f);
+            section.add(kappa_yy_f);
+            section.add(kappa_zz_f);
+            section.set_material(material);
+            RealVectorX orientation = RealVectorX::Zero(3);
+            orientation(1) = 1.0;
+            section.y_vector() = orientation;
+            section.init();
+            discipline.set_property_for_subdomain(0, section);
+
+            // Setup finite element system and discipline.
+            equation_systems.init();
+            assembly.set_discipline_and_system(discipline, structural_system);
+
+            // Create the MAST element from the libMesh reference element.
+            geom_elem.init(*reference_elem, structural_system);
+            elem_base = MAST::build_structural_element(structural_system, geom_elem, section);
+            elem = (dynamic_cast<MAST::StructuralElement1D*>(elem_base.get()));
+
+            // Get element DOFs for easy reference in tests.
+            const libMesh::DofMap& dof_map = assembly.system().get_dof_map();
+            dof_map.dof_indices (reference_elem, dof_indices);
+            n_dofs = uint(dof_indices.size());
+
+            // Set element's initial solution and solution sensitivity to zero.
+            elem_solution = RealVectorX::Zero(n_dofs);
+            elem->set_solution(elem_solution);
+            elem->set_solution(elem_solution, true);
+
+            // Set element's initial acceleration and acceleration sensitivity to zero.
+            elem_accel = RealVectorX::Zero(n_dofs);
+            elem->set_acceleration(elem_accel);
+            elem->set_acceleration(elem_accel, true);
+
+            // Calculate residual and jacobian
+            residual = RealVectorX::Zero(n_dofs);
+            jacobian0 = RealMatrixX::Zero(n_dofs, n_dofs);
+            jacobian_xdot0 = RealMatrixX::Zero(n_dofs, n_dofs);
+            jacobian_xddot0 = RealMatrixX::Zero(n_dofs, n_dofs);
+            jacobian = RealMatrixX::Zero(n_dofs, n_dofs);
+            jacobian_fd = RealMatrixX::Zero(n_dofs, n_dofs);
+
+        };
+        void update_residual_and_jacobian0() {elem->internal_residual(true, residual, jacobian0);}
+        void update_residual_and_jacobian() {elem->internal_residual(true, residual, jacobian);}
+        void update_inertial_residual_and_jacobian0() {elem->inertial_residual(true, residual, jacobian_xddot0, jacobian_xdot0, jacobian0);}
+//        void update_thermal_residual_and_jacobian0(MAST::BoundaryConditionBase temperature_load)
+//        {
+//            elem->thermal_residual(true, residual, jacobian0, temperature_load);
+//        }
+
+    };
+}
+
+#endif // MAST_MAST_STRUCTURAL_ELEMENT_1D_H

--- a/tests/material/mast_isotropic_material.cpp
+++ b/tests/material/mast_isotropic_material.cpp
@@ -44,8 +44,8 @@ TEST_CASE("constant_isotropic_thermoelastic_material_1d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_texp);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_texp_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_texp);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_texp_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -94,8 +94,8 @@ TEST_CASE("constant_isotropic_structural_material_1d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -150,8 +150,8 @@ TEST_CASE("constant_isotropic_heat_transfer_material_1d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test = eigen_matrix_to_std_vector(D_k);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_k_true);
+        std::vector<double> test = TEST::eigen_matrix_to_std_vector(D_k);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_k_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -211,8 +211,8 @@ TEST_CASE("constant_isotropic_transient_heat_transfer_material_1d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test = eigen_matrix_to_std_vector(D_cp);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_cp_true);
+        std::vector<double> test = TEST::eigen_matrix_to_std_vector(D_cp);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_cp_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -258,8 +258,8 @@ TEST_CASE("constant_isotropic_thermoelastic_material_2d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_texp);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_texp_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_texp);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_texp_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -320,8 +320,8 @@ TEST_CASE("constant_isotropic_structural_material_2d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(K_mat.transpose());
-        std::vector<double> truth = eigen_matrix_to_std_vector(K_mat);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(K_mat.transpose());
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(K_mat);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -351,8 +351,8 @@ TEST_CASE("constant_isotropic_structural_material_2d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        test =  eigen_matrix_to_std_vector(K_mat);
-        truth = eigen_matrix_to_std_vector(K_mat_true);
+        test =  TEST::eigen_matrix_to_std_vector(K_mat);
+        truth = TEST::eigen_matrix_to_std_vector(K_mat_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -375,8 +375,8 @@ TEST_CASE("constant_isotropic_structural_material_2d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(K_mat.transpose());
-        std::vector<double> truth = eigen_matrix_to_std_vector(K_mat);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(K_mat.transpose());
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(K_mat);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -406,8 +406,8 @@ TEST_CASE("constant_isotropic_structural_material_2d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        test =  eigen_matrix_to_std_vector(K_mat);
-        truth = eigen_matrix_to_std_vector(K_mat_true);
+        test =  TEST::eigen_matrix_to_std_vector(K_mat);
+        truth = TEST::eigen_matrix_to_std_vector(K_mat_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -488,8 +488,8 @@ TEST_CASE("constant_isotropic_heat_transfer_material_2d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test = eigen_matrix_to_std_vector(D_k);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_k_true);
+        std::vector<double> test = TEST::eigen_matrix_to_std_vector(D_k);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_k_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -549,8 +549,8 @@ TEST_CASE("constant_isotropic_transient_heat_transfer_material_2d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test = eigen_matrix_to_std_vector(D_cp);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_cp_true);
+        std::vector<double> test = TEST::eigen_matrix_to_std_vector(D_cp);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_cp_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -597,8 +597,8 @@ TEST_CASE("constant_isotropic_thermoelastic_material_3d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_texp);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_texp_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_texp);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_texp_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -659,8 +659,8 @@ TEST_CASE("constant_isotropic_structural_material_3d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(K_mat.transpose());
-        std::vector<double> truth = eigen_matrix_to_std_vector(K_mat);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(K_mat.transpose());
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(K_mat);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -696,8 +696,8 @@ TEST_CASE("constant_isotropic_structural_material_3d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        test =  eigen_matrix_to_std_vector(K_mat);
-        truth = eigen_matrix_to_std_vector(K_mat_true);
+        test =  TEST::eigen_matrix_to_std_vector(K_mat);
+        truth = TEST::eigen_matrix_to_std_vector(K_mat_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -752,8 +752,8 @@ TEST_CASE("constant_isotropic_heat_transfer_material_3d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test = eigen_matrix_to_std_vector(D_k);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_k_true);
+        std::vector<double> test = TEST::eigen_matrix_to_std_vector(D_k);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_k_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -813,8 +813,8 @@ TEST_CASE("constant_isotropic_transient_heat_transfer_material_3d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test = eigen_matrix_to_std_vector(D_cp);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_cp_true);
+        std::vector<double> test = TEST::eigen_matrix_to_std_vector(D_cp);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_cp_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -869,8 +869,8 @@ TEST_CASE("constant_isotropic_dynamic_material_3d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test = eigen_matrix_to_std_vector(D_inertia);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_inertia_true);
+        std::vector<double> test = TEST::eigen_matrix_to_std_vector(D_inertia);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_inertia_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.

--- a/tests/material/mast_isotropic_material_sensitivity.cpp
+++ b/tests/material/mast_isotropic_material_sensitivity.cpp
@@ -48,8 +48,8 @@ TEST_CASE("constant_isotropic_thermoelastic_material_1d_sensitivity",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(dD_texp);
-        std::vector<double> truth = eigen_matrix_to_std_vector(dD_texp_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(dD_texp);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(dD_texp_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -102,8 +102,8 @@ TEST_CASE("constant_isotropic_structural_material_1d_sensitivity",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(dD);
-        std::vector<double> truth = eigen_matrix_to_std_vector(dD_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(dD);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(dD_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -128,8 +128,8 @@ TEST_CASE("constant_isotropic_structural_material_1d_sensitivity",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(dD);
-        std::vector<double> truth = eigen_matrix_to_std_vector(dD_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(dD);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(dD_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -183,8 +183,8 @@ TEST_CASE("constant_isotropic_heat_transfer_material_1d_sensitivity",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test = eigen_matrix_to_std_vector(dD_k);
-        std::vector<double> truth = eigen_matrix_to_std_vector(dD_k_true);
+        std::vector<double> test = TEST::eigen_matrix_to_std_vector(dD_k);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(dD_k_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -244,8 +244,8 @@ TEST_CASE("constant_isotropic_transient_heat_transfer_material_1d_sensitivity",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test = eigen_matrix_to_std_vector(dD_cp);
-        std::vector<double> truth = eigen_matrix_to_std_vector(dD_cp_true);
+        std::vector<double> test = TEST::eigen_matrix_to_std_vector(dD_cp);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(dD_cp_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -291,8 +291,8 @@ TEST_CASE("constant_isotropic_thermoelastic_material_2d_sensitivity",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(dD_texp);
-        std::vector<double> truth = eigen_matrix_to_std_vector(dD_texp_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(dD_texp);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(dD_texp_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -552,8 +552,8 @@ TEST_CASE("constant_isotropic_structural_material_2d_sensitivity",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(dD_trans_shear);
-        std::vector<double> truth = eigen_matrix_to_std_vector(dD_trans_shear_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(dD_trans_shear);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(dD_trans_shear_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -618,8 +618,8 @@ TEST_CASE("constant_isotropic_transient_heat_transfer_material_2d_sensitivity",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test = eigen_matrix_to_std_vector(dD_cp);
-        std::vector<double> truth = eigen_matrix_to_std_vector(dD_cp_true);
+        std::vector<double> test = TEST::eigen_matrix_to_std_vector(dD_cp);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(dD_cp_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -643,8 +643,8 @@ TEST_CASE("constant_isotropic_transient_heat_transfer_material_2d_sensitivity",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test = eigen_matrix_to_std_vector(dD_cp);
-        std::vector<double> truth = eigen_matrix_to_std_vector(dD_cp_true);
+        std::vector<double> test = TEST::eigen_matrix_to_std_vector(dD_cp);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(dD_cp_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -708,8 +708,8 @@ TEST_CASE("constant_isotropic_heat_transfer_material_2d_sensitivity",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test = eigen_matrix_to_std_vector(dD_k);
-        std::vector<double> truth = eigen_matrix_to_std_vector(dD_k_true);
+        std::vector<double> test = TEST::eigen_matrix_to_std_vector(dD_k);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(dD_k_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.

--- a/tests/material/mast_orthotropic_material.cpp
+++ b/tests/material/mast_orthotropic_material.cpp
@@ -47,8 +47,8 @@ TEST_CASE("constant_orthotropic_thermoelastic_material_1d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_texp);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_texp_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_texp);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_texp_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -98,8 +98,8 @@ TEST_CASE("constant_orthotropic_structural_material_1d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -154,8 +154,8 @@ TEST_CASE("constant_orthotropic_heat_transfer_material_1d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test = eigen_matrix_to_std_vector(D_k);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_k_true);
+        std::vector<double> test = TEST::eigen_matrix_to_std_vector(D_k);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_k_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -215,8 +215,8 @@ TEST_CASE("constant_orthotropic_transient_heat_transfer_material_1d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test = eigen_matrix_to_std_vector(D_cp);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_cp_true);
+        std::vector<double> test = TEST::eigen_matrix_to_std_vector(D_cp);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_cp_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -267,8 +267,8 @@ TEST_CASE("constant_orthotropic_thermoelastic_material_2d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_texp);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_texp_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_texp);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_texp_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -352,8 +352,8 @@ TEST_CASE("constant_orthotropic_structural_material_2d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(K_mat.transpose());
-        std::vector<double> truth = eigen_matrix_to_std_vector(K_mat);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(K_mat.transpose());
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(K_mat);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -382,8 +382,8 @@ TEST_CASE("constant_orthotropic_structural_material_2d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        test =  eigen_matrix_to_std_vector(K_mat);
-        truth = eigen_matrix_to_std_vector(K_mat_true);
+        test =  TEST::eigen_matrix_to_std_vector(K_mat);
+        truth = TEST::eigen_matrix_to_std_vector(K_mat_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -406,8 +406,8 @@ TEST_CASE("constant_orthotropic_structural_material_2d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(K_mat.transpose());
-        std::vector<double> truth = eigen_matrix_to_std_vector(K_mat);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(K_mat.transpose());
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(K_mat);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -436,8 +436,8 @@ TEST_CASE("constant_orthotropic_structural_material_2d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        test =  eigen_matrix_to_std_vector(K_mat);
-        truth = eigen_matrix_to_std_vector(K_mat_true);
+        test =  TEST::eigen_matrix_to_std_vector(K_mat);
+        truth = TEST::eigen_matrix_to_std_vector(K_mat_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -524,8 +524,8 @@ TEST_CASE("constant_orthotropic_heat_transfer_material_2d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test = eigen_matrix_to_std_vector(D_k);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_k_true);
+        std::vector<double> test = TEST::eigen_matrix_to_std_vector(D_k);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_k_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -585,8 +585,8 @@ TEST_CASE("constant_orthotropic_transient_heat_transfer_material_2d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test = eigen_matrix_to_std_vector(D_cp);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_cp_true);
+        std::vector<double> test = TEST::eigen_matrix_to_std_vector(D_cp);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_cp_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -642,8 +642,8 @@ TEST_CASE("constant_orthotropic_thermoelastic_material_3d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_texp);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_texp_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_texp);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_texp_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -737,8 +737,8 @@ TEST_CASE("constant_orthotropic_structural_material_3d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(K_mat.transpose());
-        std::vector<double> truth = eigen_matrix_to_std_vector(K_mat);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(K_mat.transpose());
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(K_mat);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -773,8 +773,8 @@ TEST_CASE("constant_orthotropic_structural_material_3d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        test =  eigen_matrix_to_std_vector(K_mat);
-        truth = eigen_matrix_to_std_vector(K_mat_true);
+        test =  TEST::eigen_matrix_to_std_vector(K_mat);
+        truth = TEST::eigen_matrix_to_std_vector(K_mat_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -841,8 +841,8 @@ TEST_CASE("constant_orthotropic_heat_transfer_material_3d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test = eigen_matrix_to_std_vector(D_k);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_k_true);
+        std::vector<double> test = TEST::eigen_matrix_to_std_vector(D_k);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_k_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -902,8 +902,8 @@ TEST_CASE("constant_orthotropic_transient_heat_transfer_material_3d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test = eigen_matrix_to_std_vector(D_cp);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_cp_true);
+        std::vector<double> test = TEST::eigen_matrix_to_std_vector(D_cp);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_cp_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -958,8 +958,8 @@ TEST_CASE("constant_orthotropic_dynamic_material_3d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test = eigen_matrix_to_std_vector(D_inertia);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_inertia_true);
+        std::vector<double> test = TEST::eigen_matrix_to_std_vector(D_inertia);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_inertia_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.

--- a/tests/property/mast_3d_isotropic_element_property_card.cpp
+++ b/tests/property/mast_3d_isotropic_element_property_card.cpp
@@ -71,8 +71,8 @@ TEST_CASE("element_property_card_constant_heat_transfer_isotropic_3d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_conduc);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_conduc_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_sec_conduc);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_sec_conduc_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -137,8 +137,8 @@ TEST_CASE("element_property_card_constant_transient_heat_transfer_isotropic_3d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_capac);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_capac_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_sec_capac);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_sec_capac_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -212,8 +212,8 @@ TEST_CASE("element_property_card_constant_thermoelastic_isotropic_3d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_texpA);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_texpA_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_sec_texpA);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_sec_texpA_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -253,8 +253,8 @@ TEST_CASE("element_property_card_constant_thermoelastic_isotropic_3d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_texpB);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_texpB_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_sec_texpB);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_sec_texpB_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -328,8 +328,8 @@ TEST_CASE("element_property_card_constant_dynamic_isotropic_3d",
 
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_inertia);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_inertia_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_sec_inertia);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_sec_inertia_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -434,8 +434,8 @@ TEST_CASE("element_property_card_constant_structural_isotropic_3d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_stiff);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_stiff_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_stiff);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_stiff_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.

--- a/tests/property/mast_solid_1d_section_element_property_card.cpp
+++ b/tests/property/mast_solid_1d_section_element_property_card.cpp
@@ -799,8 +799,8 @@ TEST_CASE("solid_element_property_card_constant_heat_transfer_1d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_conduc);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_conduc_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_sec_conduc);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_sec_conduc_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -833,8 +833,8 @@ TEST_CASE("solid_element_property_card_constant_heat_transfer_1d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_capac);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_capac_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_sec_capac);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_sec_capac_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -969,8 +969,8 @@ TEST_CASE("solid_element_property_card_constant_thermoelastic_1d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_texpA);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_texpA_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_sec_texpA);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_sec_texpA_true);
         
         
         // Floating point approximations are diffcult to compare since the
@@ -1019,8 +1019,8 @@ TEST_CASE("solid_element_property_card_constant_thermoelastic_1d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_texpB);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_texpB_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_sec_texpB);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_sec_texpB_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -1208,8 +1208,8 @@ TEST_CASE("solid_element_property_card_constant_dynamic_1d",
 
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_iner);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_iner_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_sec_iner);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_sec_iner_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -1392,8 +1392,8 @@ TEST_CASE("solid_element_property_card_constant_structural_1d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_ext);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_ext_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_sec_ext);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_sec_ext_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -1441,8 +1441,8 @@ TEST_CASE("solid_element_property_card_constant_structural_1d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_bnd);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_bnd_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_sec_bnd);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_sec_bnd_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -1487,8 +1487,8 @@ TEST_CASE("solid_element_property_card_constant_structural_1d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_bndext);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_bndext_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_sec_bndext);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_sec_bndext_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -1528,8 +1528,8 @@ TEST_CASE("solid_element_property_card_constant_structural_1d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_shr);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_shr_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_sec_shr);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_sec_shr_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.

--- a/tests/property/mast_solid_2d_section_element_property_card.cpp
+++ b/tests/property/mast_solid_2d_section_element_property_card.cpp
@@ -82,8 +82,8 @@ TEST_CASE("element_property_card_constant_heat_transfer_2d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_conduc);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_conduc_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_sec_conduc);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_sec_conduc_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -160,8 +160,8 @@ TEST_CASE("element_property_card_constant_transient_heat_transfer_2d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_capac);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_capac_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_sec_capac);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_sec_capac_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -248,8 +248,8 @@ TEST_CASE("element_property_card_constant_thermoelastic_2d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_texpA);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_texpA_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_sec_texpA);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_sec_texpA_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -291,8 +291,8 @@ TEST_CASE("element_property_card_constant_thermoelastic_2d",
                 
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_texpA);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_texpA_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_sec_texpA);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_sec_texpA_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -334,8 +334,8 @@ TEST_CASE("element_property_card_constant_thermoelastic_2d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_texpB);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_texpB_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_sec_texpB);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_sec_texpB_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -376,8 +376,8 @@ TEST_CASE("element_property_card_constant_thermoelastic_2d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_texpB);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_texpB_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_sec_texpB);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_sec_texpB_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -472,8 +472,8 @@ TEST_CASE("element_property_card_constant_dynamic_2d",
 
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_iner);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_iner_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_sec_iner);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_sec_iner_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -619,8 +619,8 @@ TEST_CASE("element_property_card_constant_structural_2d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_ext);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_ext_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_sec_ext);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_sec_ext_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -665,8 +665,8 @@ TEST_CASE("element_property_card_constant_structural_2d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_ext);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_ext_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_sec_ext);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_sec_ext_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -711,8 +711,8 @@ TEST_CASE("element_property_card_constant_structural_2d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_bnd);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_bnd_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_sec_bnd);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_sec_bnd_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -757,8 +757,8 @@ TEST_CASE("element_property_card_constant_structural_2d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_bnd);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_bnd_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_sec_bnd);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_sec_bnd_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -804,8 +804,8 @@ TEST_CASE("element_property_card_constant_structural_2d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_bndext);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_bndext_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_sec_bndext);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_sec_bndext_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -851,8 +851,8 @@ TEST_CASE("element_property_card_constant_structural_2d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_bndext);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_bndext_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_sec_bndext);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_sec_bndext_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.
@@ -895,8 +895,8 @@ TEST_CASE("element_property_card_constant_structural_2d",
         
         // Convert the test and truth Eigen::Matrix objects to std::vector
         // since Catch2 has built in methods to compare vectors
-        std::vector<double> test =  eigen_matrix_to_std_vector(D_sec_shr);
-        std::vector<double> truth = eigen_matrix_to_std_vector(D_sec_shr_true);
+        std::vector<double> test =  TEST::eigen_matrix_to_std_vector(D_sec_shr);
+        std::vector<double> truth = TEST::eigen_matrix_to_std_vector(D_sec_shr_true);
         
         // Floating point approximations are diffcult to compare since the
         // values typically aren't exactly equal due to numerical error.

--- a/tests/test_helpers.cpp
+++ b/tests/test_helpers.cpp
@@ -30,7 +30,7 @@
 #define pi 3.14159265358979323846
 
 
-std::vector<double> eigen_matrix_to_std_vector(RealMatrixX M)
+std::vector<double> TEST::eigen_matrix_to_std_vector(RealMatrixX M)
 {
     std::vector<double> vec(M.data(), M.data()+M.rows()*M.cols());
     return vec;
@@ -50,7 +50,7 @@ Real TEST::get_shoelace_area(RealMatrixX X)
     return true_volume;
 }
 
-void approximate_internal_jacobian_with_finite_difference(
+void TEST::approximate_internal_jacobian_with_finite_difference(
                                     MAST::StructuralElementBase& elem, 
                                     const RealVectorX& initial_elem_solution, 
                                     RealMatrixX& jacobian)
@@ -105,7 +105,7 @@ void approximate_internal_jacobian_with_finite_difference(
 }
 
 
-void approximate_side_external_jacobian_with_finite_difference(
+void TEST::approximate_side_external_jacobian_with_finite_difference(
                                     MAST::StructuralElementBase& elem, 
                                     MAST::PhysicsDisciplineBase& discipline,
                                     const RealVectorX& initial_elem_solution, 
@@ -147,7 +147,7 @@ void approximate_side_external_jacobian_with_finite_difference(
 }
 
 
-void approximate_volume_external_jacobian_with_finite_difference(
+void TEST::approximate_volume_external_jacobian_with_finite_difference(
                                     MAST::StructuralElementBase& elem, 
                                     MAST::PhysicsDisciplineBase& discipline,
                                     const RealVectorX& initial_elem_solution, 
@@ -189,7 +189,7 @@ void approximate_volume_external_jacobian_with_finite_difference(
 }
 
 
-void approximate_inertial_jacobian_with_finite_difference(
+void TEST::approximate_inertial_jacobian_with_finite_difference(
                                     MAST::StructuralElementBase& elem, 
                                     const RealVectorX& initial_elem_accel, 
                                     RealMatrixX& jacobian)
@@ -244,7 +244,7 @@ void approximate_inertial_jacobian_with_finite_difference(
 }
 
 
-void approximate_thermal_jacobian_with_finite_difference(
+void TEST::approximate_thermal_jacobian_with_finite_difference(
                                     MAST::StructuralElementBase& elem, 
                                     const RealVectorX& initial_elem_solution, 
                                     RealMatrixX& jacobian,
@@ -300,7 +300,7 @@ void approximate_thermal_jacobian_with_finite_difference(
 }
 
 
-void transform_element(libMesh::MeshBase& mesh, const RealMatrixX X0, 
+void TEST::transform_element(libMesh::MeshBase& mesh, const RealMatrixX X0,
                         Real shift_x, Real shift_y, Real shift_z,
                         Real scale_x, Real scale_y,
                         Real rotation_x, Real rotation_y, Real rotation_z,

--- a/tests/test_helpers.cpp
+++ b/tests/test_helpers.cpp
@@ -36,7 +36,7 @@ std::vector<double> eigen_matrix_to_std_vector(RealMatrixX M)
     return vec;
 }
 
-Real get_shoelace_area(RealMatrixX X)
+Real TEST::get_shoelace_area(RealMatrixX X)
 {
     Real true_volume = 0.0;
     uint n_nodes = X.cols();

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -17,6 +17,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#ifndef __test__test_helpers__
+#define __test__test_helpers__
+
 #include "base/mast_data_types.h"
 #include "elasticity/structural_element_base.h"
 #include "base/physics_discipline_base.h"
@@ -28,11 +31,14 @@
  */
 std::vector<double> eigen_matrix_to_std_vector(RealMatrixX M);
 
+namespace TEST {
+
 /**
  * Calcualtes the area of a 2D polygon using the shoelace formula.
  */
-Real get_shoelace_area(RealMatrixX X);
+    Real get_shoelace_area(RealMatrixX X);
 
+}
 /**
  * Approximates the internal jacobian using a 6th order accurate central 
  * finite difference scheme.
@@ -93,4 +99,4 @@ void transform_element(libMesh::MeshBase& mesh, const RealMatrixX X0,
                         Real rotation_x, Real rotation_y, Real rotation_z,
                         Real shear_x = 0, Real shear_y = 0);
 
-
+#endif // __test__test_helpers__

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -23,80 +23,83 @@
 #include "base/mast_data_types.h"
 #include "elasticity/structural_element_base.h"
 #include "base/physics_discipline_base.h"
-
-
-/**
- * Converts an Eigen Matrix object to a std::vector. Useful for performing
- * elementwise comparisons in Catch2 tests.
- */
-std::vector<double> eigen_matrix_to_std_vector(RealMatrixX M);
+#include "libmesh/point.h"
+#include "libmesh/face_quad4.h"
 
 namespace TEST {
 
-/**
- * Calcualtes the area of a 2D polygon using the shoelace formula.
- */
+    /**
+     * Converts an Eigen Matrix object to a std::vector. Useful for performing
+     * elementwise comparisons in Catch2 tests.
+     */
+    std::vector<double> eigen_matrix_to_std_vector(RealMatrixX M);
+
+
+    /**
+     * Calcualtes the area of a 2D polygon using the shoelace formula.
+     */
     Real get_shoelace_area(RealMatrixX X);
 
+    /**
+     * Approximates the internal Jacobian of an element using a 6th order
+     * accurate central finite difference scheme.
+     */
+    void approximate_internal_jacobian_with_finite_difference(
+            MAST::StructuralElementBase& elem,
+            const RealVectorX& initial_elem_solution,
+            RealMatrixX& jacobian);
+
+
+    /**
+     * Approximates the side external jacobian using a 4th order accurate central
+     * finite difference scheme.
+     */
+    void approximate_side_external_jacobian_with_finite_difference(
+            MAST::StructuralElementBase& elem,
+            MAST::PhysicsDisciplineBase& discipline,
+            const RealVectorX& initial_elem_solution,
+            RealMatrixX& jacobian);
+
+    /**
+     * Approximates the volume external jacobian using a 4th order accurate central
+     * finite difference scheme.
+     */
+    void approximate_volume_external_jacobian_with_finite_difference(
+            MAST::StructuralElementBase& elem,
+            MAST::PhysicsDisciplineBase& discipline,
+            const RealVectorX& initial_elem_solution,
+            RealMatrixX& jacobian);
+
+    /**
+     * Approximates the inertial jacobian using a 6th order accurate central
+     * finite difference scheme.
+     */
+    void approximate_inertial_jacobian_with_finite_difference(
+            MAST::StructuralElementBase& elem,
+            const RealVectorX& initial_elem_solution,
+            RealMatrixX& jacobian);
+
+
+    /**
+     * Approximates the thermal jacobian using a 6th order accurate central
+     * finite difference scheme.
+     */
+    void approximate_thermal_jacobian_with_finite_difference(
+                                        MAST::StructuralElementBase& elem,
+                                        const RealVectorX& initial_elem_solution,
+                                        RealMatrixX& jacobian,
+                                        MAST::BoundaryConditionBase& thermal_bc);
+
+
+    /**
+     * Transform an element by applying any combination of: shifts, scales,
+     * rotations, and shears. Useful for testing elements of different geometries
+     * and in different orientations.
+     */
+    void transform_element(libMesh::MeshBase& mesh, const RealMatrixX X0,
+                           Real shift_x, Real shift_y, Real shift_z,
+                           Real scale_x, Real scale_y,
+                           Real rotation_x, Real rotation_y, Real rotation_z,
+                           Real shear_x = 0, Real shear_y = 0);
 }
-/**
- * Approximates the internal jacobian using a 6th order accurate central 
- * finite difference scheme.
- */
-void approximate_internal_jacobian_with_finite_difference(
-                                    MAST::StructuralElementBase& elem, 
-                                    const RealVectorX& initial_elem_solution, 
-                                    RealMatrixX& jacobian);
-
-/**
- * Approximates the side external jacobian using a 4th order accurate central 
- * finite difference scheme.
- */
-void approximate_side_external_jacobian_with_finite_difference(
-                                    MAST::StructuralElementBase& elem, 
-                                    MAST::PhysicsDisciplineBase& discipline,
-                                    const RealVectorX& initial_elem_solution, 
-                                    RealMatrixX& jacobian);
-
-/**
- * Approximates the volume external jacobian using a 4th order accurate central 
- * finite difference scheme.
- */
-void approximate_volume_external_jacobian_with_finite_difference(
-                                    MAST::StructuralElementBase& elem, 
-                                    MAST::PhysicsDisciplineBase& discipline,
-                                    const RealVectorX& initial_elem_solution, 
-                                    RealMatrixX& jacobian);
-
-/**
- * Approximates the inertial jacobian using a 6th order accurate central 
- * finite difference scheme.
- */
-void approximate_inertial_jacobian_with_finite_difference(
-                                    MAST::StructuralElementBase& elem, 
-                                    const RealVectorX& initial_elem_solution, 
-                                    RealMatrixX& jacobian);
-
-/**
- * Approximates the thermal jacobian using a 6th order accurate central 
- * finite difference scheme.
- */
-void approximate_thermal_jacobian_with_finite_difference(
-                                    MAST::StructuralElementBase& elem, 
-                                    const RealVectorX& initial_elem_solution, 
-                                    RealMatrixX& jacobian,
-                                    MAST::BoundaryConditionBase& thermal_bc);
-
-
-/**
- * Transform an element by applying any combination of: shifts, scales, 
- * rotations, and shears. Useful for testing elements of different geometries
- * and in different orientations.
- */
-void transform_element(libMesh::MeshBase& mesh, const RealMatrixX X0, 
-                        Real shift_x, Real shift_y, Real shift_z,
-                        Real scale_x, Real scale_y,
-                        Real rotation_x, Real rotation_y, Real rotation_z,
-                        Real shear_x = 0, Real shear_y = 0);
-
 #endif // __test__test_helpers__


### PR DESCRIPTION
This pull request refactors some of the Catch2 test code. It introduces some re-usable classes to define basic elements/storage that can be utilized as setup-code so similar storage doesn't need to be created for every test.

There is still a fair amount of replicated code, but it all generally appears inside of Catch `SECTIONS` that I believe we want to keep separate. Short of writing some macros for this, I'm not sure how we can avoid it at this time.

In addition, this PR introduces the TEST namespace where these test helper classes and other test-methods can be stored. The Doxygen documentation has also been updated to parse the `tests` directory so that these helper classes/functions can be documented. They are separated from library by being in a different namespace.

@JohnDN90 can you look over this stuff and make sure I am still capturing the spirit of your tests.