### PR TITLE
Conduction 3D element flux boundary condition. 

### DIFF
--- a/src/property_cards/element_property_card_base.h
+++ b/src/property_cards/element_property_card_base.h
@@ -108,7 +108,7 @@ namespace MAST
         virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
         thermal_capacitance_matrix(const MAST::ElementBase& e) const= 0;
 
-        virtual const MAST::FieldFunction<Real>&
+        virtual const MAST::FieldFunction<Real>*
         section(const MAST::ElementBase& e) const = 0;
 
         

--- a/src/property_cards/isotropic_element_property_card_3D.h
+++ b/src/property_cards/isotropic_element_property_card_3D.h
@@ -163,8 +163,7 @@ namespace MAST
         virtual const MAST::FieldFunction<Real>*
         section(const MAST::ElementBase& e) const {
 
-            MAST::FieldFunction<Real>* ptr = nullptr;
-            return ptr;
+            return nullptr;
         }
 
     protected:

--- a/src/property_cards/isotropic_element_property_card_3D.h
+++ b/src/property_cards/isotropic_element_property_card_3D.h
@@ -160,11 +160,11 @@ namespace MAST
         virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
         thermal_capacitance_matrix() const;
         
-        virtual const MAST::FieldFunction<Real>&
+        virtual const MAST::FieldFunction<Real>*
         section(const MAST::ElementBase& e) const {
-            libmesh_error();
+
             MAST::FieldFunction<Real>* ptr = nullptr;
-            return *ptr;
+            return ptr;
         }
 
     protected:

--- a/src/property_cards/solid_1d_section_element_property_card.cpp
+++ b/src/property_cards/solid_1d_section_element_property_card.cpp
@@ -2072,17 +2072,17 @@ thermal_capacitance_matrix() const {
 }
 
 
-const MAST::FieldFunction<Real>&
+const MAST::FieldFunction<Real>*
 MAST::Solid1DSectionElementPropertyCard::
 section(const MAST::ElementBase& e) const {
     
-    return *_A;
+    return _A.get();
 }
 
 
-const MAST::FieldFunction<Real>&
+const MAST::FieldFunction<Real>*
 MAST::Solid1DSectionElementPropertyCard::
 section() const {
     
-    return *_A;
+    return _A.get();
 }

--- a/src/property_cards/solid_1d_section_element_property_card.h
+++ b/src/property_cards/solid_1d_section_element_property_card.h
@@ -81,7 +81,7 @@ namespace MAST {
         virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
         thermal_capacitance_matrix(const MAST::ElementBase& e) const;
 
-        virtual const MAST::FieldFunction<Real>&
+        virtual const MAST::FieldFunction<Real>*
         section(const MAST::ElementBase& e) const;
         
         virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
@@ -120,7 +120,7 @@ namespace MAST {
         virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
         thermal_capacitance_matrix() const;
 
-        virtual const MAST::FieldFunction<Real>&
+        virtual const MAST::FieldFunction<Real>*
         section() const;
         
 

--- a/src/property_cards/solid_2d_section_element_property_card.cpp
+++ b/src/property_cards/solid_2d_section_element_property_card.cpp
@@ -1346,9 +1346,9 @@ thermal_capacitance_matrix() const {
     return std::unique_ptr<MAST::FieldFunction<RealMatrixX> > (rval);
 }
 
-const MAST::FieldFunction<Real>&
+const MAST::FieldFunction<Real>*
 MAST::Solid2DSectionElementPropertyCard::
 section(const MAST::ElementBase& e) const {
     
-    return this->get<FieldFunction<Real>>("h");
+    return &(this->get<FieldFunction<Real>>("h"));
 }

--- a/src/property_cards/solid_2d_section_element_property_card.h
+++ b/src/property_cards/solid_2d_section_element_property_card.h
@@ -150,7 +150,7 @@ namespace MAST {
         virtual std::unique_ptr<MAST::FieldFunction<RealMatrixX> >
         thermal_capacitance_matrix() const;
         
-        virtual const MAST::FieldFunction<Real>&
+        virtual const MAST::FieldFunction<Real>*
         section(const MAST::ElementBase& e) const;
         
         void set_warping_only(const bool warping_only)


### PR DESCRIPTION
Bug-fix for conduction boundary condition application for 3D elements that do not provide a section object unlike 1D area and 2D thickness. This should address the issue raised by @anupzope