### PR TITLE
Explicitly Set Adjoint RHS

### DIFF
--- a/src/base/nonlinear_system.h
+++ b/src/base/nonlinear_system.h
@@ -157,7 +157,9 @@ namespace MAST {
                                    MAST::AssemblyElemOperations&       elem_ops,
                                    MAST::OutputAssemblyElemOperations& output,
                                    MAST::AssemblyBase&                 assembly,
-                                   bool if_assemble_jacobian           = true);
+                                   bool if_assemble_jacobian           = true,
+                                   bool compute_adjoint_rhs            = true,
+                                   unsigned int i                      = 0);
         
         
         /**


### PR DESCRIPTION
These changes allow the user to explicitly define the adjoint right-hand-side (rhs) for multiple quantities of interest.  This brings the MAST implementation of adjoints closer to that implemented in libMesh.  This feature was added to support interfacing MAST with third-party programs for coupled analyses.

Backwards compatibility of the "adjoint_solve" method is maintained.