### PR TITLE
Topology optimization runtime efficiency

### DIFF
--- a/examples/structural/example_6/example_6.cpp
+++ b/examples/structural/example_6/example_6.cpp
@@ -99,14 +99,12 @@ class ElasticityFunction:
 public MAST::FieldFunction<Real> {
 public:
     ElasticityFunction(Real E0, Real rho_min, Real penalty,
-                       MAST::MeshFieldFunction& rho,
-                       MAST::MeshFieldFunction& drho):
+                       MAST::MeshFieldFunction& rho):
     MAST::FieldFunction<Real>("E"),
     _E0(E0),
     _rho_min(rho_min),
     _penalty(penalty),
-    _rho(rho),
-    _drho(drho) { }
+    _rho(rho) { }
     virtual ~ElasticityFunction(){}
     void set_penalty_val(Real penalty) {_penalty = penalty;}
     
@@ -124,7 +122,7 @@ public:
         
         RealVectorX v1, dv1;
         _rho(p, t, v1);
-        _drho(p, t, dv1);
+        _rho.derivative(f, p, t, dv1);
         
         v = _E0 * (1.-_rho_min) * _penalty * pow(v1(0), _penalty-1.) * dv1(0);
     }
@@ -134,7 +132,6 @@ protected:
     Real                    _rho_min; // lower limit on density
     Real                    _penalty; // value of penalty term
     MAST::MeshFieldFunction &_rho;
-    MAST::MeshFieldFunction &_drho;
 };
 
 
@@ -197,7 +194,6 @@ public:
     MAST::ElementPropertyCardBase*            _p_card;
     
     MAST::MeshFieldFunction*                  _density_function;
-    MAST::MeshFieldFunction*                  _density_sens_function;
     libMesh::ExodusII_IO*                     _output;
     
     libMesh::FEType                           _fetype;
@@ -314,9 +310,7 @@ public:
         *k_f     = new MAST::ConstantFieldFunction( "k_th",      *k),
         *cp_f    = new MAST::ConstantFieldFunction(   "cp",     *cp);
 
-        _Ef      = new ElasticityFunction(Eval, _rho_min, penalty,
-                                          *_density_function,
-                                          *_density_sens_function);
+        _Ef      = new ElasticityFunction(Eval, _rho_min, penalty, *_density_function);
         
         _parameters[  rho->name()]     = rho;
         _parameters[   nu->name()]     = nu;
@@ -465,9 +459,31 @@ public:
                 base_phi.set(_dv_params[i].first, dvars[i]);
         base_phi.close();
         _filter->compute_filtered_values(base_phi, *_density_sys->solution);
+
+        // this will create a localized vector in _level_set_sys->curret_local_solution
+        _density_sys->update();
+        
+        // create a serialized vector for use in interpolation
+        std::unique_ptr<libMesh::NumericVector<Real>>
+        serial_density_sol(libMesh::NumericVector<Real>::build(_sys->comm()).release());
+        serial_density_sol->init(_density_sys->solution->size(), false, libMesh::SERIAL);
+        _density_sys->solution->localize(*serial_density_sol);
+
         _density_function->clear();
-        _density_function->init(*_density_sys->solution);
+        _density_function->init(*serial_density_sol, true);
         _sys->solution->zero();
+        
+        //////////////////////////////////////////////////////////////////////
+        // check to see if the sensitivity of constraint is requested
+        //////////////////////////////////////////////////////////////////////
+        bool if_grad_sens = false;
+        for (unsigned int i=0; i<eval_grads.size(); i++)
+            if_grad_sens = (if_grad_sens || eval_grads[i]);
+
+        // if sensitivity analysis is requested, then initialize the vectors
+        std::vector<libMesh::NumericVector<Real>*> sens_vecs;
+        if (eval_obj_grad || if_grad_sens)
+            _initialize_sensitivity_data(sens_vecs);
         
         //*********************************************************************
         // DO NOT zero out the gradient vector, since GCMMA needs it for the  *
@@ -526,15 +542,23 @@ public:
         vm_agg = 0.,
         vol    = 0.,
         comp   = 0.;
+
+        // ask the system to update so that the localized solution is available for
+        // further processing
+        _sys->update();
+
+        //////////////////////////////////////////////////////////////////////
+        // evaluate the functions
+        //////////////////////////////////////////////////////////////////////
         
         // evaluate the volume for used in the problem setup
-        _evaluate_volume(&vol, nullptr);
+        _evaluate_volume(*serial_density_sol, sens_vecs, &vol, nullptr);
         libMesh::out << "volume: " << vol << std::endl;
 
         // evaluate the output based on specified problem type
         if (_problem == "compliance_volume") {
             
-            nonlinear_assembly.calculate_output(*_sys->solution, true, compliance);
+            nonlinear_assembly.calculate_output(*_sys->current_local_solution, false, compliance);
             comp      = compliance.output_total();
             obj       = _obj_scaling * comp;
             fvals[0]  = vol/_volume - _vf; // vol/vol0 - a <=
@@ -544,7 +568,7 @@ public:
             
             // set the elasticity penalty for stress evaluation
             _Ef->set_penalty_val(stress_penalty);
-            nonlinear_assembly.calculate_output(*_sys->solution, true, stress);
+            nonlinear_assembly.calculate_output(*_sys->current_local_solution, false, stress);
             max_vm    = stress.get_maximum_von_mises_stress();
             vm_agg    = stress.output_total();
             obj       = _obj_scaling * vol;
@@ -575,7 +599,7 @@ public:
             }
             else if (_problem == "volume_stress") {
                 
-                _evaluate_volume(nullptr, &obj_grad);
+                _evaluate_volume(*serial_density_sol, sens_vecs, nullptr, &obj_grad);
                 for (unsigned int i=0; i<grads.size(); i++)
                     obj_grad[i] *= _obj_scaling;
             }
@@ -583,12 +607,6 @@ public:
                 libmesh_error();
         }
         
-        //////////////////////////////////////////////////////////////////////
-        // check to see if the sensitivity of constraint is requested
-        //////////////////////////////////////////////////////////////////////
-        bool if_grad_sens = false;
-        for (unsigned int i=0; i<eval_grads.size(); i++)
-            if_grad_sens = (if_grad_sens || eval_grads[i]);
         
         //////////////////////////////////////////////////////////////////////
         // evaluate the sensitivities for constraints
@@ -597,7 +615,7 @@ public:
             
             if (_problem == "compliance_volume") {
                 
-                _evaluate_volume(nullptr, &grads);
+                _evaluate_volume(*serial_density_sol, sens_vecs, nullptr, &grads);
                 for (unsigned int i=0; i<grads.size(); i++)
                     grads[i] /= _volume;
             }
@@ -621,45 +639,73 @@ public:
         stress_assembly.update_stress_strain_data(stress, *_sys->solution);
         
         _density_function->clear();
+        _clear_sensitivity_data(sens_vecs);
     }
+
+    
+    //
+    // \subsection ex_6_sensitivity_vectors Initialize sensitivity data
+    //
+    void _initialize_sensitivity_data(std::vector<libMesh::NumericVector<Real>*>& dphi_vecs) {
+
+        libmesh_assert_equal_to(dphi_vecs.size(), 0);
+        
+        dphi_vecs.resize(_n_vars, nullptr);
+        
+        // Serial vectors are used for the level
+        // set mesh function since it uses a different mesh than the analysis mesh
+        // and the two can have different partitionings in the paralle environment.
+        for (unsigned int i=0; i<_n_vars; i++) {
+
+            libMesh::NumericVector<Real>
+            *vec = nullptr;
+
+            // non-zero value of the DV perturbation
+            std::map<unsigned int, Real> nonzero_val;
+            nonzero_val[_dv_params[i].first] = 1.;
+            
+            vec = libMesh::NumericVector<Real>::build(_sys->comm()).release();
+            vec->init(_density_sys->solution->size(), false, libMesh::SERIAL);
+            _filter->compute_filtered_values(nonzero_val, *vec, false);
+
+            dphi_vecs[i] = vec;
+        }
+
+        for ( unsigned int i=0; i<_n_vars; i++)
+            dphi_vecs[i]->close();
+
+        // we will use this serialized vector to initialize the mesh function,
+        // which is setup to reuse this vector, so we have to store it
+        for ( unsigned int i=0; i<_n_vars; i++)
+            _density_function->init_sens(*_dv_params[i].second, *dphi_vecs[i], true);
+    }
+
+    
+    void _clear_sensitivity_data(std::vector<libMesh::NumericVector<Real>*>& dphi_vecs) {
+
+        // delete the vectors that we do not need any more
+        for (unsigned int i=0; i<dphi_vecs.size(); i++)
+            delete dphi_vecs[i];
+        dphi_vecs.clear();
+
+        _density_function->clear();
+    }
+    
 
     //
     //  \subsection  ex_6_volume_sensitivity Sensitivity of Material Volume
     //
