### PR TITLE
Update Travis-CI to use Ubuntu 18.04 with newer libMesh builds and documentation build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
         osx_image: xcode10.2
         env: LIBMESH_VERSION=1.4.1
       - os: linux
-        dist: xenial
+        dist: bionic
         env: LIBMESH_VERSION=1.4.1
 
       # macOS/Linux builds - libMesh version 1.3.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,13 @@ matrix:
         osx_image: xcode10.2
         env: LIBMESH_VERSION=1.5.1
       - os: linux
-        dist: xenial
+        dist: bionic
         env: LIBMESH_VERSION=1.5.1
 
       # Doxygen documentation build
       # - this job also progresses to deployment when on master branch
       - os: linux
-        dist: xenial
+        dist: bionic
         env: CI_BUILD_DOCS=true CI_DEPLOY_DOCS=true LIBMESH_VERSION=1.5.1
 
       # macOS/Linux builds - libMesh version 1.4.1

--- a/ci/build_dependencies.sh
+++ b/ci/build_dependencies.sh
@@ -2,12 +2,12 @@
 
 if [ "${TRAVIS_OS_NAME}" = linux ]; then # Ubuntu Linux
 
+  cd ${HOME} || exit
+
+  # Python 3.7 apt repository (since its not neatly included in Ubuntu 16.04/18.04)
+  sudo add-apt-repository -y ppa:deadsnakes/ppa
+
   if [ "${TRAVIS_DIST}" = xenial ]; then # Ubuntu 16.04 Xenial Xerus
-    cd ${HOME} || exit
-
-    # Python 3.7 apt repository (since its not neatly included in Ubuntu 16.04)
-    sudo add-apt-repository -y ppa:deadsnakes/ppa
-
     # Regular libMesh/MAST dependencies.
     sudo apt-get -qq update
     sudo apt-get -qq install -y gfortran wget m4
@@ -21,29 +21,38 @@ if [ "${TRAVIS_OS_NAME}" = linux ]; then # Ubuntu Linux
     sudo apt-get -qq install -y texlive-latex-base dvi2ps ghostscript
     sudo apt-get -qq install -y python3.7 python3.7-dev libpython3.7
 
-    # Get pip working with external Python 3.7.
-    wget https://bootstrap.pypa.io/get-pip.py || exit
-    sudo python3.7 get-pip.py || exit
-
-    sudo python3.7 -m pip install numpy scipy docopt colorama pandas h5py matplotlib cpylog pyNastran
-    sudo python3.7 -m pip install Cython --install-option="--no-cython-compile"
-
-    # Update to later CMake release.
-    wget https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5-Linux-x86_64.sh || exit
-    sudo mkdir /opt/cmake || exit
-    sudo sh cmake-3.15.5-Linux-x86_64.sh --prefix=/opt/cmake --skip-license || exit
-
-  # elif [ "${TRAVIS_DIST}" = bionic ]; then # Ubuntu 18.04 Bionic Beaver
-  #  sudo apt-get -qq update
-  #  sudo apt-get -qq install -y gfortran wget m4
-  #  which gfortran
-  #  gcc --version
-  #  echo "Hello From BIONIC"
+  elif [ "${TRAVIS_DIST}" = bionic ]; then # Ubuntu 18.04 Bionic Beaver
+    # Regular libMesh/MAST dependencies.
+    sudo apt-get -qq update
+    sudo apt-get -qq install -y gfortran wget m4
+    sudo apt-get -qq install -y openmpi-bin libopenmpi-dev
+    sudo apt-get -qq install -y petsc-dev libpetsc3.7.7-dbg
+    sudo apt-get -qq install -y slepc-dev libparpack2-dev
+    sudo apt-get -qq install -y metis libmetis-dev
+    sudo apt-get -qq install -y libparpack2-dev
+    sudo apt-get -qq install -y libnetcdf11 libnetcdf-dev
+    sudo apt-get -qq install -y libboost-all-dev
+    sudo apt-get -qq install -y libeigen3-dev
+    sudo apt-get -qq install -y doxygen graphviz rsync
+    sudo apt-get -qq install -y texlive-latex-base dvi2ps ghostscript
+    sudo apt-get -qq install -y python3.7 python3.7-dev libpython3.7
 
   else
     echo "INVALID LINUX DISTRO: ${TRAVIS_DIST}"
     exit 1
   fi
+
+  # Get pip working with external Python 3.7.
+  wget https://bootstrap.pypa.io/get-pip.py || exit
+  sudo python3.7 get-pip.py || exit
+
+  sudo python3.7 -m pip install numpy scipy docopt colorama pandas h5py matplotlib cpylog pyNastran
+  sudo python3.7 -m pip install Cython --install-option="--no-cython-compile"
+
+  # Update to later CMake release.
+  wget https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5-Linux-x86_64.sh || exit
+  sudo mkdir /opt/cmake || exit
+  sudo sh cmake-3.15.5-Linux-x86_64.sh --prefix=/opt/cmake --skip-license || exit
 
 elif [ "${TRAVIS_OS_NAME}" = osx ]; then # macOS 10.14, XCode 10.2
   # Currently we don't do anything here since we get all dependencies for macOS

--- a/ci/get_libmesh.sh
+++ b/ci/get_libmesh.sh
@@ -8,7 +8,9 @@ if [ "${TRAVIS_OS_NAME}" = linux ]; then # Ubuntu Linux
     wget -nv "https://github.com/MASTmultiphysics/mast-ci-packages/releases/download/libmesh-${LIBMESH_VERSION}-1.deb/libmesh-${LIBMESH_VERSION}-1.deb" || exit
     sudo apt install "./libmesh-${LIBMESH_VERSION}-1.deb" || exit
 
-  # elif [ "${TRAVIS_DIST}" = bionic ]; then # Ubuntu 18.04 Bionic Beaver
+   elif [ "${TRAVIS_DIST}" = bionic ]; then # Ubuntu 18.04 Bionic Beaver
+    wget -nv "https://github.com/MASTmultiphysics/mast-ci-packages/releases/download/libmesh_ubuntu18.04/libmesh-${LIBMESH_VERSION}-1.deb" || exit
+    sudo apt install "./libmesh-${LIBMESH_VERSION}-1.deb" || exit
 
   else
     echo "INVALID LINUX DISTRO: ${TRAVIS_DIST}"


### PR DESCRIPTION
Updated Travis-CI to use Ubuntu 18.04 worker with versions of libMesh >= 1.4.1 and for the documentation/website builds. Builds using the older Ubuntu 16.04 worker are still used for libMesh version 1.3.1 since I could not get libMesh to build using standard Ubuntu 18.04 package repositories without a lot of work. 

In all the current releases of libMesh (including 1.5.1) there are some conflicts that occur with the metis library that is built alongside libMesh and the one that is provided by Ubuntu 18.04 repositories. After v1.5.1 the libMesh developers added an option use and external metis to the libMesh configure. I successfully back-ported this to the v1.5.1 and v1.4.1 releases without too much trouble. It wouldn't work on v1.3.1 release without more effort.

I could make the upgrade to Ubuntu 18.04 on the older versions of libMesh by building more of the dependencies manually and not using apt provided packages, but that is more work than I want to do right now.

The main reason to upgrade to Ubuntu 18.04 is that it provides a newer version of doxygen that has some improved features like picture resizing. Ubuntu 16.04 also goes end-of-life in April 2021 so I suspect Travis-Ci will stop supporting it at some point.