### PR TITLE
Thermoelastic topology optimization

### DIFF
--- a/examples/structural/base/bracket_2d_model.h
+++ b/examples/structural/base/bracket_2d_model.h
@@ -75,6 +75,10 @@ struct Bracket2DModel {
     static void init_structural_loads(Opt& opt);
 
     template <typename Opt>
+    static void
+    init_thermoelastic_loads(Opt& opt);
+
+    template <typename Opt>
     static MAST::BoundaryConditionBase&
     init_structural_shifted_boudnary_load(Opt& opt, unsigned int bid);
     
@@ -260,6 +264,39 @@ MAST::Examples::Bracket2DModel::init_structural_loads(Opt& opt) {
     opt._boundary_conditions.insert(p_load);
 
     opt._field_functions.insert(press_f);
+}
+
+
+template <typename Opt>
+void
+MAST::Examples::Bracket2DModel::init_thermoelastic_loads(Opt& opt) {
+    
+    Real
+    T_val      = opt._input(    "temperature",           "temperature for thermoelastic load",   0.),
+    T_ref_val  = opt._input("ref_temperature", "reference temperature for thermoelastic load",   0.);
+
+    MAST::Parameter
+    *temperature = new MAST::Parameter("T",     T_val),
+    *ref_temp    = new MAST::Parameter("T_ref", T_ref_val);
+
+    MAST::ConstantFieldFunction
+    *temperature_f = new MAST::ConstantFieldFunction(    "temperature", *temperature),
+    *ref_temp_f    = new MAST::ConstantFieldFunction("ref_temperature",    *ref_temp);
+    
+    // initialize the load
+    MAST::BoundaryConditionBase
+    *t_load          = new MAST::BoundaryConditionBase(MAST::TEMPERATURE);
+
+    t_load->add(*temperature_f);
+    t_load->add(*ref_temp_f);
+    opt._discipline->add_volume_load(0, *t_load);
+
+    opt._boundary_conditions.insert(t_load);
+
+    opt._parameters[temperature->name()] = temperature;
+    opt._parameters[ref_temp->name()]    = ref_temp;
+    opt._field_functions.insert(temperature_f);
+    opt._field_functions.insert(ref_temp_f);
 }
 
 

--- a/examples/structural/base/bracket_3d_model.h
+++ b/examples/structural/base/bracket_3d_model.h
@@ -74,6 +74,10 @@ struct Bracket3DModel {
     static void init_structural_loads(Opt& opt);
 
     template <typename Opt>
+    static void
+    init_thermoelastic_loads(Opt& opt);
+
+    template <typename Opt>
     static MAST::BoundaryConditionBase&
     init_structural_shifted_boudnary_load(Opt& opt, unsigned int bid);
     
@@ -267,6 +271,40 @@ MAST::Examples::Bracket3DModel::init_structural_loads(Opt& opt) {
 
     opt._field_functions.insert(press_f);
 }
+
+
+template <typename Opt>
+void
+MAST::Examples::Bracket3DModel::init_thermoelastic_loads(Opt& opt) {
+    
+    Real
+    T_val      = opt._input(    "temperature",           "temperature for thermoelastic load",   0.),
+    T_ref_val  = opt._input("ref_temperature", "reference temperature for thermoelastic load",   0.);
+
+    MAST::Parameter
+    *temperature = new MAST::Parameter("T",     T_val),
+    *ref_temp    = new MAST::Parameter("T_ref", T_ref_val);
+
+    MAST::ConstantFieldFunction
+    *temperature_f = new MAST::ConstantFieldFunction(    "temperature", *temperature),
+    *ref_temp_f    = new MAST::ConstantFieldFunction("ref_temperature",    *ref_temp);
+    
+    // initialize the load
+    MAST::BoundaryConditionBase
+    *t_load          = new MAST::BoundaryConditionBase(MAST::TEMPERATURE);
+
+    t_load->add(*temperature_f);
+    t_load->add(*ref_temp_f);
+    opt._discipline->add_volume_load(0, *t_load);
+
+    opt._boundary_conditions.insert(t_load);
+
+    opt._parameters[temperature->name()] = temperature;
+    opt._parameters[ref_temp->name()]    = ref_temp;
+    opt._field_functions.insert(temperature_f);
+    opt._field_functions.insert(ref_temp_f);
+}
+
 
 
 template <typename Opt>

--- a/examples/structural/base/eyebar_2d_model.h
+++ b/examples/structural/base/eyebar_2d_model.h
@@ -87,6 +87,10 @@ struct Eyebar2DModel {
     
     template <typename Opt>
     static void
+    init_thermoelastic_loads(Opt& opt);
+
+    template <typename Opt>
+    static void
     init_indicator_loads(Opt& opt);
     
     template <typename Opt>
@@ -317,6 +321,41 @@ MAST::Examples::Eyebar2DModel::init_structural_loads(Opt& opt) {
 
     opt._field_functions.insert(press_f);
 }
+
+
+template <typename Opt>
+void
+MAST::Examples::Eyebar2DModel::init_thermoelastic_loads(Opt& opt) {
+    
+    Real
+    T_val      = opt._input(    "temperature",           "temperature for thermoelastic load",   0.),
+    T_ref_val  = opt._input("ref_temperature", "reference temperature for thermoelastic load",   0.);
+
+    MAST::Parameter
+    *temperature = new MAST::Parameter("T",     T_val),
+    *ref_temp    = new MAST::Parameter("T_ref", T_ref_val);
+
+    MAST::ConstantFieldFunction
+    *temperature_f = new MAST::ConstantFieldFunction(    "temperature", *temperature),
+    *ref_temp_f    = new MAST::ConstantFieldFunction("ref_temperature",    *ref_temp);
+    
+    // initialize the load
+    MAST::BoundaryConditionBase
+    *t_load          = new MAST::BoundaryConditionBase(MAST::TEMPERATURE);
+
+    t_load->add(*temperature_f);
+    t_load->add(*ref_temp_f);
+    opt._discipline->add_volume_load(0, *t_load);
+
+    opt._boundary_conditions.insert(t_load);
+
+    opt._parameters[temperature->name()] = temperature;
+    opt._parameters[ref_temp->name()]    = ref_temp;
+    opt._field_functions.insert(temperature_f);
+    opt._field_functions.insert(ref_temp_f);
+}
+
+
 
 
 template <typename Opt>

--- a/examples/structural/base/inplane_2d_model.h
+++ b/examples/structural/base/inplane_2d_model.h
@@ -85,6 +85,10 @@ struct Inplane2DModel {
     
     template <typename Opt>
     static void
+    init_thermoelastic_loads(Opt& opt);
+
+    template <typename Opt>
+    static void
     init_indicator_loads(Opt& opt);
     
     template <typename Opt>
@@ -297,6 +301,41 @@ MAST::Examples::Inplane2DModel::init_structural_loads(Opt& opt) {
 
     opt._field_functions.insert(press_f);
 }
+
+
+template <typename Opt>
+void
+MAST::Examples::Inplane2DModel::init_thermoelastic_loads(Opt& opt) {
+    
+    Real
+    T_val      = opt._input(    "temperature",           "temperature for thermoelastic load",   0.),
+    T_ref_val  = opt._input("ref_temperature", "reference temperature for thermoelastic load",   0.);
+
+    MAST::Parameter
+    *temperature = new MAST::Parameter("T",     T_val),
+    *ref_temp    = new MAST::Parameter("T_ref", T_ref_val);
+
+    MAST::ConstantFieldFunction
+    *temperature_f = new MAST::ConstantFieldFunction(    "temperature", *temperature),
+    *ref_temp_f    = new MAST::ConstantFieldFunction("ref_temperature",    *ref_temp);
+    
+    // initialize the load
+    MAST::BoundaryConditionBase
+    *t_load          = new MAST::BoundaryConditionBase(MAST::TEMPERATURE);
+
+    t_load->add(*temperature_f);
+    t_load->add(*ref_temp_f);
+    opt._discipline->add_volume_load(0, *t_load);
+
+    opt._boundary_conditions.insert(t_load);
+
+    opt._parameters[temperature->name()] = temperature;
+    opt._parameters[ref_temp->name()]    = ref_temp;
+    opt._field_functions.insert(temperature_f);
+    opt._field_functions.insert(ref_temp_f);
+}
+
+
 
 
 template <typename Opt>

--- a/examples/structural/base/truss_2d_model.h
+++ b/examples/structural/base/truss_2d_model.h
@@ -85,6 +85,10 @@ struct Truss2DModel {
     
     template <typename Opt>
     static void
+    init_thermoelastic_loads(Opt& opt);
+
+    template <typename Opt>
+    static void
     init_indicator_loads(Opt& opt);
     
     template <typename Opt>
@@ -338,6 +342,41 @@ MAST::Examples::Truss2DModel::init_structural_loads(Opt& opt) {
 
     opt._field_functions.insert(press_f);
 }
+
+
+template <typename Opt>
+void
+MAST::Examples::Truss2DModel::init_thermoelastic_loads(Opt& opt) {
+    
+    Real
+    T_val      = opt._input(    "temperature",           "temperature for thermoelastic load",   0.),
+    T_ref_val  = opt._input("ref_temperature", "reference temperature for thermoelastic load",   0.);
+
+    MAST::Parameter
+    *temperature = new MAST::Parameter("T",     T_val),
+    *ref_temp    = new MAST::Parameter("T_ref", T_ref_val);
+
+    MAST::ConstantFieldFunction
+    *temperature_f = new MAST::ConstantFieldFunction(    "temperature", *temperature),
+    *ref_temp_f    = new MAST::ConstantFieldFunction("ref_temperature",    *ref_temp);
+    
+    // initialize the load
+    MAST::BoundaryConditionBase
+    *t_load          = new MAST::BoundaryConditionBase(MAST::TEMPERATURE);
+
+    t_load->add(*temperature_f);
+    t_load->add(*ref_temp_f);
+    opt._discipline->add_volume_load(0, *t_load);
+
+    opt._boundary_conditions.insert(t_load);
+
+    opt._parameters[temperature->name()] = temperature;
+    opt._parameters[ref_temp->name()]    = ref_temp;
+    opt._field_functions.insert(temperature_f);
+    opt._field_functions.insert(ref_temp_f);
+}
+
+
 
 
 template <typename Opt>

--- a/src/base/assembly_base.cpp
+++ b/src/base/assembly_base.cpp
@@ -556,7 +556,7 @@ Real
 MAST::AssemblyBase::
 calculate_output_adjoint_sensitivity(const libMesh::NumericVector<Real>& X,
                                      bool if_localize_sol,
-                                     const libMesh::NumericVector<Real>& dq_dX,
+                                     const libMesh::NumericVector<Real>& adj_sol,
                                      const MAST::FunctionBase& p,
                                      MAST::AssemblyElemOperations&       elem_ops,
                                      MAST::OutputAssemblyElemOperations& output,
@@ -575,7 +575,7 @@ calculate_output_adjoint_sensitivity(const libMesh::NumericVector<Real>& X,
     this->clear_elem_operation_object();
 
     Real
-    dq_dp = dq_dX.dot(dres_dp);
+    dq_dp = adj_sol.dot(dres_dp);
 
     if (include_partial_sens) {
 
@@ -595,7 +595,7 @@ void
 MAST::AssemblyBase::calculate_output_adjoint_sensitivity_multiple_parameters_no_direct
 (const libMesh::NumericVector<Real>&           X,
  bool                                          if_localize_sol,
- const libMesh::NumericVector<Real>&           dq_dX,
+ const libMesh::NumericVector<Real>&           adj_sol,
  const std::vector<const MAST::FunctionBase*>& p_vec,
  MAST::AssemblyElemOperations&                 elem_ops,
  MAST::OutputAssemblyElemOperations&           output,
@@ -634,7 +634,7 @@ MAST::AssemblyBase::calculate_output_adjoint_sensitivity_multiple_parameters_no_
         libMesh::NumericVector<Real>
         &dres_dp = nonlin_sys.add_sensitivity_rhs(i);
         dres_dp.close();
-        sens[i] = dq_dX.dot(dres_dp);
+        sens[i] = adj_sol.dot(dres_dp);
     }
 }
 

--- a/src/base/assembly_base.h
+++ b/src/base/assembly_base.h
@@ -290,13 +290,13 @@ namespace MAST {
         
         /*!
          *   Evaluates the total sensitivity of \p output wrt \p p using
-         *   the adjoint solution provided in \p dq_dX for a linearization
+         *   the adjoint solution provided in \p adj_sol for a linearization
          *   about solution \p X.
          */
         virtual Real
         calculate_output_adjoint_sensitivity(const libMesh::NumericVector<Real>& X,
                                              bool if_localize_sol,
-                                             const libMesh::NumericVector<Real>& dq_dX,
+                                             const libMesh::NumericVector<Real>& adj_sol,
                                              const MAST::FunctionBase& p,
                                              MAST::AssemblyElemOperations&       elem_ops,
                                              MAST::OutputAssemblyElemOperations& output,
@@ -304,7 +304,7 @@ namespace MAST {
 
         
         /*!
-         *   Evaluates the dot product between  \p dq_dX and sensitivity of residual about \p X for multiple
+         *   Evaluates the dot product between  \p adj_sol and sensitivity of residual about \p X for multiple
          *   parameter_vectors \p p_vec and returns the results in \p sens. Note that partial derivative of output
          *   with respect to design variables will not be included.
          *   The size of \p p_vec and \p sens should be the same and the results
@@ -314,7 +314,7 @@ namespace MAST {
         calculate_output_adjoint_sensitivity_multiple_parameters_no_direct
         (const libMesh::NumericVector<Real>&           X,
          bool                                          if_localize_sol,
-         const libMesh::NumericVector<Real>&           dq_dX,
+         const libMesh::NumericVector<Real>&           adj_sol,
          const std::vector<const MAST::FunctionBase*>& p_vec,
          MAST::AssemblyElemOperations&                 elem_ops,
          MAST::OutputAssemblyElemOperations&           output,

--- a/src/level_set/level_set_elem_base.cpp
+++ b/src/level_set/level_set_elem_base.cpp
@@ -67,7 +67,8 @@ MAST::LevelSetElementBase::internal_residual (bool request_jacobian,
     
     libmesh_assert(_phi_vel);
     
-    std::unique_ptr<MAST::FEBase> fe(_elem.init_fe(true, false));
+    std::unique_ptr<MAST::FEBase> fe(_elem.init_fe(true, false,
+                                                   _system.system().extra_quadrature_order));
     
     const std::vector<Real>& JxW           = fe->get_JxW();
     const std::vector<libMesh::Point>& xyz = fe->get_xyz();
@@ -162,7 +163,8 @@ MAST::LevelSetElementBase::velocity_residual (bool request_jacobian,
 
     libmesh_assert(_phi_vel);
 
-    std::unique_ptr<MAST::FEBase> fe(_elem.init_fe(true, false));
+    std::unique_ptr<MAST::FEBase> fe(_elem.init_fe(true, false,
+                                                   _system.system().extra_quadrature_order));
 
     const std::vector<Real>& JxW           = fe->get_JxW();
     const std::vector<libMesh::Point>& xyz = fe->get_xyz();
@@ -312,7 +314,8 @@ velocity_residual_sensitivity (bool request_jacobian,
 Real
 MAST::LevelSetElementBase::volume() {
     
-    std::unique_ptr<MAST::FEBase> fe(_elem.init_fe(true, false));
+    std::unique_ptr<MAST::FEBase> fe(_elem.init_fe(true, false,
+                                                   _system.system().extra_quadrature_order));
 
     const std::vector<Real>& JxW           = fe->get_JxW();
     const unsigned int
@@ -343,7 +346,8 @@ MAST::LevelSetElementBase::volume() {
 Real
 MAST::LevelSetElementBase::homogenized_volume_fraction(Real delta) {
     
-    std::unique_ptr<MAST::FEBase> fe(_elem.init_fe(true, false));
+    std::unique_ptr<MAST::FEBase> fe(_elem.init_fe(true, false,
+                                                   _system.system().extra_quadrature_order));
     
     const std::vector<Real>& JxW           = fe->get_JxW();
     const unsigned int
@@ -378,7 +382,8 @@ MAST::LevelSetElementBase::homogenized_volume_fraction(Real delta) {
 Real
 MAST::LevelSetElementBase::homogenized_volume_fraction_sensitivity(Real delta) {
     
-    std::unique_ptr<MAST::FEBase> fe(_elem.init_fe(true, false));
+    std::unique_ptr<MAST::FEBase> fe(_elem.init_fe(true, false,
+                                                   _system.system().extra_quadrature_order));
     
     const std::vector<Real>& JxW           = fe->get_JxW();
     const unsigned int
@@ -415,7 +420,8 @@ MAST::LevelSetElementBase::homogenized_volume_fraction_sensitivity(Real delta) {
 Real
 MAST::LevelSetElementBase::perimeter(Real d) {
     
-    std::unique_ptr<MAST::FEBase> fe(_elem.init_fe(true, false));
+    std::unique_ptr<MAST::FEBase> fe(_elem.init_fe(true, false,
+                                                   _system.system().extra_quadrature_order));
     
     const std::vector<Real>& JxW           = fe->get_JxW();
     const unsigned int
@@ -447,7 +453,8 @@ MAST::LevelSetElementBase::perimeter(Real d) {
 Real
 MAST::LevelSetElementBase::perimeter_sensitivity(Real d) {
     
-    std::unique_ptr<MAST::FEBase> fe(_elem.init_fe(true, false));
+    std::unique_ptr<MAST::FEBase> fe(_elem.init_fe(true, false,
+                                                   _system.system().extra_quadrature_order));
     
     const std::vector<Real>& JxW           = fe->get_JxW();
     const unsigned int


### PR DESCRIPTION
This PR adds thermoelastic loads to the three topology optimization examples. Temperature load can be set from input parameters. Additional bug-fixes are included. 

-- Added thermoelastic load to topology optimization problems.
-- Bug-fix in SIMP based topology optimization example for compliance sensitivity with thermoelastic loads.