-    void _evaluate_volume(Real               *volume,
+    void _evaluate_volume(const libMesh::NumericVector<Real>& sol,
+                          const std::vector<libMesh::NumericVector<Real>*>& dsol_vecs,
+                          Real               *volume,
                           std::vector<Real>  *grad) {
-
-        libMesh::DofMap
-        &dof_map  =  _density_sys->get_dof_map();
         
-        const std::vector<libMesh::dof_id_type>
-        &send_list = dof_map.get_send_list();
-        
-        std::unique_ptr<libMesh::NumericVector<Real>>
-        local_sol(libMesh::NumericVector<Real>::build(_density_sys->comm()).release()),
-        local_dsol(libMesh::NumericVector<Real>::build(_density_sys->comm()).release());
-        
-        local_sol->init(_density_sys->n_dofs(),
-                        _density_sys->n_local_dofs(),
-                        send_list,
-                        false,
-                        libMesh::GHOSTED);
-
-        local_dsol->init(_density_sys->n_dofs(),
-                         _density_sys->n_local_dofs(),
-                         send_list,
-                         false,
-                         libMesh::GHOSTED);
-
+        unsigned int
+        sys_num = _density_sys->number();
         
         if (volume) {
 
             *volume = 0.;
-            
-            unsigned int
-            sys_num = _density_sys->number();
-            
-            _density_sys->solution->localize(*local_sol, send_list);
             
             libMesh::MeshBase::element_iterator
             it    =  _mesh->active_local_elements_begin(),
@@ -676,7 +722,7 @@ public:
                 rho = 0.;
                 for (unsigned int i=0; i<e.n_nodes(); i++) {
                     const libMesh::Node& n = *e.node_ptr(i);
-                    rho += local_sol->el(n.dof_number(sys_num, 0, 0));
+                    rho += sol.el(n.dof_number(sys_num, 0, 0));
                 }
                 rho /= (1. * e.n_nodes());
 
@@ -691,35 +737,9 @@ public:
         if (grad) {
             
             std::fill(grad->begin(), grad->end(), 0.);
-            
-            //
-            // iterate over each DV, create a sensitivity vector and calculate the
-            // volume sensitivity explicitly
-            //
-            std::unique_ptr<libMesh::NumericVector<Real>>
-            dphi_base(_density_sys->solution->zero_clone().release()),
-            dphi_filtered(_density_sys->solution->zero_clone().release());
-            
             ElementParameterDependence dep(*_filter);
             
             for (unsigned int i=0; i<_n_vars; i++) {
-                
-                dphi_base->zero();
-                dphi_filtered->zero();
-                local_dsol->zero();
-                //
-                // set the value only if the dof corresponds to a local node
-                //
-                if (_dv_params[i].first >=  dphi_base->first_local_index() &&
-                    _dv_params[i].first <   dphi_base->last_local_index())
-                    dphi_base->set(_dv_params[i].first, 1.);
-                dphi_base->close();
-                _filter->compute_filtered_values(*dphi_base, *dphi_filtered);
-                
-                dphi_filtered->localize(*local_dsol, send_list);
-                
-                unsigned int
-                sys_num = _density_sys->number();
                 
                 libMesh::MeshBase::element_iterator
                 it    =  _mesh->active_local_elements_begin(),
@@ -739,18 +759,18 @@ public:
                     
                     // compute the average element density value
                     drho = 0.;
-                    for (unsigned int i=0; i<e.n_nodes(); i++) {
-                        const libMesh::Node& n = *e.node_ptr(i);
-                        drho += local_dsol->el(n.dof_number(sys_num, 0, 0));
+                    for (unsigned int j=0; j<e.n_nodes(); j++) {
+                        const libMesh::Node& n = *e.node_ptr(j);
+                        drho += dsol_vecs[i]->el(n.dof_number(sys_num, 0, 0));
                     }
                     drho /= (1. * e.n_nodes());
                     
                     // use this density value to compute the volume
                     (*grad)[i]  +=  e.volume() * drho;
                 }
-                
-                this->comm().sum((*grad)[i]);
             }
+
+            this->comm().sum(*grad);
         }
     }
     
@@ -768,11 +788,12 @@ public:
      MAST::NonlinearImplicitAssembly& nonlinear_assembly,
      std::vector<Real>& grads) {
         
-        _sys->adjoint_solve(*_sys->solution, true, nonlinear_elem_ops, stress, nonlinear_assembly, false);
-        
-        std::unique_ptr<libMesh::NumericVector<Real>>
-        dphi_base(_density_sys->solution->zero_clone().release()),
-        dphi_filtered(_density_sys->solution->zero_clone().release());
+        _sys->adjoint_solve(*_sys->current_local_solution,
+                            false,
+                            nonlinear_elem_ops,
+                            stress,
+                            nonlinear_assembly,
+                            false);
         
         ElementParameterDependence dep(*_filter);
         nonlinear_assembly.attach_elem_parameter_dependence_object(dep);
@@ -781,50 +802,58 @@ public:
         // indices used by GCMMA follow this rule:
         // grad_k = dfi/dxj  ,  where k = j*NFunc + i
         //////////////////////////////////////////////////////////////////
+        // first compute the sensitivity contribution from dot product of adjoint vector
+        // and residual sensitivity
+        std::vector<Real>
+        g1(_n_vars, 0.),
+        g2(_n_vars, 0.);
+        std::vector<const MAST::FunctionBase*>
+        p_vec(_n_vars, nullptr);
+        for (unsigned int i=0; i<_n_vars; i++)
+            p_vec[i] = _dv_params[i].second;
+
+        //////////////////////////////////////////////////////////////////////
+        // stress sensitivity
+        //////////////////////////////////////////////////////////////////////
+        _Ef->set_penalty_val(penalty);
+        nonlinear_assembly.calculate_output_adjoint_sensitivity_multiple_parameters_no_direct
+        (*_sys->current_local_solution,
+         false,
+         _sys->get_adjoint_solution(),
+         p_vec,
+         nonlinear_elem_ops,
+         stress,
+         g1);
+
+
+        // we will skip the summation of sensitivity inside the stress object to minimize
+        // communication cost. Instead, we will do it at the end for the constraint vector
+        stress.set_skip_comm_sum(true);
+        _Ef->set_penalty_val(stress_penalty);
         for (unsigned int i=0; i<_n_vars; i++) {
             
-            dphi_base->zero();
-            dphi_filtered->zero();
-            //
-            // set the value only if the dof corresponds to a local node
-            //
-            if (_dv_params[i].first >=  dphi_base->first_local_index() &&
-                _dv_params[i].first <   dphi_base->last_local_index())
-                dphi_base->set(_dv_params[i].first, 1.);
-            dphi_base->close();
-            _filter->compute_filtered_values(*dphi_base, *dphi_filtered);
-            
-            _density_sens_function->init(*dphi_filtered);
-            
-            //////////////////////////////////////////////////////////////////////
-            // stress sensitivity
-            //////////////////////////////////////////////////////////////////////
             // set the elasticity penalty for solution, which is needed for
             // computation of the residual sensitivity
-            _Ef->set_penalty_val(penalty);
-
-            grads[1*i+0] = 1./_stress_lim*
-            nonlinear_assembly.calculate_output_adjoint_sensitivity(*_sys->solution,
-                                                                    true,
-                                                                    _sys->get_adjoint_solution(),
-                                                                    *_dv_params[i].second,
-                                                                    nonlinear_elem_ops,
-                                                                    stress,
-                                                                    false);
-            
-            _Ef->set_penalty_val(stress_penalty);
-            nonlinear_assembly.calculate_output_direct_sensitivity(*_sys->solution,
-                                                                   true,
+            nonlinear_assembly.calculate_output_direct_sensitivity(*_sys->current_local_solution,
+                                                                   false,
                                                                    nullptr,
                                                                    false,
                                                                    *_dv_params[i].second,
                                                                    stress);
-            grads[1*i+0] += 1./_stress_lim* stress.output_sensitivity_total(*_dv_params[i].second);
-            
+            g2[i] = stress.output_sensitivity_total(*_dv_params[i].second);
+
             stress.clear_sensitivity_data();
-            _density_sens_function->clear();
         }
+        stress.set_skip_comm_sum(false);
+
+        // now sum the values across processors to sum the partial derivatives for
+        // each parameter
+        _sys->comm().sum(g2);
         
+        // now compute contribution to the stress constraint
+        for (unsigned int i=0; i<_n_vars; i++)
+            grads[1*i+0] = 1./_stress_lim * (g1[i] + g2[i]);
+
         nonlinear_assembly.clear_elem_parameter_dependence_object();
     }
 
@@ -838,10 +867,6 @@ public:
         
         // Adjoint solution for compliance = - X
         
-        std::unique_ptr<libMesh::NumericVector<Real>>
-        dphi_base(_density_sys->solution->zero_clone().release()),
-        dphi_filtered(_density_sys->solution->zero_clone().release());
-        
         ElementParameterDependence dep(*_filter);
         nonlinear_assembly.attach_elem_parameter_dependence_object(dep);
 
@@ -849,34 +874,51 @@ public:
         // indices used by GCMMA follow this rule:
         // grad_k = dfi/dxj  ,  where k = j*NFunc + i
         //////////////////////////////////////////////////////////////////
+        // first compute the sensitivity contribution from dot product of adjoint vector
+        // and residual sensitivity
+        std::vector<Real>
+        g1(_n_vars, 0.),
+        g2(_n_vars, 0.);
+        std::vector<const MAST::FunctionBase*>
+        p_vec(_n_vars, nullptr);
+        for (unsigned int i=0; i<_n_vars; i++)
+            p_vec[i] = _dv_params[i].second;
+        
+        //////////////////////////////////////////////////////////////////////
+        // compliance sensitivity
+        //////////////////////////////////////////////////////////////////////
+        // set the elasticity penalty for solution, which is needed for
+        // computation of the residual sensitivity
+        nonlinear_assembly.calculate_output_adjoint_sensitivity_multiple_parameters_no_direct
+        (*_sys->current_local_solution,
+         false,
+         *_sys->current_local_solution,
+         p_vec,
+         nonlinear_elem_ops,
+         compliance,
+         g1);
+
+        compliance.set_skip_comm_sum(true);
         for (unsigned int i=0; i<_n_vars; i++) {
             
-            dphi_base->zero();
-            dphi_filtered->zero();
-            //
-            // set the value only if the dof corresponds to a local node
-            //
-            if (_dv_params[i].first >=  dphi_base->first_local_index() &&
-                _dv_params[i].first <   dphi_base->last_local_index())
-                dphi_base->set(_dv_params[i].first, 1.);
-            dphi_base->close();
-            _filter->compute_filtered_values(*dphi_base, *dphi_filtered);
-            
-            _density_sens_function->init(*dphi_filtered);
-            
-            //////////////////////////////////////////////////////////////////////
-            // compliance sensitivity
-            //////////////////////////////////////////////////////////////////////
-            grads[i] = -1. *
-            nonlinear_assembly.calculate_output_adjoint_sensitivity(*_sys->solution,
-                                                                    true,
-                                                                    *_sys->solution,
-                                                                    *_dv_params[i].second,
-                                                                    nonlinear_elem_ops,
-                                                                    compliance);
-            _density_sens_function->clear();
+            nonlinear_assembly.calculate_output_direct_sensitivity(*_sys->current_local_solution,
+                                                                   false,
+                                                                   nullptr,
+                                                                   false,
+                                                                   *_dv_params[i].second,
+                                                                   compliance);
+            g2[i] = compliance.output_sensitivity_total(*_dv_params[i].second);
         }
         
+        compliance.set_skip_comm_sum(false);
+        
+        // now sum the values across processors to sum the partial derivatives for
+        // each parameter
+        _sys->comm().sum(g2);
+
+        for (unsigned int i=0; i<_n_vars; i++)
+            grads[i] = -(g1[i] + g2[i]);
+
         nonlinear_assembly.clear_elem_parameter_dependence_object();
     }
 
@@ -915,7 +957,13 @@ public:
                 base_phi.set(_dv_params[i].first, x[i]);
         base_phi.close();
         _filter->compute_filtered_values(base_phi, *_density_sys->solution);
-        _density_function->init(*_density_sys->solution);
+        // create a serialized vector for use in interpolation
+        std::unique_ptr<libMesh::NumericVector<Real>>
+        serial_density_sol(libMesh::NumericVector<Real>::build(_sys->comm()).release());
+        serial_density_sol->init(_density_sys->solution->size(), false, libMesh::SERIAL);
+        _density_sys->solution->localize(*serial_density_sol);
+
+        _density_function->init(*serial_density_sol, true);
         
         std::vector<bool> eval_grads(this->n_ineq(), false);
         std::vector<Real> f(this->n_ineq(), 0.), grads;
@@ -1031,8 +1079,7 @@ public:
 
         // density function is used by elasticity modulus function. So, we
         // initialize this here
-        _density_function        = new MAST::MeshFieldFunction(*_density_sys, "rho");
-        _density_sens_function   = new MAST::MeshFieldFunction(*_density_sys, "rho");
+        _density_function        = new MAST::MeshFieldFunction(*_density_sys, "rho", libMesh::SERIAL);
 
         _init_material();
         T::init_structural_loads(*this);
@@ -1140,7 +1187,6 @@ public:
         delete _filter;
         delete _output;
         delete _density_function;
-        delete _density_sens_function;
 
         for (unsigned int i=0; i<_dv_params.size(); i++)
             delete _dv_params[i].second;

--- a/examples/structural/example_8/example_8.cpp
+++ b/examples/structural/example_8/example_8.cpp
@@ -1164,6 +1164,8 @@ public:
 
         for (unsigned int i=0; i<_n_vars; i++)
             grads[i] = (g1[i] + g2[i]);
+
+        nonlinear_assembly.clear_elem_parameter_dependence_object();
     }
     
     

