### PR TITLE
Non-zero Dirichlet Constraint

### DIFF
--- a/src/base/nonlinear_system.cpp
+++ b/src/base/nonlinear_system.cpp
@@ -224,6 +224,10 @@ MAST::NonlinearSystem::solve(MAST::AssemblyElemOperations& elem_ops,
     
     libMesh::NonlinearImplicitSystem::solve();
     
+    // enforce constraints on the solution since NonlinearImplicitSystem only
+    // enforces the constraints on current_local_solution.
+    this->get_dof_map().enforce_constraints_exactly(*this, this->solution.get());
+    
     this->nonlinear_solver->residual_and_jacobian_object = old_ptr;
     
     assembly.clear_elem_operation_object();

--- a/src/boundary_condition/dirichlet_boundary_condition.cpp
+++ b/src/boundary_condition/dirichlet_boundary_condition.cpp
@@ -26,8 +26,12 @@
 #include "libmesh/zero_function.h"
 
 void
-MAST::DirichletBoundaryCondition::init(const libMesh::boundary_id_type bid,
-                                       const std::vector<unsigned int>& constrained_vars) {
+MAST::DirichletBoundaryCondition::
+init(const libMesh::boundary_id_type bid,
+     const std::vector<unsigned int>& constrained_vars,
+     MAST::FieldFunction<RealVectorX>* f_val,
+     libMesh::VariableIndexing index,
+     unsigned int n_sys_vars) {
     
     // should not have been initialized if this is called
     libmesh_assert(_dirichlet_boundary.get() == nullptr);
@@ -35,14 +39,109 @@ MAST::DirichletBoundaryCondition::init(const libMesh::boundary_id_type bid,
     std::set<libMesh::boundary_id_type> bid_set;
     bid_set.insert(bid);
     
-    std::unique_ptr<libMesh::FunctionBase<Real> > function;
+    if (!f_val) {
+        
+        // if the function was not give, then assume it to be zero function
+        std::unique_ptr<libMesh::FunctionBase<Real> >
+        function(new libMesh::ZeroFunction<Real>);
+                
+        _dirichlet_boundary.reset(new libMesh::DirichletBoundary(bid_set,
+                                                                 constrained_vars,
+                                                                 function.get()));
+    }
+    else {
+        
+        // make sure that the number of variables is specified if indexing
+        // is set to system_variable_order.
+        if (index == libMesh::SYSTEM_VARIABLE_ORDER)
+            libmesh_assert_greater(n_sys_vars, 0);
+        
+        // create a wrapper to the provided field function and pass it to the
+        // DirichletBoundary object
+        class FunctionWrapper: public libMesh::FunctionBase<Real> {
+        public:
+            FunctionWrapper(MAST::FieldFunction<RealVectorX>& f,
+                            libMesh::VariableIndexing index,
+                            unsigned int n_constrained_vars,
+                            unsigned int n_sys_vars):
+            libMesh::FunctionBase<Real>(),
+            _f(f),
+            _index(index),
+            _n_constrained_vars(n_constrained_vars),
+            _n_sys_vars(n_sys_vars) {
+                
+                if (_index == libMesh::SYSTEM_VARIABLE_ORDER)
+                    libmesh_assert_greater(n_sys_vars, 0);
+            }
 
-    // if the function was not give, then assume it to be zero function
-    function.reset(new libMesh::ZeroFunction<Real>);
-    
-    _dirichlet_boundary.reset(new libMesh::DirichletBoundary(bid_set,
-                                                             constrained_vars,
-                                                             function.get()));
+            // copy constructor
+            FunctionWrapper(const FunctionWrapper& f):
+            libMesh::FunctionBase<Real>(),
+            _f(f._f),
+            _index(f._index),
+            _n_constrained_vars(f._n_constrained_vars),
+            _n_sys_vars(f._n_sys_vars) { }
+
+            virtual ~FunctionWrapper() {}
+            
+            virtual std::unique_ptr<libMesh::FunctionBase<Real>> clone () const {
+                
+                std::unique_ptr<libMesh::FunctionBase<Real>> f;
+                f.reset(new FunctionWrapper(*this));
+                return f;
+            }
+
+            /**
+             * \returns The scalar function value at coordinate \p p and time \p
+             * time, which defaults to zero.
+             *
+             * Pure virtual, so you have to override it.
+             */
+            virtual Real operator() (const libMesh::Point & p,
+                                     const Real time = 0.) {
+                // should not get called
+                libmesh_error();
+            }
+
+            virtual void operator() (const libMesh::Point & p,
+                                     const Real time,
+                                     libMesh::DenseVector<Real>& output) {
+             
+                RealVectorX v;
+                _f(p, time, v);
+                
+                if (_index == libMesh::SYSTEM_VARIABLE_ORDER) {
+                    libmesh_assert_equal_to(v.size(), _n_sys_vars);
+                    output.resize(_n_sys_vars);
+                    for (unsigned int i=0; i<_n_sys_vars; i++) output(i) = v(i);
+                }
+                else if (_index == libMesh::LOCAL_VARIABLE_ORDER) {
+                 
+                    libmesh_assert_equal_to(v.size(), _n_constrained_vars);
+                    output.resize(_n_constrained_vars);
+                    for (unsigned int i=0; i<_n_constrained_vars; i++) output(i) = v(i);
+                }
+            }
+
+            
+        protected:
+            MAST::FieldFunction<RealVectorX> &_f;
+            libMesh::VariableIndexing _index;
+            unsigned int _n_constrained_vars;
+            unsigned int _n_sys_vars;
+        };
+        
+        std::unique_ptr<libMesh::FunctionBase<Real>>
+        function(new FunctionWrapper(*f_val,
+                                     index,
+                                     constrained_vars.size(),
+                                     n_sys_vars));
+        
+        _dirichlet_boundary.reset(new libMesh::DirichletBoundary(bid_set,
+                                                                 constrained_vars,
+                                                                 *function,
+                                                                 index));
+    }
 }
 
 

--- a/src/boundary_condition/dirichlet_boundary_condition.h
+++ b/src/boundary_condition/dirichlet_boundary_condition.h
@@ -52,10 +52,23 @@ namespace MAST {
          *   initializes the object for the specified domain id (either boundary,
          *   or subdomain), for the displacement components initialized using
          *   a bitwise operator. This method initializes the components to zero
-         *   value on the domain.
+         *   value on the domain. If \p f_val is not provided then a zero value is
+         *   assumed for all constrained variables. \p FieldFunction should
+         *   implement a method that provides a vector containing the value of constrained
+         *   variables at specified spatial point and time. The order of variables in this vector is
+         *   based on the value of \p index. If \p index = \p libMesh::SYSTEM_VARIABLE_ORDER,
+         *   which is the default, then the \p i^th component of the vector returned by \p f_val
+         *   is the value of the \p i^th system variable. On the other hand, if
+         *   If \p index = \p libMesh::LOCAL_VARIABLE_ORDER, then the \p i^th component
+         *   of the vector returned by \p f_val is the value of the \p i^th component in
+         *   \p constrained_vars. If \p index = \p libMesh::SYSTEM_VARIABLE_ORDER
+         *   then \p n_vars should be set to the number of variables in the system.
          */
         void init(const libMesh::boundary_id_type bid,
-                  const std::vector<unsigned int>& constrained_vars);
+                  const std::vector<unsigned int>& constrained_vars,
+                  MAST::FieldFunction<RealVectorX>* f_val = nullptr,
+                  libMesh::VariableIndexing index = libMesh::SYSTEM_VARIABLE_ORDER,
+                  unsigned int n_sys_vars = 0);
         
         
         /*!


### PR DESCRIPTION
-- Added ability to specify non-zero Dirichlet boundary condition
-- Updated transient conduction example to include a non-zero boundary condition on the left boundary
-- Added a call to DofMap::enforce_constraints_exactly() for System::solution in NonlinearSystem::solve(), since libMesh::NonlinearImplicitSystem::solve() only calls this method on System::currentl_local_solution