### PR TITLE
Added PointLoad class for simpler definition of point loads.

### DIFF
--- a/src/boundary_condition/point_load_condition.cpp
+++ b/src/boundary_condition/point_load_condition.cpp
@@ -58,4 +58,31 @@ MAST::PointLoadCondition::get_nodes() {
 }
 
 
+MAST::PointLoad::PointLoad(MAST::Parameter& magnitude, RealVectorX direction):
+MAST::FieldFunction<RealVectorX>("load"), _magnitude(magnitude),
+_direction(direction) {}
 
+
+MAST::PointLoad::~PointLoad() { }
+
+
+void MAST::PointLoad::operator()(const libMesh::Point& p, const Real t, 
+                                 RealVectorX& v) const
+{
+    v = _magnitude() * _direction;
+}
+
+
+void MAST::PointLoad::derivative(const MAST::FunctionBase& f, 
+                                 const libMesh::Point& p, const Real t, 
+                                 RealVectorX& v) const 
+{
+    v = RealVectorX::Zero(6);
+    if (&f == &_magnitude)
+    {
+        for (uint64_t i=0; i<_direction.size(); i++)
+        {
+            v(i) = _direction(i);
+        }
+    }
+}

--- a/src/boundary_condition/point_load_condition.h
+++ b/src/boundary_condition/point_load_condition.h
@@ -25,6 +25,8 @@
 
 // MAST includes
 #include "base/boundary_condition_base.h"
+#include "base/field_function_base.h"
+#include "base/parameter.h"
 
 // libMesh includes
 #include "libmesh/node.h"
@@ -72,6 +74,32 @@ namespace MAST {
          *   set of nodes on which load is specified
          */
         std::set<const libMesh::Node*> _nodes;
+        
+    };
+    
+    
+    /**
+     * This class is used in the conjuction with the class above. Added by DJN
+     * to enhance compatability with NASTRAN interface.
+     */
+    class PointLoad: public MAST::FieldFunction<RealVectorX>
+    {
+    public:
+        PointLoad(MAST::Parameter& magnitude, RealVectorX direction);
+        
+        virtual ~PointLoad();
+        
+        virtual void operator()(const libMesh::Point& p, const Real t, 
+                                RealVectorX& v) const;
+        
+        virtual void derivative(const MAST::FunctionBase& f, 
+                                const libMesh::Point& p, const Real t, 
+                                RealVectorX& v) const;
+        
+    protected:
+        
+        MAST::Parameter&    _magnitude;
+        RealVectorX        _direction;
         
     };
 }


### PR DESCRIPTION
This was implemented a long time ago but was never merged into master.

This moves the definition of the PointLoad class definition from the examples into the library itself.  This allows structural point loads to be defined in a Nastran-like way by defining its magnitude and its unit direction (or alternatively a unit magnitude and non-unit direction).