--- a/examples/structural/example_8/example_8.cpp
+++ b/examples/structural/example_8/example_8.cpp
@@ -1107,7 +1107,12 @@ public:
         // Adjoint solution for compliance = - X
         // if the shifted boundary is implementing a traction-free condition
         // compliance does not need contribution from shifted boundary load
-        _sys->adjoint_solve(*_sys->solution, true, nonlinear_elem_ops, compliance, nonlinear_assembly, false);
+        _sys->adjoint_solve(*_sys->current_local_solution,
+                            false,
+                            nonlinear_elem_ops,
+                            compliance,
+                            nonlinear_assembly,
+                            false);
 
         ElementParameterDependence dep(*_filter);
         nonlinear_assembly.attach_elem_parameter_dependence_object(dep);
@@ -1116,21 +1121,49 @@ public:
         // indices used by GCMMA follow this rule:
         // grad_k = dfi/dxj  ,  where k = j*NFunc + i
         //////////////////////////////////////////////////////////////////
+        // first compute the sensitivity contribution from dot product of adjoint vector
+        // and residual sensitivity
+        std::vector<Real>
+        g1(_n_vars, 0.),
+        g2(_n_vars, 0.);
+        std::vector<const MAST::FunctionBase*>
+        p_vec(_n_vars, nullptr);
+        for (unsigned int i=0; i<_n_vars; i++)
+            p_vec[i] = _dv_params[i].second;
+        
+        //////////////////////////////////////////////////////////////////////
+        // compliance sensitivity
+        //////////////////////////////////////////////////////////////////////
+        // set the elasticity penalty for solution, which is needed for
+        // computation of the residual sensitivity
+        nonlinear_assembly.calculate_output_adjoint_sensitivity_multiple_parameters_no_direct
+        (*_sys->current_local_solution,
+         false,
+         _sys->get_adjoint_solution(),
+         p_vec,
+         nonlinear_elem_ops,
+         compliance,
+         g1);
+
+        compliance.set_skip_comm_sum(true);
         for (unsigned int i=0; i<_n_vars; i++) {
             
-            //////////////////////////////////////////////////////////////////////
-            // compliance sensitivity
-            //////////////////////////////////////////////////////////////////////
-            grads[i] = 1. *
-            nonlinear_assembly.calculate_output_adjoint_sensitivity(*_sys->current_local_solution,
-                                                                    false,
-                                                                    _sys->get_adjoint_solution(),
-                                                                    *_dv_params[i].second,
-                                                                    nonlinear_elem_ops,
-                                                                    compliance);
+            nonlinear_assembly.calculate_output_direct_sensitivity(*_sys->current_local_solution,
+                                                                   false,
+                                                                   nullptr,
+                                                                   false,
+                                                                   *_dv_params[i].second,
+                                                                   compliance);
+            g2[i] = compliance.output_sensitivity_total(*_dv_params[i].second);
         }
+        compliance.set_skip_comm_sum(false);
         
-        nonlinear_assembly.clear_elem_parameter_dependence_object();
+        // now sum the values across processors to sum the partial derivatives for
+        // each parameter
+        _sys->comm().sum(g2);
+
+        for (unsigned int i=0; i<_n_vars; i++)
+            grads[i] = (g1[i] + g2[i]);
     }
     
     

