### PR TITLE
Upgrade CI libMesh 1.5.0->1.5.1 & add triangle/tetgen to all libMesh CI binaries.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,19 @@ language: cpp
 
 matrix:
     include:
-      # macOS/Linux builds - libMesh version 1.5.0
+      # macOS/Linux builds - libMesh version 1.5.1
       - os: osx
         osx_image: xcode10.2
-        env: LIBMESH_VERSION=1.5.0
+        env: LIBMESH_VERSION=1.5.1
       - os: linux
         dist: xenial
-        env: LIBMESH_VERSION=1.5.0
+        env: LIBMESH_VERSION=1.5.1
 
       # Doxygen documentation build
       # - this job also progresses to deployment when on master branch
       - os: linux
         dist: xenial
-        env: CI_BUILD_DOCS=true CI_DEPLOY_DOCS=true LIBMESH_VERSION=1.4.1
+        env: CI_BUILD_DOCS=true CI_DEPLOY_DOCS=true LIBMESH_VERSION=1.5.1
 
       # macOS/Linux builds - libMesh version 1.4.1
       - os: osx

--- a/ci/build_mast.sh
+++ b/ci/build_mast.sh
@@ -109,15 +109,19 @@ elif [ "${TRAVIS_OS_NAME}" = osx ]; then # macOS 10.14, XCode 10.2
   if [ "${LIBMESH_VERSION}" = "1.3.1" ]; then
     PETSc_DIR=/Users/travis/Code/spack-mstc/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/petsc-3.11.4-4ode2ljnkurc55362bc6k6wtlgfjpdmf
     SLEPc_DIR=/Users/travis/Code/spack-mstc/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/slepc-3.11.2-nts2wrpmixfsvfev7x5b5e2e4vpct6wy
-    libMesh_DIR=/Users/travis/Code/spack-mstc/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/libmesh-1.3.1-gsiac4h5rvdoowg2mjfvwrvmwbbnw5yv
+    libMesh_DIR=/Users/travis/Code/spack-mstc/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/libmesh-1.3.1-4h7zpmhjpw6qwodrpoehwaq7fukjwfno
   elif [ "${LIBMESH_VERSION}" = "1.4.1" ]; then
     PETSc_DIR=/Users/travis/Code/spack-mstc/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/petsc-3.11.4-4ode2ljnkurc55362bc6k6wtlgfjpdmf
     SLEPc_DIR=/Users/travis/Code/spack-mstc/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/slepc-3.11.2-nts2wrpmixfsvfev7x5b5e2e4vpct6wy
-    libMesh_DIR=/Users/travis/Code/spack-mstc/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/libmesh-1.4.1-3zx2df3tra2fd6znisp5cthgawkh4zol
+    libMesh_DIR=/Users/travis/Code/spack-mstc/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/libmesh-1.4.1-bry6shpqjekanfoepltqyic5ami5umor
   elif [ "${LIBMESH_VERSION}" = "1.5.0" ]; then
     PETSc_DIR=/Users/travis/Code/spack-mstc/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/petsc-3.12.1-edmddchkkhtwckfumww3mtghyadytdxj
     SLEPc_DIR=/Users/travis/Code/spack-mstc/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/slepc-3.12.0-dbsf3rtgj4hoih6okdja6godorotij22
-    libMesh_DIR=/Users/travis/Code/spack-mstc/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/libmesh-1.5.0-dxjeof7unenkr5ivfpdekiuftgyktkeh
+    libMesh_DIR=/Users/travis/Code/spack-mstc/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/libmesh-1.5.0-dcgl6zldkp4xvfvfrajghwoy5b24ilrr
+  elif [ "${LIBMESH_VERSION}" = "1.5.1" ]; then
+    PETSc_DIR=/Users/travis/Code/spack-mstc/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/petsc-3.12.1-edmddchkkhtwckfumww3mtghyadytdxj
+    SLEPc_DIR=/Users/travis/Code/spack-mstc/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/slepc-3.12.0-dbsf3rtgj4hoih6okdja6godorotij22
+    libMesh_DIR=/Users/travis/Code/spack-mstc/spack/opt/spack/darwin-mojave-x86_64/clang-10.0.1-apple/libmesh-1.5.1-5y4kmrrnq6axqa2hv2ag36tjv6mgwknw
   fi
 
   # First let us build/install a Debug version of MAST (-DCMAKE_BUILD_TYPE=Debug).


### PR DESCRIPTION
This pull request modifies some of the Travis CI scripts to incorporate libMesh v1.5.1 and updates paths to versions of libMesh that are built with triangle/tetgen support (previous CI binaries didn't have these).

- Triangle required by John's addition to compute 1D section properties. CI libMesh dependencies previously didn't have this.
- Tetgen added in case it is used in the future.