### PR TITLE
Added method to define zero and non-zero boundary conditons on indivi…

### DIFF
--- a/src/base/boundary_condition_base.h
+++ b/src/base/boundary_condition_base.h
@@ -47,7 +47,8 @@ namespace MAST {
         EXHAUST,
         ISOTHERMAL,
         ADIABATIC,
-        BOUNDARY_VELOCITY
+        BOUNDARY_VELOCITY,
+        DOF_DIRICHLET
     };
     
     

--- a/src/base/physics_discipline_base.cpp
+++ b/src/base/physics_discipline_base.cpp
@@ -23,6 +23,7 @@
 #include "base/parameter.h"
 #include "base/nonlinear_system.h"
 #include "boundary_condition/dirichlet_boundary_condition.h"
+#include "boundary_condition/dirichlet_dof_boundary_condition.h"
 #include "mesh/geom_elem.h"
 
 // libMesh includes
@@ -87,6 +88,13 @@ MAST::PhysicsDisciplineBase::add_dirichlet_bc(libMesh::boundary_id_type bid,
     libmesh_assert(insert_success);
 }
 
+
+void
+MAST::PhysicsDisciplineBase::add_dirichlet_dof_bc(MAST::DOFDirichletBoundaryCondition& load)
+{
+    libmesh_assert(!_dirichlet_dof_bcs.count(&load));
+    _dirichlet_dof_bcs.insert(&load);
+}
 
 
 void
@@ -229,6 +237,21 @@ init_system_dirichlet_bc(MAST::NonlinearSystem& sys) const {
 }
 
 
+void
+MAST::PhysicsDisciplineBase::
+init_system_dirichlet_dof_bc(MAST::NonlinearSystem& sys) {
+    
+    // give the set of all dirichlet dof BCs to the MAST::DOFConstraint object 
+    // (a child class of libMesh::System:Constraint) 
+    _dof_constraint.reset(new MAST::DOFConstraint(_dirichlet_dof_bcs));
+    
+    // tell the MAST::DOFConstraint which system it is acting on
+    _dof_constraint->setNonlinearSystem(sys);
+    
+    // attach the MAST::DOFConstraint object to the system
+    sys.attach_constraint_object(*_dof_constraint);
+    
+}
 
 
 void

--- a/src/base/physics_discipline_base.h
+++ b/src/base/physics_discipline_base.h
@@ -25,6 +25,7 @@
 
 // MAST includes
 #include "base/mast_data_types.h"
+#include "boundary_condition/dirichlet_dof_boundary_condition.h"
 
 // libMesh includes
 #include "libmesh/equation_systems.h"
@@ -35,6 +36,7 @@ namespace MAST {
     // Forward declerations
     class BoundaryConditionBase;
     class DirichletBoundaryCondition;
+    class DOFDirichletBoundaryCondition;
     class PropertyCardBase;
     class FunctionBase;
     class FunctionSetBase;
@@ -52,6 +54,7 @@ namespace MAST {
     typedef std::map<libMesh::subdomain_id_type, const MAST::ElementPropertyCardBase*>      PropertyCardMapType;
     typedef std::map<libMesh::boundary_id_type, MAST::DirichletBoundaryCondition*>  DirichletBCMapType;
     typedef std::set<MAST::PointLoadCondition*> PointLoadSetType;
+    typedef std::set<MAST::DOFDirichletBoundaryCondition*> DOFDirichletBCSetType;
     
     class PhysicsDisciplineBase {
     public:
@@ -106,6 +109,11 @@ namespace MAST {
          */
         void add_dirichlet_bc(libMesh::boundary_id_type bid,
                               MAST::DirichletBoundaryCondition& load);
+                              
+        /*!
+         *  adds the specified Dirichlet DOF boundary condition
+         */
+        void add_dirichlet_dof_bc(MAST::DOFDirichletBoundaryCondition& load);
         
         /*!
          *    @returns a const reference to the side boundary conditions
@@ -172,6 +180,12 @@ namespace MAST {
             return _point_loads;
         }
 
+        /*!
+         *    @returns a reference to the dirichlet dof boundary conditions
+         */
+        MAST::DOFDirichletBCSetType& dirichlet_dof_bc() {
+            return _dirichlet_dof_bcs;
+        }
         
         
         /*!
@@ -185,6 +199,12 @@ namespace MAST {
          *    initializes the system for dirichlet boundary conditions
          */
         void init_system_dirichlet_bc(MAST::NonlinearSystem& sys) const;
+        
+        
+        /*!
+         *  initializes the system for dirichlet dof boundary conditions
+         */
+        void init_system_dirichlet_dof_bc(MAST::NonlinearSystem& sys);
 
         
         /*!
@@ -260,6 +280,12 @@ namespace MAST {
          *   point loads
          */
         MAST::PointLoadSetType _point_loads;
+        
+        /*!
+         *  degree of freedom dirichlet boundary conditions
+         */
+        MAST::DOFDirichletBCSetType _dirichlet_dof_bcs;
+        std::unique_ptr<MAST::DOFConstraint> _dof_constraint;
     };
     
 }

--- a/src/boundary_condition/CMakeLists.txt
+++ b/src/boundary_condition/CMakeLists.txt
@@ -2,6 +2,8 @@ target_sources(mast
     PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/dirichlet_boundary_condition.cpp
         ${CMAKE_CURRENT_LIST_DIR}/dirichlet_boundary_condition.h
+        ${CMAKE_CURRENT_LIST_DIR}/dirichlet_dof_boundary_condition.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/dirichlet_dof_boundary_condition.h
         ${CMAKE_CURRENT_LIST_DIR}/point_load_condition.cpp
         ${CMAKE_CURRENT_LIST_DIR}/point_load_condition.h)
 


### PR DESCRIPTION
This allows dirichlet boundary conditions, both zero and non-zero, to be applied on individual degrees of freedom.  The formatting for defining BCs is similar to that of Nastran.  The new class accepts three vectors which defines the nodes the BC is applied to, the DOFs the BC acts on within those nodes, and the value for each of those DOFs.

This was implement a long time ago (~10 months?), but was never moved from GitLab to here.  This pull request moves this into the GitHub repo.