--- a/src/base/assembly_base.cpp
+++ b/src/base/assembly_base.cpp
@@ -284,7 +284,7 @@ MAST::AssemblyBase::calculate_output(const libMesh::NumericVector<Real>& X,
     
     // if a solution function is attached, initialize it
     //if (_sol_function)
-    //    _sol_function->init( X);
+    //    _sol_function->init( X, false);
     
     libMesh::MeshBase::const_element_iterator       el     =
     nonlin_sys.get_mesh().active_local_elements_begin();
@@ -373,7 +373,7 @@ calculate_output_derivative(const libMesh::NumericVector<Real>& X,
     
     // if a solution function is attached, initialize it
     if (_sol_function)
-        _sol_function->init( X);
+        _sol_function->init( X, false);
     
     
     libMesh::MeshBase::const_element_iterator       el     =
@@ -484,7 +484,7 @@ calculate_output_direct_sensitivity(const libMesh::NumericVector<Real>& X,
     
     // if a solution function is attached, initialize it
     if (_sol_function)
-        _sol_function->init( X);
+        _sol_function->init( X, false);
     
     
     libMesh::MeshBase::const_element_iterator       el     =

--- a/src/base/assembly_base.cpp
+++ b/src/base/assembly_base.cpp
@@ -589,3 +589,49 @@ calculate_output_adjoint_sensitivity(const libMesh::NumericVector<Real>& X,
     return dq_dp;
 }
 
+
+
+void
+MAST::AssemblyBase::calculate_output_adjoint_sensitivity_multiple_parameters_no_direct
+ (const libMesh::NumericVector<Real>&           X,
+  bool                                          if_localize_sol,
+  const libMesh::NumericVector<Real>&           dq_dX,
+  const std::vector<const MAST::FunctionBase*>& p_vec,
+  MAST::AssemblyElemOperations&                 elem_ops,
+  MAST::OutputAssemblyElemOperations&           output,
+  std::vector<Real>&                            sens) {
+
+    libmesh_assert(_discipline);
+    libmesh_assert(_system);
+    libmesh_assert_equal_to(sens.size(), p_vec.size());
+    
+    MAST::NonlinearSystem& nonlin_sys = _system->system();
+
+    // zero the sensitivity data first
+    std::fill(sens.begin(), sens.end(), 0.);
+    
+    // first compute all the residual vectors without closing them. later we will close them
+    // and then compute the sensitivity
+    for (unsigned int i=0; i<p_vec.size(); i++) {
+        
+        const MAST::FunctionBase& p = *p_vec[i];
+        
+        libMesh::NumericVector<Real>
+        &dres_dp = nonlin_sys.add_sensitivity_rhs(i);
+        
+        this->set_elem_operation_object(elem_ops);
+        this->sensitivity_assemble(X, if_localize_sol, p, dres_dp, false);
+        this->clear_elem_operation_object();
+    }
+    
+    for (unsigned int i=0; i<p_vec.size(); i++) {
+        
+        const MAST::FunctionBase& p = *p_vec[i];
+        
+        libMesh::NumericVector<Real>
+        &dres_dp = nonlin_sys.add_sensitivity_rhs(i);
+        dres_dp.close();
+        sens[i] = dq_dX.dot(dres_dp);
+    }
+}
+

--- a/src/base/assembly_base.h
+++ b/src/base/assembly_base.h
@@ -246,7 +246,8 @@ namespace MAST {
         sensitivity_assemble (const libMesh::NumericVector<Real>& X,
                               bool if_localize_sol,
                               const MAST::FunctionBase& f,
-                              libMesh::NumericVector<Real>& sensitivity_rhs) {
+                              libMesh::NumericVector<Real>& sensitivity_rhs,
+                              bool close_vector = true) {
             libmesh_assert(false); // implemented in the derived class
         }
 
@@ -300,6 +301,24 @@ namespace MAST {
                                              MAST::AssemblyElemOperations&       elem_ops,
                                              MAST::OutputAssemblyElemOperations& output,
                                              const bool include_partial_sens = true);
+
+        
+        /*!
+         *   Evaluates the dot product between  \p dq_dX and sensitivity of residual about \p X for multiple
+         *   parameter_vectors \p p_vec and returns the results in \p sens. Note that partial derivative of output
+         *   with respect to design variables will not be included.
+         *   The size of \p p_vec and \p sens should be the same and the results
+         *   of \p sens will be overwritten.
+         */
+        virtual void
+        calculate_output_adjoint_sensitivity_multiple_parameters_no_direct
+        (const libMesh::NumericVector<Real>&           X,
+         bool                                          if_localize_sol,
+         const libMesh::NumericVector<Real>&           dq_dX,
+         const std::vector<const MAST::FunctionBase*>& p_vec,
+         MAST::AssemblyElemOperations&                 elem_ops,
+         MAST::OutputAssemblyElemOperations&           output,
+         std::vector<Real>&                            sens);
 
         
         /*!

--- a/src/base/complex_assembly_base.cpp
+++ b/src/base/complex_assembly_base.cpp
@@ -147,7 +147,7 @@ MAST::ComplexAssemblyBase::residual_l2_norm(const libMesh::NumericVector<Real>& 
     
     // if a solution function is attached, initialize it
     //if (_sol_function)
-    //    _sol_function->init( X);
+    //    _sol_function->init( X, false);
     
     
     libMesh::MeshBase::const_element_iterator       el     =
@@ -294,7 +294,7 @@ residual_and_jacobian_field_split (const libMesh::NumericVector<Real>& X_R,
     
     // if a solution function is attached, initialize it
     //if (_sol_function)
-    //    _sol_function->init( X);
+    //    _sol_function->init( X, false);
     
     
     libMesh::MeshBase::const_element_iterator       el     =
@@ -477,7 +477,7 @@ residual_and_jacobian_blocked (const libMesh::NumericVector<Real>& X,
 
     // if a solution function is attached, initialize it
     //if (_sol_function)
-    //    _sol_function->init( X);
+    //    _sol_function->init( X, false);
     
     
     libMesh::MeshBase::const_element_iterator       el     =

--- a/src/base/mesh_field_function.cpp
+++ b/src/base/mesh_field_function.cpp
@@ -28,30 +28,30 @@
 
 MAST::MeshFieldFunction::
 MeshFieldFunction(MAST::SystemInitialization& sys,
-                  const std::string& nm):
+                  const std::string& nm,
+                  libMesh::ParallelType p_type):
 MAST::FieldFunction<RealVectorX>(nm),
-_use_qp_sol(false),
-_qp_sol(),
-_sys(&sys.system()),
-_sol(nullptr),
-_dsol(nullptr),
-_function(nullptr),
-_perturbed_function(nullptr)
+_use_qp_sol            (false),
+_p_type                (p_type),
+_qp_sol                (),
+_sys                   (&sys.system()),
+_function              (nullptr),
+_perturbed_function    (nullptr)
 { }
 
 
 
 MAST::MeshFieldFunction::
 MeshFieldFunction(libMesh::System& sys,
-                  const std::string& nm):
+                  const std::string& nm,
+                  libMesh::ParallelType p_type):
 MAST::FieldFunction<RealVectorX>(nm),
-_use_qp_sol(false),
-_qp_sol(),
-_sys(&sys),
-_sol(nullptr),
-_dsol(nullptr),
-_function(nullptr),
-_perturbed_function(nullptr)
+_use_qp_sol            (false),
+_p_type                (p_type),
+_qp_sol                (),
+_sys                   (&sys),
+_function              (nullptr),
+_perturbed_function    (nullptr)
 { }
 
 
@@ -87,7 +87,7 @@ MAST::MeshFieldFunction::operator() (const libMesh::Point& p,
     n_vars = _sys->n_vars();
 
     DenseRealVector v1;
-    (*_function)(p, t, v1);
+    (*_function->_func)(p, t, v1);
     
     // make sure that the mesh function was able to find the element
     // and a solution
@@ -120,7 +120,7 @@ MAST::MeshFieldFunction::gradient (const libMesh::Point& p,
     n_vars = _sys->n_vars();
     
     std::vector<libMesh::Gradient> v1;
-    _function->gradient(p, t, v1);
+    _function->_func->gradient(p, t, v1);
     
     // make sure that the mesh function was able to find the element
     // and a solution
@@ -154,7 +154,7 @@ MAST::MeshFieldFunction::perturbation(const libMesh::Point& p,
     n_vars = _sys->n_vars();
 
     DenseRealVector v1;
-    (*_perturbed_function)(p, t, v1);
+    (*_perturbed_function->_func)(p, t, v1);
     
     // make sure that the mesh function was able to find the element
     // and a solution
@@ -186,7 +186,7 @@ MAST::MeshFieldFunction::perturbation_gradient (const libMesh::Point& p,
     n_vars = _sys->n_vars();
     
     std::vector<libMesh::Gradient> v1;
-    _perturbed_function->gradient(p, t, v1);
+    _perturbed_function->_func->gradient(p, t, v1);
     
     // make sure that the mesh function was able to find the element
     // and a solution
@@ -207,69 +207,105 @@ MAST::MeshFieldFunction::derivative (const MAST::FunctionBase& f,
                                      const Real t,
                                      RealVectorX& v) const {
     
+    // if the element has provided a quadrature point solution,
+    // then use it
+    if (_use_qp_sol) {
+        v = _qp_sol;
+        return;
+    }
     
-    libmesh_error_msg("To be implemented.");
+    // make sure that the data for this function has been initialized
+    std::map<const MAST::FunctionBase*, MAST::MeshFieldFunction::SolFunc*>::const_iterator
+    it  = _function_sens.find(&f);
+    
+    // make sure that the object was initialized
+    libmesh_assert(it != _function_sens.end());
+    
+    unsigned int
+    n_vars = _sys->n_vars();
+
+    DenseRealVector v1;
+    (*it->second->_func)(p, t, v1);
+    
+    // make sure that the mesh function was able to find the element
+    // and a solution
+    libmesh_assert_equal_to(v1.size(), n_vars);
+
+    // now copy this to the output vector
+    v = RealVectorX::Zero(n_vars);
+    for (unsigned int i=0; i<n_vars; i++)
+        v(i) = v1(i);
+}
+
+
+void
+MAST::MeshFieldFunction::derivative_gradient (const MAST::FunctionBase& f,
+                                              const libMesh::Point& p,
+                                              const Real t,
+                                              RealMatrixX& v) const {
+    
+    // if the element has provided a quadrature point solution,
+    // then use it
+    if (_use_qp_sol) {
+        v = _qp_sol;
+        return;
+    }
+    
+    // make sure that the data for this function has been initialized
+    std::map<const MAST::FunctionBase*, MAST::MeshFieldFunction::SolFunc*>::const_iterator
+    it  = _function_sens.find(&f);
+
+    // make sure that the object was initialized
+    libmesh_assert(it != _function_sens.end());
+
+    unsigned int
+    n_vars = _sys->n_vars();
+    
+    std::vector<libMesh::Gradient> v1;
+    it->second->_func->gradient(p, t, v1);
+    
+    // make sure that the mesh function was able to find the element
+    // and a solution
+    libmesh_assert_equal_to(v1.size(), n_vars);
+    
+    // now copy this to the output vector
+    v = RealMatrixX::Zero(n_vars, 3); // assume 3-dimensional by default
+    for (unsigned int i=0; i<n_vars; i++)
+        for (unsigned int j=0; j<3; j++)
+            v(i, j) = v1[i](j);
 }
 
 
 
-
-
 void
-MAST::MeshFieldFunction::
-init(const libMesh::NumericVector<Real>& sol,
-     const libMesh::NumericVector<Real>* dsol) {
-    
+MAST::MeshFieldFunction::init(const libMesh::NumericVector<Real>& sol,
+                              bool reuse_vector) {
     
     // first make sure that the object is not already initialized
     libmesh_assert(!_function);
     
-    // next, clone this solution and localize to the sendlist
-    _sol = libMesh::NumericVector<Real>::build(_sys->comm()).release();
+    _function = new MAST::MeshFieldFunction::SolFunc;
+    _init_sol_func(reuse_vector, sol, *_function);
+}
 
-    // initialize and then localize the vector with the provided solution
-    /*_sol->init(system.n_dofs(),
-                       system.n_local_dofs(),
-                       send_list,
-                       false,
-                       libMesh::GHOSTED);
-    sol.localize(*_sol, send_list);*/
-    _sol->init(sol.size(), true, libMesh::SERIAL);
-    sol.localize(*_sol);
 
-    // finally, create the mesh interpolation function
-    std::vector<unsigned int> vars;
-    _sys->get_all_variable_numbers(vars);
+
+void
+MAST::MeshFieldFunction::init_sens(const MAST::FunctionBase& f,
+                                   const libMesh::NumericVector<Real>& sol,
+                                   bool reuse_vector) {
     
-    _function = new libMesh::MeshFunction(_sys->get_equation_systems(),
-                                          *_sol,
-                                          _sys->get_dof_map(),
-                                          vars);
-    _function->init();
+    // make sure the function has not already been initialized
+    std::map<const MAST::FunctionBase*, MAST::MeshFieldFunction::SolFunc*>::const_iterator
+    it  = _function_sens.find(&f);
+
+    // make sure that the object was initialized
+    libmesh_assert(it == _function_sens.end());
     
-    if (dsol) {
-
-        _dsol = libMesh::NumericVector<Real>::build(_sys->comm()).release();
-
-        /*_dsol->init(system.n_dofs(),
-                            system.n_local_dofs(),
-                            send_list,
-                            false,
-                            libMesh::GHOSTED);
-         dsol->localize(*_dsol, send_list);*/
-        _dsol->init(dsol->size(), true, libMesh::SERIAL);
-        dsol->localize(*_dsol);
-        
-        
-        // finally, create the mesh interpolation function
-        _perturbed_function =
-        new libMesh::MeshFunction(_sys->get_equation_systems(),
-                                  *_dsol,
-                                  _sys->get_dof_map(),
-                                  vars);
-        _perturbed_function->init();
-
-    }
+    MAST::MeshFieldFunction::SolFunc* func = new MAST::MeshFieldFunction::SolFunc;
+    _init_sol_func(reuse_vector, sol, *func);
+    
+    _function_sens[&f] = func;
 }
 
 
@@ -283,20 +319,23 @@ MAST::MeshFieldFunction::clear() {
     if (_function) {
         delete _function;
         _function = nullptr;
-        
-        delete _sol;
-        _sol = nullptr;
     }
-
+    
     if (_perturbed_function) {
         delete _perturbed_function;
         _perturbed_function = nullptr;
-        
-        delete _dsol;
-        _dsol = nullptr;
     }
 
+    // now clear all the sensitivity data
+    std::map<const MAST::FunctionBase*, MAST::MeshFieldFunction::SolFunc*>::const_iterator
+    it  = _function_sens.begin(),
+    end = _function_sens.end();
     
+    for ( ; it != end; it++)
+        delete it->second;
+    
+    _function_sens.clear();
+
     // clear flags for quadrature point solution
     _use_qp_sol = false;
 }
@@ -322,3 +361,59 @@ clear_element_quadrature_point_solution() {
     _qp_sol.setZero();
 }
 
+
+void
+MAST::MeshFieldFunction::_init_sol_func(bool reuse_sol,
+                                        const libMesh::NumericVector<Real> &sol,
+                                        MAST::MeshFieldFunction::SolFunc& sol_func) {
+    
+    // make sure it has not already been initialized
+    libmesh_assert(!sol_func._func);
+        
+    if (reuse_sol) {
+        
+        // make sure the given vector is of the same type as that specified for this object
+        libmesh_assert_equal_to(sol.type(), _p_type);
+        sol_func._sol       = &sol;
+    }
+    else  {
+        
+        sol_func._cloned_sol = libMesh::NumericVector<Real>::build(_sys->comm()).release();
+        sol_func._sol        = sol_func._cloned_sol;
+        
+        switch (_p_type) {
+                
+            case libMesh::SERIAL: {
+                sol_func._cloned_sol->init(sol.size(), true, libMesh::SERIAL);
+                sol.localize(*sol_func._cloned_sol);
+            }
+                break;
+                
+            case libMesh::GHOSTED: {
+                
+                sol_func._cloned_sol->init(_sys->n_dofs(),
+                                           _sys->n_local_dofs(),
+                                           _sys->get_dof_map().get_send_list(),
+                                           true,
+                                           libMesh::GHOSTED);
+                sol.localize(*sol_func._cloned_sol, _sys->get_dof_map().get_send_list());
+            }
+                break;
+                
+            default:
+                // not implemented for other types.
+                libmesh_error();
+                break;
+        }
+    }
+
+    // finally, create the mesh interpolation function
+    std::vector<unsigned int> vars;
+    _sys->get_all_variable_numbers(vars);
+    
+    sol_func._func = new libMesh::MeshFunction(_sys->get_equation_systems(),
+                                                   *sol_func._sol,
+                                                   _sys->get_dof_map(),
+                                                   vars);
+    sol_func._func->init();
+}

--- a/src/base/nonlinear_implicit_assembly.cpp
+++ b/src/base/nonlinear_implicit_assembly.cpp
@@ -97,7 +97,7 @@ residual_and_jacobian (const libMesh::NumericVector<Real>& X,
     
     // if a solution function is attached, initialize it
     if (_sol_function)
-        _sol_function->init( X);
+        _sol_function->init( X, false);
     
     
     libMesh::MeshBase::const_element_iterator       el     =
@@ -309,7 +309,7 @@ linearized_jacobian_solution_product (const libMesh::NumericVector<Real>& X,
     
     // if a solution function is attached, initialize it
     if (_sol_function)
-        _sol_function->init( X);
+        _sol_function->init( X, false);
     
     
     libMesh::MeshBase::const_element_iterator       el     =
@@ -439,7 +439,7 @@ second_derivative_dot_solution_assembly (const libMesh::NumericVector<Real>& X,
     
     // if a solution function is attached, initialize it
     if (_sol_function)
-        _sol_function->init( X);
+        _sol_function->init( X, false);
     
     
     libMesh::MeshBase::const_element_iterator       el     =
@@ -548,7 +548,7 @@ sensitivity_assemble (const libMesh::NumericVector<Real>& X,
     
     // if a solution function is attached, initialize it
     if (_sol_function)
-        _sol_function->init( *nonlin_sys.solution);
+        _sol_function->init( *nonlin_sys.solution, false);
     
     libMesh::MeshBase::const_element_iterator       el     =
     nonlin_sys.get_mesh().active_local_elements_begin();

--- a/src/base/nonlinear_implicit_assembly.cpp
+++ b/src/base/nonlinear_implicit_assembly.cpp
@@ -517,7 +517,8 @@ MAST::NonlinearImplicitAssembly::
 sensitivity_assemble (const libMesh::NumericVector<Real>& X,
                       bool if_localize_sol,
                       const MAST::FunctionBase& f,
-                      libMesh::NumericVector<Real>& sensitivity_rhs) {
+                      libMesh::NumericVector<Real>& sensitivity_rhs,
+                      bool close_vector) {
     
     libmesh_assert(_system);
     libmesh_assert(_discipline);
@@ -678,7 +679,8 @@ sensitivity_assemble (const libMesh::NumericVector<Real>& X,
     if (_sol_function)
         _sol_function->clear();
     
-    sensitivity_rhs.close();
+    if (close_vector)
+        sensitivity_rhs.close();
     
     return true;
 }

--- a/src/base/nonlinear_implicit_assembly.h
+++ b/src/base/nonlinear_implicit_assembly.h
@@ -145,7 +145,8 @@ namespace MAST {
         sensitivity_assemble (const libMesh::NumericVector<Real>& X,
                               bool if_localize_sol,
                               const MAST::FunctionBase& f,
-                              libMesh::NumericVector<Real>& sensitivity_rhs);
+                              libMesh::NumericVector<Real>& sensitivity_rhs,
+                              bool close_vector = true);
         
     protected:
         

--- a/src/base/transient_assembly.cpp
+++ b/src/base/transient_assembly.cpp
@@ -100,7 +100,7 @@ residual_and_jacobian (const libMesh::NumericVector<Real>& X,
     
     // if a solution function is attached, initialize it
     if (_sol_function)
-        _sol_function->init( X);
+        _sol_function->init( X, false);
     
     // ask the solver to localize the relevant solutions
     solver.build_local_quantities(X, local_qtys);
@@ -216,7 +216,7 @@ linearized_jacobian_solution_product (const libMesh::NumericVector<Real>& X,
     
     // if a solution function is attached, initialize it
     if (_sol_function)
-        _sol_function->init( X);
+        _sol_function->init( X, false);
 
     // ask the solver to localize the relevant solutions
     solver.build_local_quantities(X, local_qtys);
@@ -317,7 +317,7 @@ sensitivity_assemble (const MAST::FunctionBase& f,
 
     // if a solution function is attached, initialize it
     if (_sol_function)
-        _sol_function->init( *nonlin_sys.solution);
+        _sol_function->init( *nonlin_sys.solution, false);
     
     libMesh::MeshBase::const_element_iterator       el     =
     nonlin_sys.get_mesh().active_local_elements_begin();

--- a/src/elasticity/fsi_generalized_aero_force_assembly.cpp
+++ b/src/elasticity/fsi_generalized_aero_force_assembly.cpp
@@ -161,7 +161,7 @@ assemble_generalized_aerodynamic_force_matrix
     
     // if a solution function is attached, initialize it
     if (_sol_function && _base_sol)
-        _sol_function->init( *_base_sol);
+        _sol_function->init( *_base_sol, false);
     
     MAST::FluidStructureAssemblyElemOperations&
     ops = dynamic_cast<MAST::FluidStructureAssemblyElemOperations&>(*_elem_ops);

--- a/src/elasticity/mindlin_bending_operator.cpp
+++ b/src/elasticity/mindlin_bending_operator.cpp
@@ -277,7 +277,7 @@ calculate_transverse_shear_residual_boundary_velocity
     // modify the JxW_Vn by multiplying the normal velocity to it
     for (unsigned int qp=0; qp<JxW_Vn.size(); qp++) {
         
-        vel_f(xyz[qp], _structural_elem.system().time, vel);
+        vel_f.derivative(p, xyz[qp], _structural_elem.system().time, vel);
         vn = 0.;
         for (unsigned int i=0; i<dim; i++)
             vn += vel(i)*face_normals[qp](i);

--- a/src/elasticity/structural_assembly.cpp
+++ b/src/elasticity/structural_assembly.cpp
@@ -203,7 +203,7 @@ MAST::StructuralAssembly::update_incompatible_solution(libMesh::NumericVector<Re
     
     // if a solution function is attached, initialize it
     //if (_sol_function)
-    //    _sol_function->init( X);
+    //    _sol_function->init( X, false);
     
     
     libMesh::MeshBase::const_element_iterator       el     =

--- a/src/elasticity/structural_element_2d.cpp
+++ b/src/elasticity/structural_element_2d.cpp
@@ -787,7 +787,7 @@ calculate_stress_boundary_velocity(const MAST::FunctionBase& p,
     // modify the JxW_Vn by multiplying the normal velocity to it
     for (unsigned int qp=0; qp<JxW_Vn.size(); qp++) {
         
-        vel_f(xyz[qp], _time, vel);
+        vel_f.derivative(p, xyz[qp], _time, vel);
         vn = 0.;
         for (unsigned int i=0; i<dim; i++)
             vn += vel(i)*face_normals[qp](i);
@@ -1489,7 +1489,7 @@ internal_residual_boundary_velocity(const MAST::FunctionBase& p,
     // modify the JxW_Vn by multiplying the normal velocity to it
     for (unsigned int qp=0; qp<JxW_Vn.size(); qp++) {
         
-        vel_f(xyz[qp], _time, vel);
+        vel_f.derivative(p, xyz[qp], _time, vel);
         vn = 0.;
         for (unsigned int i=0; i<dim; i++)
             vn += vel(i)*face_normals[qp](i);
@@ -3510,7 +3510,7 @@ thermal_residual_boundary_velocity(const MAST::FunctionBase& p,
     // modify the JxW_Vn by multiplying the normal velocity to it
     for (unsigned int qp=0; qp<JxW_Vn.size(); qp++) {
         
-        vel_f(xyz[qp], _time, vel);
+        vel_f.derivative(p, xyz[qp], _time, vel);
         vn = 0.;
         for (unsigned int i=0; i<dim; i++)
             vn += vel(i)*face_normals[qp](i);

--- a/src/elasticity/structural_element_base.cpp
+++ b/src/elasticity/structural_element_base.cpp
@@ -547,7 +547,7 @@ inertial_residual_boundary_velocity (const MAST::FunctionBase& p,
     // modify the JxW_Vn by multiplying the normal velocity to it
     for (unsigned int qp=0; qp<JxW_Vn.size(); qp++) {
         
-        vel_f(xyz[qp], _time, vel);
+        vel_f.derivative(p, xyz[qp], _time, vel);
         vn = 0.;
         for (unsigned int i=0; i<dim; i++)
             vn += vel(i)*face_normals[qp](i);
@@ -1369,7 +1369,7 @@ surface_pressure_boundary_velocity(const MAST::FunctionBase& p,
     // modify the JxW_Vn by multiplying the normal velocity to it
     for (unsigned int qp=0; qp<JxW_Vn.size(); qp++) {
         
-        vel_f(xyz[qp], _time, vel);
+        vel_f.derivative(p, xyz[qp], _time, vel);
         vn = 0.;
         for (unsigned int i=0; i<dim; i++)
             vn += vel(i)*face_normals[qp](i);

--- a/src/elasticity/structural_fluid_interaction_assembly.cpp
+++ b/src/elasticity/structural_fluid_interaction_assembly.cpp
@@ -145,7 +145,7 @@ assemble_reduced_order_quantity
     
     // if a solution function is attached, initialize it
     if (_sol_function && _base_sol)
-        _sol_function->init( *_base_sol);
+        _sol_function->init( *_base_sol, false);
     
     
     libMesh::MeshBase::const_element_iterator       el     =
@@ -293,7 +293,7 @@ assemble_reduced_order_quantity_sensitivity
     
     // if a solution function is attached, initialize it
     if (_sol_function && _base_sol)
-        _sol_function->init( *_base_sol);
+        _sol_function->init( *_base_sol, false);
     
     
     libMesh::MeshBase::const_element_iterator       el     =

--- a/src/heat_conduction/heat_conduction_elem_base.cpp
+++ b/src/heat_conduction/heat_conduction_elem_base.cpp
@@ -657,7 +657,7 @@ internal_residual_boundary_velocity (const MAST::FunctionBase& p,
     // modify the JxW_Vn by multiplying the normal velocity to it
     for (unsigned int qp=0; qp<JxW_Vn.size(); qp++) {
         
-        vel_f(xyz[qp], _time, vel);
+        vel_f.derivative(p, xyz[qp], _time, vel);
         vn = 0.;
         for (unsigned int i=0; i<dim; i++)
             vn += vel(i)*face_normals[qp](i);
@@ -817,7 +817,7 @@ velocity_residual_boundary_velocity (const MAST::FunctionBase& p,
     // modify the JxW_Vn by multiplying the normal velocity to it
     for (unsigned int qp=0; qp<JxW_Vn.size(); qp++) {
         
-        vel_f(xyz[qp], _time, vel);
+        vel_f.derivative(p, xyz[qp], _time, vel);
         vn = 0.;
         for (unsigned int i=0; i<dim; i++)
             vn += vel(i)*face_normals[qp](i);
@@ -1070,7 +1070,7 @@ surface_flux_boundary_velocity(const MAST::FunctionBase& p,
     // modify the JxW_Vn by multiplying the normal velocity to it
     for (unsigned int qp=0; qp<JxW_Vn.size(); qp++) {
         
-        vel_f(xyz[qp], _time, vel);
+        vel_f.derivative(p, xyz[qp], _time, vel);
         vn = 0.;
         for (unsigned int i=0; i<dim; i++)
             vn += vel(i)*face_normals[qp](i);
@@ -1370,7 +1370,7 @@ surface_convection_boundary_velocity(const MAST::FunctionBase& p,
     // modify the JxW_Vn by multiplying the normal velocity to it
     for (unsigned int qp=0; qp<JxW_Vn.size(); qp++) {
         
-        vel_f(xyz[qp], _time, vel);
+        vel_f.derivative(p, xyz[qp], _time, vel);
         vn = 0.;
         for (unsigned int i=0; i<dim; i++)
             vn += vel(i)*face_normals[qp](i);
@@ -1682,7 +1682,7 @@ surface_radiation_boundary_velocity(const MAST::FunctionBase& p,
     // modify the JxW_Vn by multiplying the normal velocity to it
     for (unsigned int qp=0; qp<JxW_Vn.size(); qp++) {
         
-        vel_f(xyz[qp], _time, vel);
+        vel_f.derivative(p, xyz[qp], _time, vel);
         vn = 0.;
         for (unsigned int i=0; i<dim; i++)
             vn += vel(i)*face_normals[qp](i);
@@ -1827,7 +1827,7 @@ volume_heat_source_boundary_velocity(const MAST::FunctionBase& p,
     // modify the JxW_Vn by multiplying the normal velocity to it
     for (unsigned int qp=0; qp<JxW_Vn.size(); qp++) {
         
-        vel_f(xyz[qp], _time, vel);
+        vel_f.derivative(p, xyz[qp], _time, vel);
         vn = 0.;
         for (unsigned int i=0; i<dim; i++)
             vn += vel(i)*face_normals[qp](i);

--- a/src/level_set/filter_base.cpp
+++ b/src/level_set/filter_base.cpp
@@ -57,7 +57,8 @@ MAST::FilterBase::~FilterBase() {
 
 void
 MAST::FilterBase::compute_filtered_values(const libMesh::NumericVector<Real>& input,
-                                          libMesh::NumericVector<Real>& output) const {
+                                          libMesh::NumericVector<Real>& output,
+                                          bool close_vector) const {
     
     libmesh_assert_equal_to(input.size(), _filter_map.size());
     libmesh_assert_equal_to(output.size(), _filter_map.size());
@@ -89,7 +90,45 @@ MAST::FilterBase::compute_filtered_values(const libMesh::NumericVector<Real>& in
         }
     }
     
-    output.close();
+    if (close_vector)
+        output.close();
+}
+
+
+
+void
+MAST::FilterBase::compute_filtered_values(std::map<unsigned int, Real>& nonzero_input,
+                                          libMesh::NumericVector<Real>& output,
+                                          bool close_vector) const {
+    
+    libmesh_assert_equal_to(output.size(), _filter_map.size());
+    libmesh_assert_equal_to(output.type(), libMesh::SERIAL);
+    
+    output.zero();
+    
+    std::map<unsigned int, std::vector<std::pair<unsigned int, Real>>>::const_iterator
+    map_it   = _filter_map.begin(),
+    map_end  = _filter_map.end();
+    
+    for ( ; map_it != map_end; map_it++) {
+        
+        std::vector<std::pair<unsigned int, Real>>::const_iterator
+        vec_it  = map_it->second.begin(),
+        vec_end = map_it->second.end();
+        
+        for ( ; vec_it != vec_end; vec_it++) {
+            if (nonzero_input.count(vec_it->first)) {
+                
+                if (_dv_dof_ids.count(map_it->first))
+                    output.add(map_it->first, nonzero_input[vec_it->first] * vec_it->second);
+                else
+                    output.set(map_it->first, nonzero_input[map_it->first]);
+            }
+        }
+    }
+    
+    if (close_vector)
+        output.close();
 }
 
 

--- a/src/level_set/filter_base.h
+++ b/src/level_set/filter_base.h
@@ -51,8 +51,19 @@ namespace MAST {
          *   computes the filtered output from the provided input.
          */
         void compute_filtered_values(const libMesh::NumericVector<Real>& input,
-                                     libMesh::NumericVector<Real>& output) const;
+                                     libMesh::NumericVector<Real>& output,
+                                     bool close_vector = true) const;
 
+        /*!
+         *  for large problems it is more efficient to specify only the non-zero entries in the input vector in
+         *  \p nonzero_vals. Here, \p output is expected to be of type SERIAL vector. All ranks in the
+         *  communicator will perform the same operaitons and provide an identical \p output vector.
+         *  If \p close_vector is \p true then \p output.close() will be called in this
+         *  routines, otherwise not.
+         */
+        void compute_filtered_values(std::map<unsigned int, Real>& nonzero_vals,
+                                     libMesh::NumericVector<Real>& output,
+                                     bool close_vector) const;
         
         void compute_filtered_values(const std::vector<Real>& input,
                                      std::vector<Real>& output) const;

--- a/src/level_set/heaviside_elem_homogenization_function.cpp
+++ b/src/level_set/heaviside_elem_homogenization_function.cpp
@@ -107,7 +107,7 @@ MAST::HeavisideElemHomogenizedDensityFunction::
 initialize_element_volume_fraction_sensitivity(const MAST::FunctionBase& f) {
     
     libmesh_assert(_analysis_mesh);
-    libmesh_assert(_elem_volume_fraction_sensitivity.empty());
+    libmesh_assert(_elem_volume_fraction_sensitivity[&f].empty());
     libmesh_assert(f.is_topology_parameter());
     
     // make sure that the system uses Lagrange shape functions for
@@ -165,10 +165,10 @@ initialize_element_volume_fraction_sensitivity(const MAST::FunctionBase& f) {
             v = level_set_elem.homogenized_volume_fraction_sensitivity(_width);
             
             // store the value for this elmeent
-            _elem_volume_fraction_sensitivity[e] = v;
+            _elem_volume_fraction_sensitivity[&f][e] = v;
         }
         else
-            _elem_volume_fraction_sensitivity[e] = 0.;
+            _elem_volume_fraction_sensitivity[&f][e] = 0.;
     }
 }
 

--- a/src/level_set/homogenized_density_function_base.cpp
+++ b/src/level_set/homogenized_density_function_base.cpp
@@ -93,12 +93,7 @@ derivative(const MAST::FunctionBase& f,
     
     libmesh_assert(e);
     
-    std::map<const libMesh::Elem*, Real>::const_iterator
-    it = _elem_volume_fraction_sensitivity.find(e);
-    
-    libmesh_assert(it != _elem_volume_fraction.end());
-    
-    v = it->second;
+    v = this->get_elem_volume_fraction_sensitivity(f, *e);
 }
 
 
@@ -121,11 +116,29 @@ MAST::HomogenizedDensityFunctionBase::
 get_elem_volume_fraction_sensitivity(const MAST::FunctionBase& f,
                                      const libMesh::Elem& e) const {
     
+    std::map<const MAST::FunctionBase*, std::map<const libMesh::Elem*, Real>>::const_iterator
+    it_f   = _elem_volume_fraction_sensitivity.find(&f);
+
+    libmesh_assert (it_f != _elem_volume_fraction_sensitivity.end());
+
     std::map<const libMesh::Elem*, Real>::const_iterator
-    it = _elem_volume_fraction_sensitivity.find(&e);
+    it_e = it_f->second.find(&e);
     
-    libmesh_assert (it != _elem_volume_fraction_sensitivity.end());
+    libmesh_assert (it_e != it_f->second.end());
     
-    return it->second;
+    return it_e->second;
 }
 
+
+const std::map<const libMesh::Elem*, Real>*
+MAST::HomogenizedDensityFunctionBase::
+get_elem_volume_fraction_sensitivity_map(const MAST::FunctionBase& f) const
+{
+    std::map<const MAST::FunctionBase*, std::map<const libMesh::Elem*, Real>>::const_iterator
+    it   = _elem_volume_fraction_sensitivity.find(&f);
+    
+    if (it != _elem_volume_fraction_sensitivity.end())
+        return &(it->second);
+    else
+        return nullptr;
+}

--- a/src/level_set/homogenized_density_function_base.h
+++ b/src/level_set/homogenized_density_function_base.h
@@ -58,9 +58,8 @@ namespace MAST {
         const std::map<const libMesh::Elem*, Real>&
         get_elem_volume_fraction_map() const { return _elem_volume_fraction;}
         
-        const std::map<const libMesh::Elem*, Real>&
-        get_elem_volume_fraction_sensitivity_map() const
-        { return _elem_volume_fraction_sensitivity;}
+        const std::map<const libMesh::Elem*, Real>*
+        get_elem_volume_fraction_sensitivity_map(const MAST::FunctionBase& f) const;
 
         Real
         get_elem_volume_fraction(const libMesh::Elem& e) const;
@@ -92,7 +91,8 @@ namespace MAST {
         
         std::map<const libMesh::Elem*, Real> _elem_volume_fraction;
         
-        std::map<const libMesh::Elem*, Real> _elem_volume_fraction_sensitivity;
+        std::map<const MAST::FunctionBase*, std::map<const libMesh::Elem*, Real>>
+        _elem_volume_fraction_sensitivity;
 
         std::unique_ptr<libMesh::PointLocatorBase> _sub_point_locator;
     };

--- a/src/level_set/intersected_elem_homogenization_function.cpp
+++ b/src/level_set/intersected_elem_homogenization_function.cpp
@@ -109,7 +109,7 @@ initialize_element_volume_fraction_sensitivity(const MAST::FunctionBase& f) {
 //            ops.clear_elem();
 //        }
 
-        _elem_volume_fraction_sensitivity[elem] =
+        _elem_volume_fraction_sensitivity[&f][elem] =
         _intersection->get_positive_phi_volume_fraction();
         
         _intersection->clear();

--- a/src/level_set/level_set_boundary_velocity.h
+++ b/src/level_set/level_set_boundary_velocity.h
@@ -35,16 +35,11 @@ namespace MAST {
         virtual ~LevelSetBoundaryVelocity();
         
         void init(MAST::SystemInitialization& sys,
-                  const MAST::FieldFunction<Real>& phi,
-                  const libMesh::NumericVector<Real>& sol,
-                  libMesh::ParallelType p_type,
-                  bool reuse_vector);
+                  const MAST::MeshFieldFunction& phi);
 
-        void init_sens(const MAST::FunctionBase& f,
-                       const libMesh::NumericVector<Real>& dsol,
-                       bool reuse_vector);
+        void clear();
 
-        virtual void operator() (const MAST::FunctionBase& f,
+        virtual void derivative (const MAST::FunctionBase& f,
                                  const libMesh::Point& p,
                                  const Real t,
                                  RealVectorX& v) const;
@@ -54,6 +49,17 @@ namespace MAST {
                       const Real t,
                       RealVectorX& v) const;
 
+        /*!
+         * attaches the level set function \p phi with this object. This is necessary only when the
+         * interface point functions are used.
+         */
+        void attach_level_set_function(const MAST::FieldFunction<Real>& phi);
+
+        /*!
+         * clears the attached level set function
+         */
+        void clear_level_set_function();
+        
         void search_nearest_interface_point(const libMesh::Elem& e,
                                             const unsigned int side,
                                             const libMesh::Point& p,
@@ -110,7 +116,7 @@ namespace MAST {
                                         const RealVectorX& dv) const;
 
         unsigned int                     _dim;
-        MAST::MeshFieldFunction*         _phi;
+        const MAST::MeshFieldFunction*   _phi;
         libMesh::MeshBase*               _mesh;
         const MAST::FieldFunction<Real>* _level_set_func;
     };

--- a/src/level_set/level_set_boundary_velocity.h
+++ b/src/level_set/level_set_boundary_velocity.h
@@ -37,13 +37,20 @@ namespace MAST {
         void init(MAST::SystemInitialization& sys,
                   const MAST::FieldFunction<Real>& phi,
                   const libMesh::NumericVector<Real>& sol,
-                  const libMesh::NumericVector<Real>* dsol);
-        
-        virtual void operator() (const libMesh::Point& p,
+                  libMesh::ParallelType p_type,
+                  bool reuse_vector);
+
+        void init_sens(const MAST::FunctionBase& f,
+                       const libMesh::NumericVector<Real>& dsol,
+                       bool reuse_vector);
+
+        virtual void operator() (const MAST::FunctionBase& f,
+                                 const libMesh::Point& p,
                                  const Real t,
                                  RealVectorX& v) const;
 
-        void velocity(const libMesh::Point& p,
+        void velocity(const MAST::FunctionBase& f,
+                      const libMesh::Point& p,
                       const Real t,
                       RealVectorX& v) const;
 

--- a/src/level_set/level_set_nonlinear_implicit_assembly.cpp
+++ b/src/level_set/level_set_nonlinear_implicit_assembly.cpp
@@ -553,7 +553,8 @@ MAST::LevelSetNonlinearImplicitAssembly::
 sensitivity_assemble (const libMesh::NumericVector<Real>& X,
                       bool if_localize_sol,
                       const MAST::FunctionBase& f,
-                      libMesh::NumericVector<Real>& sensitivity_rhs) {
+                      libMesh::NumericVector<Real>& sensitivity_rhs,
+                      bool close_vector) {
     
     libmesh_assert(_system);
     libmesh_assert(_discipline);
@@ -757,7 +758,8 @@ sensitivity_assemble (const libMesh::NumericVector<Real>& X,
     if (_sol_function)
         _sol_function->clear();
     
-    sensitivity_rhs.close();
+    if (close_vector)
+        sensitivity_rhs.close();
     
     return true;
 }

--- a/src/level_set/level_set_nonlinear_implicit_assembly.cpp
+++ b/src/level_set/level_set_nonlinear_implicit_assembly.cpp
@@ -368,7 +368,7 @@ residual_and_jacobian (const libMesh::NumericVector<Real>& X,
     
     // if a solution function is attached, initialize it
     if (_sol_function)
-        _sol_function->init( X);
+        _sol_function->init( X, false);
     
     
     libMesh::MeshBase::const_element_iterator       el     =
@@ -609,7 +609,7 @@ sensitivity_assemble (const libMesh::NumericVector<Real>& X,
     
     // if a solution function is attached, initialize it
     if (_sol_function)
-        _sol_function->init( *nonlin_sys.solution);
+        _sol_function->init( *nonlin_sys.solution, false);
     
     libMesh::MeshBase::const_element_iterator       el     =
     nonlin_sys.get_mesh().active_local_elements_begin();
@@ -806,7 +806,7 @@ calculate_output(const libMesh::NumericVector<Real>& X,
     
     // if a solution function is attached, initialize it
     //if (_sol_function)
-    //    _sol_function->init( X);
+    //    _sol_function->init( X, false);
     
     
     libMesh::MeshBase::const_element_iterator       el     =
@@ -985,7 +985,7 @@ calculate_output_derivative(const libMesh::NumericVector<Real>& X,
     
     // if a solution function is attached, initialize it
     if (_sol_function)
-        _sol_function->init( X);
+        _sol_function->init( X, false);
     
     
     libMesh::MeshBase::const_element_iterator       el     =
@@ -1226,7 +1226,7 @@ calculate_output_direct_sensitivity(const libMesh::NumericVector<Real>& X,
     
     // if a solution function is attached, initialize it
     //if (_sol_function)
-    //    _sol_function->init( X);
+    //    _sol_function->init( X, false);
     
     
     libMesh::MeshBase::const_element_iterator       el     =

--- a/src/level_set/level_set_nonlinear_implicit_assembly.h
+++ b/src/level_set/level_set_nonlinear_implicit_assembly.h
@@ -125,7 +125,8 @@ namespace MAST {
         sensitivity_assemble (const libMesh::NumericVector<Real>& X,
                               bool if_localize_sol,
                               const MAST::FunctionBase& f,
-                              libMesh::NumericVector<Real>& sensitivity_rhs);
+                              libMesh::NumericVector<Real>& sensitivity_rhs,
+                              bool close_vector = true);
         
         
         virtual void

--- a/src/level_set/level_set_reinitialization_transient_assembly.cpp
+++ b/src/level_set/level_set_reinitialization_transient_assembly.cpp
@@ -111,7 +111,7 @@ residual_and_jacobian (const libMesh::NumericVector<Real>& X,
 
     // if a solution function is attached, initialize it
     if (_sol_function)
-        _sol_function->init( X);
+        _sol_function->init( X, false);
     
     // ask the solver to localize the relevant solutions
     solver.build_local_quantities(X, local_qtys);


### PR DESCRIPTION
Topology optimization implementation has had considerable bottlenecks, with became more critical with increasing problem size, particularly when moving to 3D shapes. This PR implements a number of optimizations in the code and example 8 (homogenized level set topology optimization). I am currently able to get 75% reduction of computational cost on this example with reference to the implementation from a couple of months ago. 

* modifications to homogenized level set, mesh field function and derived classes to allow for storing of sensitivity data for multiple variables at a time. This is to help with efficiency enhancements in large-scale topology optimization solves by minimizing interprocess communication.
* added a method in assembly_base to compute a portion of adjoint sensitivity with significantly reduced communication cost and higher efficiency.
* modifications in example 8 (homogenized level-set topology optimization) to take advantage of these enhancements .
* Added new method in filter_base to use only nonzero values in the input vector and to provide output in a serialized vector. This helps in significantly reducing the bottleneck to compute the filtered values of level-set function.
* Modified topology optimization examples 5, 6, 8 to use this modification.

